### PR TITLE
[Ninja] Support -j (jobs) parameter to Ninja.

### DIFF
--- a/perftests/Xcode/PerfTests/NinjaPerfTests.mm
+++ b/perftests/Xcode/PerfTests/NinjaPerfTests.mm
@@ -86,7 +86,7 @@ static void ExecuteShellCommand(const char *String) {
                              dbPath].UTF8String);
         
         llbuild::commands::executeNinjaCommand({
-            "build", "--quiet", "--no-parallel", "--simulate",
+            "build", "--quiet", "--jobs", "1", "--simulate",
             "--db", dbPath.UTF8String, "-f", ninjaPath.UTF8String, TargetName });
     }];
 }
@@ -124,7 +124,7 @@ static void ExecuteShellCommand(const char *String) {
     ExecuteShellCommand([NSString stringWithFormat:@"rm -f \"%@\"",
                          dbPath].UTF8String);
     llbuild::commands::executeNinjaCommand({
-        "build", "--quiet", "--no-parallel", "--simulate",
+        "build", "--quiet", "--jobs", "1", "--simulate",
         "--db", dbPath.UTF8String, "-f", ninjaPath.UTF8String, TargetName });
     
     // Test the null build performance, each run of which will reuse the initial
@@ -133,7 +133,7 @@ static void ExecuteShellCommand(const char *String) {
     [self measureBlock:^{
         for (int i = 0; i != 10; ++i) {
             llbuild::commands::executeNinjaCommand({
-                "build", "--quiet", "--no-parallel", "--simulate",
+                "build", "--quiet", "--jobs", "1", "--simulate",
                 "--db", dbPath.UTF8String, "-f", ninjaPath.UTF8String, TargetName });
         }
     }];
@@ -252,7 +252,7 @@ static void ExecuteShellCommand(const char *String) {
     printf("performing null builds (performance test)...\n");
     [self measureBlock:^{
         llbuild::commands::executeNinjaCommand({
-            "build", "--quiet", "-C", pseudoLLVMPath.UTF8String, "--no-parallel", "all" });
+            "build", "--quiet", "-C", pseudoLLVMPath.UTF8String, "--jobs", "1", "all" });
     }];
 }
 

--- a/tests/Ninja/Build/basic.ninja
+++ b/tests/Ninja/Build/basic.ninja
@@ -6,7 +6,7 @@
 # RUN: rm -rf %t.build
 # RUN: mkdir -p %t.build
 # RUN: cp %s %t.build/build.ninja
-# RUN: %{llbuild} ninja build --no-parallel --no-db --chdir %t.build &> %t.out
+# RUN: %{llbuild} ninja build --jobs 1 --no-db --chdir %t.build &> %t.out
 # RUN: %{FileCheck} < %t.out %s
 
 # CHECK: [1/{{.*}}] "A"

--- a/tests/Ninja/Build/changed-commands.ninja
+++ b/tests/Ninja/Build/changed-commands.ninja
@@ -6,13 +6,13 @@
 # RUN: echo input-1 > %t.build/input-1
 # RUN: echo input-2 > %t.build/input-2
 # RUN: echo "build output: CAT input-1 input-2" > %t.build/output-rule.ninja
-# RUN: %{llbuild} ninja build --no-parallel --chdir %t.build &> %t.out
+# RUN: %{llbuild} ninja build --jobs 1 --chdir %t.build &> %t.out
 # RUN: %{FileCheck} --check-prefix=CHECK-FIRST < %t.out %s
 
 # Change the manifest and rebuild.
 #
 # RUN: echo "build output: CAT input-1" > %t.build/output-rule.ninja
-# RUN: %{llbuild} ninja build --no-parallel --chdir %t.build &> %t.out
+# RUN: %{llbuild} ninja build --jobs 1 --chdir %t.build &> %t.out
 # RUN: %{FileCheck} --check-prefix=CHECK-SECOND < %t.out %s
 
 # CHECK-FIRST: [1/{{.*}}] cat input-1 input-2 > output

--- a/tests/Ninja/Build/changed-generator-commands.ninja
+++ b/tests/Ninja/Build/changed-generator-commands.ninja
@@ -4,7 +4,7 @@
 # RUN: mkdir -p %t.build
 # RUN: cp %s %t.build/build.ninja
 # RUN: touch %t.build/config.ninja
-# RUN: %{llbuild} ninja build --no-parallel --chdir %t.build &> %t1.out
+# RUN: %{llbuild} ninja build --jobs 1 --chdir %t.build &> %t1.out
 # RUN: %{FileCheck} --check-prefix CHECK-FIRST --input-file %t1.out %s
 #
 # CHECK-FIRST-NOT: echo
@@ -13,7 +13,7 @@
 # Running again after changing the generator flags should not rebuild.
 #
 # RUN: echo "echo_flags = foo" > %t.build/config.ninja
-# RUN: %{llbuild} ninja build --no-parallel --chdir %t.build &> %t2.out
+# RUN: %{llbuild} ninja build --jobs 1 --chdir %t.build &> %t2.out
 # RUN: %{FileCheck} --check-prefix CHECK-SECOND --input-file %t2.out %s
 #
 # CHECK-SECOND-NOT: echo

--- a/tests/Ninja/Build/changed-multiple-outputs-command.ninja
+++ b/tests/Ninja/Build/changed-multiple-outputs-command.ninja
@@ -8,7 +8,7 @@
 # RUN: ln -s %s %t.build/build.ninja
 # RUN: echo "build input-1 input-2: ECHO" > %t.build/output-specs.ninja
 # RUN: echo "build output: CAT input-1 input-2" >> %t.build/output-specs.ninja
-# RUN: %{llbuild} ninja build --no-parallel --chdir %t.build &> %t1.out
+# RUN: %{llbuild} ninja build --jobs 1 --chdir %t.build &> %t1.out
 # RUN: %{FileCheck} --check-prefix=CHECK-INITIAL --input-file=%t1.out %s
 #
 # CHECK-INITIAL: ECHO input-1 input-2
@@ -18,7 +18,7 @@
 #
 # RUN: echo "build input-1 input-2 input-3: ECHO" > %t.build/output-specs.ninja
 # RUN: echo "build output: CAT input-1 input-2 input-3" >> %t.build/output-specs.ninja
-# RUN: %{llbuild} ninja build --no-parallel --chdir %t.build &> %t2.out
+# RUN: %{llbuild} ninja build --jobs 1 --chdir %t.build &> %t2.out
 # RUN: %{FileCheck} --check-prefix=CHECK-REBUILD --input-file=%t2.out %s
 #
 # CHECK-REBUILD-NOT: missing input

--- a/tests/Ninja/Build/command-buffering.ninja
+++ b/tests/Ninja/Build/command-buffering.ninja
@@ -4,7 +4,7 @@
 # RUN: mkdir -p %t.build
 # RUN: cp %s %t.build/build.ninja
 # RUN: cp %S/Inputs/wait-for-file %t.build
-# RUN: %{llbuild} ninja build --parallel --chdir %t.build --no-db &> %t.out
+# RUN: %{llbuild} ninja build --chdir %t.build --no-db &> %t.out
 # RUN: %{FileCheck} --check-prefix=CHECK-A --input-file %t.out %s
 # RUN: %{FileCheck} --check-prefix=CHECK-B --input-file %t.out %s
 #

--- a/tests/Ninja/Build/continue-on-failure.ninja
+++ b/tests/Ninja/Build/continue-on-failure.ninja
@@ -5,7 +5,7 @@
 # RUN: rm -rf %t.build
 # RUN: mkdir -p %t.build
 # RUN: cp %s %t.build/build.ninja
-# RUN: %{llbuild} ninja build --no-parallel --chdir %t.build --no-db &> %t1.out || true
+# RUN: %{llbuild} ninja build --jobs 1 --chdir %t.build --no-db &> %t1.out || true
 # RUN: %{FileCheck} --check-prefix CHECK-DEFAULT --input-file %t1.out %s
 #
 # CHECK-DEFAULT: [1/{{.*}}] echo > output-0
@@ -18,7 +18,7 @@
 # RUN: rm -rf %t.build
 # RUN: mkdir -p %t.build
 # RUN: cp %s %t.build/build.ninja
-# RUN: %{llbuild} ninja build --no-parallel --chdir %t.build --no-db -k 2 &> %t2.out || true
+# RUN: %{llbuild} ninja build --jobs 1 --chdir %t.build --no-db -k 2 &> %t2.out || true
 # RUN: %{FileCheck} --check-prefix CHECK-TWO --input-file %t2.out %s
 #
 # CHECK-TWO: [1/{{.*}}] echo > output-0
@@ -33,7 +33,7 @@
 # RUN: rm -rf %t.build
 # RUN: mkdir -p %t.build
 # RUN: cp %s %t.build/build.ninja
-# RUN: %{llbuild} ninja build --no-parallel --chdir %t.build --no-db -k 0 &> %t3.out || true
+# RUN: %{llbuild} ninja build --jobs 1 --chdir %t.build --no-db -k 0 &> %t3.out || true
 # RUN: %{FileCheck} --check-prefix CHECK-UNLIMITED --input-file %t3.out %s
 #
 # CHECK-UNLIMITED: [1/{{.*}}] echo > output-0

--- a/tests/Ninja/Build/cycle-detection.ninja
+++ b/tests/Ninja/Build/cycle-detection.ninja
@@ -3,7 +3,7 @@
 # RUN: rm -rf %t.build
 # RUN: mkdir -p %t.build
 # RUN: cp %s %t.build/build.ninja
-# RUN: /bin/sh -c "%{llbuild} ninja build --no-parallel --no-db --chdir %t.build; echo \"exit code: $?\"" &> %t.out
+# RUN: /bin/sh -c "%{llbuild} ninja build --jobs 1 --no-db --chdir %t.build; echo \"exit code: $?\"" &> %t.out
 # RUN: %{FileCheck} < %t.out %s
 
 # CHECK: cycle detected among targets: "intermediate" -> "output-2" -> "output-1" -> "intermediate"

--- a/tests/Ninja/Build/environment.ninja
+++ b/tests/Ninja/Build/environment.ninja
@@ -6,7 +6,7 @@
 # RUN: rm -rf %t.build
 # RUN: mkdir -p %t.build
 # RUN: cp %s %t.build/build.ninja
-# RUN: env EXTRAKEY=foobar %{llbuild} ninja build --no-parallel --chdir %t.build &> %t1.out
+# RUN: env EXTRAKEY=foobar %{llbuild} ninja build --jobs 1 --chdir %t.build &> %t1.out
 # RUN: %{FileCheck} --input-file=%t1.out %s
 #
 # CHECK: EXTRAKEY=foobar

--- a/tests/Ninja/Build/exit-status.ninja
+++ b/tests/Ninja/Build/exit-status.ninja
@@ -3,7 +3,7 @@
 # RUN: rm -rf %t.build
 # RUN: mkdir -p %t.build
 # RUN: cp %s %t.build/build.ninja
-# RUN: /bin/sh -c "%{llbuild} ninja build --no-parallel --chdir %t.build; echo \"exit code: $?\"" > %t.out
+# RUN: /bin/sh -c "%{llbuild} ninja build --jobs 1 --chdir %t.build; echo \"exit code: $?\"" > %t.out
 # RUN: %{FileCheck} < %t.out %s
 # CHECK: exit code: 1
 

--- a/tests/Ninja/Build/failing-commands.ninja
+++ b/tests/Ninja/Build/failing-commands.ninja
@@ -5,7 +5,7 @@
 # RUN: rm -rf %t.build
 # RUN: mkdir -p %t.build
 # RUN: cp %s %t.build/build.ninja
-# RUN: %{llbuild} ninja build --no-parallel --chdir %t.build --no-db &> %t1.out || true
+# RUN: %{llbuild} ninja build --jobs 1 --chdir %t.build --no-db &> %t1.out || true
 # RUN: %{FileCheck} < %t1.out %s
 #
 # CHECK: [1/{{.*}}] FALSE

--- a/tests/Ninja/Build/graphviz-output.ninja
+++ b/tests/Ninja/Build/graphviz-output.ninja
@@ -6,7 +6,7 @@
 # RUN: rm -rf %t.build
 # RUN: mkdir -p %t.build
 # RUN: cp %s %t.build/build.ninja
-# RUN: %{llbuild} ninja build --no-parallel --chdir %t.build --no-db --simulate --dump-graph %t.dot
+# RUN: %{llbuild} ninja build --jobs 1 --chdir %t.build --no-db --simulate --dump-graph %t.dot
 # RUN: %{FileCheck} < %t.dot %s
 #
 # CHECK: digraph {{.*}} {

--- a/tests/Ninja/Build/incremental.ninja
+++ b/tests/Ninja/Build/incremental.ninja
@@ -8,14 +8,14 @@
 # RUN: cp %s %t.build/build.ninja
 # RUN: touch %t.build/input-1
 # RUN: touch %t.build/input-2
-# RUN: %{llbuild} ninja build --no-parallel --chdir %t.build &> %t1.out
+# RUN: %{llbuild} ninja build --jobs 1 --chdir %t.build &> %t1.out
 # RUN: %{FileCheck} --check-prefix=CHECK-INITIAL --input-file=%t1.out %s
 
 # We use strict mode here to ensure the update-if-newer behavior works properly
 # when timestamps collide.
 #
 # RUN: echo "mod" >> %t.build/input-1
-# RUN: %{llbuild} ninja build --strict --no-parallel --chdir %t.build &> %t2.out
+# RUN: %{llbuild} ninja build --strict --jobs 1 --chdir %t.build &> %t2.out
 # RUN: %{FileCheck} --check-prefix=CHECK-AFTER-MOD --input-file=%t2.out %s
 
 # Check the first build.

--- a/tests/Ninja/Build/inherited-file-descriptors.ninja
+++ b/tests/Ninja/Build/inherited-file-descriptors.ninja
@@ -7,7 +7,7 @@
 # RUN: mkdir -p %t.build
 # RUN: ln -s %S/Inputs/check-open-fds %t.build
 # RUN: ln -s %s %t.build/build.ninja
-# RUN: /bin/sh -c "%{llbuild} ninja build --no-parallel --no-db --chdir %t.build 4< /dev/null" &> %t.out
+# RUN: /bin/sh -c "%{llbuild} ninja build --jobs 1 --no-db --chdir %t.build 4< /dev/null" &> %t.out
 # RUN: %{FileCheck} < %t.out %s
 
 # CHECK: [1/1] ./check-open-fds

--- a/tests/Ninja/Build/makefile-implicit-deps.ninja
+++ b/tests/Ninja/Build/makefile-implicit-deps.ninja
@@ -10,7 +10,7 @@
 # RUN: mkdir -p %t.build
 # RUN: cp %s %t.build/build.ninja
 # RUN: touch -r / %t.build/header-1 %t.build/input-1
-# RUN: %{llbuild} ninja build --no-parallel --chdir %t.build &> %t1.out
+# RUN: %{llbuild} ninja build --jobs 1 --chdir %t.build &> %t1.out
 # RUN: %{FileCheck} --check-prefix=CHECK-INITIAL --input-file=%t1.out %s
 
 # Check the first build.
@@ -21,7 +21,7 @@
 # Check a build that modifies the header.
 #
 # RUN: echo "mod" >> %t.build/header-1
-# RUN: %{llbuild} ninja build --strict --no-parallel --chdir %t.build &> %t2.out
+# RUN: %{llbuild} ninja build --strict --jobs 1 --chdir %t.build &> %t2.out
 # RUN: %{FileCheck} --check-prefix=CHECK-AFTER-MOD --input-file=%t2.out %s
 #
 # CHECK-AFTER-MOD: [1/{{.*}}] "CC output-1"
@@ -34,7 +34,7 @@
 #
 # RUN: touch -r / %t.build/header-1
 # RUN: echo "xxx" >> %t.build/output-1
-# RUN: %{llbuild} ninja build --strict --no-parallel --chdir %t.build &> %t2.out
+# RUN: %{llbuild} ninja build --strict --jobs 1 --chdir %t.build &> %t2.out
 # RUN: %{FileCheck} --check-prefix=CHECK-AFTER-OUTPUT-MOD --input-file=%t2.out %s
 #
 # FIXME: This build currently will actually rerun the command, but this test is
@@ -46,7 +46,7 @@
 # Check another build that modifies the header.
 #
 # RUN: echo "mod-2" >> %t.build/header-1
-# RUN: %{llbuild} ninja build --strict --no-parallel --chdir %t.build &> %t2.out
+# RUN: %{llbuild} ninja build --strict --jobs 1 --chdir %t.build &> %t2.out
 # RUN: %{FileCheck} --check-prefix=CHECK-AFTER-SECOND-MOD --input-file=%t2.out %s
 #
 # CHECK-AFTER-SECOND-MOD: [1/{{.*}}] "CC output-1"

--- a/tests/Ninja/Build/max-commands-progress.ninja
+++ b/tests/Ninja/Build/max-commands-progress.ninja
@@ -4,7 +4,7 @@
 # RUN: mkdir -p %t.build
 # RUN: touch -r / %t.build/input-1 %t.build/input-2
 # RUN: cp %s %t.build/build.ninja
-# RUN: %{llbuild} ninja build --no-parallel --chdir %t.build &> %t1.out
+# RUN: %{llbuild} ninja build --jobs 1 --chdir %t.build &> %t1.out
 # RUN: %{FileCheck} --check-prefix=CHECK-INITIAL < %t1.out %s
 #
 # CHECK-INITIAL: [1/3] cp input-2 output-2
@@ -12,7 +12,7 @@
 # CHECK-INITIAL: [3/3] cat output-1 output-2 > output
 
 # RUN: echo "mod" > %t.build/input-1
-# RUN: %{llbuild} ninja build --strict --no-parallel --chdir %t.build &> %t1.out
+# RUN: %{llbuild} ninja build --strict --jobs 1 --chdir %t.build &> %t1.out
 # RUN: %{FileCheck} --check-prefix=CHECK-INCREMENTAL < %t1.out %s
 #
 # CHECK-INCREMENTAL: [1/2] cp input-1 output-1

--- a/tests/Ninja/Build/missing-depfile.ninja
+++ b/tests/Ninja/Build/missing-depfile.ninja
@@ -3,7 +3,7 @@
 # RUN: rm -rf %t.build
 # RUN: mkdir -p %t.build
 # RUN: cp %s %t.build/build.ninja
-# RUN: %{llbuild} ninja build --strict --no-parallel --chdir %t.build --no-db &> %t1.out || true
+# RUN: %{llbuild} ninja build --strict --jobs 1 --chdir %t.build --no-db &> %t1.out || true
 # RUN: %{FileCheck} --check-prefix CHECK-STRICT --input-file %t1.out %s
 #
 # CHECK-STRICT: [1/{{.*}}] true
@@ -12,7 +12,7 @@
 # RUN: rm -rf %t.build
 # RUN: mkdir -p %t.build
 # RUN: cp %s %t.build/build.ninja
-# RUN: %{llbuild} ninja build --no-parallel --chdir %t.build --no-db &> %t2.out
+# RUN: %{llbuild} ninja build --jobs 1 --chdir %t.build --no-db &> %t2.out
 # RUN: %{FileCheck} --check-prefix CHECK-NONSTRICT --input-file %t2.out %s
 #
 # CHECK-NONSTRICT: [1/{{.*}}] true

--- a/tests/Ninja/Build/missing-inputs.ninja
+++ b/tests/Ninja/Build/missing-inputs.ninja
@@ -6,7 +6,7 @@
 # RUN: rm -rf %t.build
 # RUN: mkdir -p %t.build
 # RUN: cp %s %t.build/build.ninja
-# RUN: /bin/sh -c "%{llbuild} ninja build --no-parallel --chdir %t.build --no-db; echo \"exit code: $?\"" &> %t1.out
+# RUN: /bin/sh -c "%{llbuild} ninja build --jobs 1 --chdir %t.build --no-db; echo \"exit code: $?\"" &> %t1.out
 # RUN: %{FileCheck} < %t1.out %s
 #
 # CHECK: error:{{.*}} missing input 'input-1' and no rule to build it

--- a/tests/Ninja/Build/multiple-outputs.ninja
+++ b/tests/Ninja/Build/multiple-outputs.ninja
@@ -8,7 +8,7 @@
 # RUN: cp %S/Inputs/split-numbers %t.build
 # RUN: cp %s %t.build/build.ninja
 # RUN: touch %t.build/input
-# RUN: %{llbuild} ninja build --no-parallel --chdir %t.build &> %t1.out
+# RUN: %{llbuild} ninja build --jobs 1 --chdir %t.build &> %t1.out
 # RUN: %{FileCheck} --check-prefix CHECK-INITIAL --input-file %t1.out %s
 #
 # CHECK-INITIAL: [1/{{.*}}] ./split-numbers < input odd even
@@ -18,7 +18,7 @@
 # Add an even number, and check that only the even side rebuilds.
 # 
 # RUN: echo 0 >> %t.build/input
-# RUN: %{llbuild} ninja build --strict --no-parallel --chdir %t.build &> %t2.out
+# RUN: %{llbuild} ninja build --strict --jobs 1 --chdir %t.build &> %t2.out
 # RUN: %{FileCheck} --check-prefix CHECK-UPDATE-EVEN --input-file %t2.out %s
 #
 # CHECK-UPDATE-EVEN: [1/{{.*}}] ./split-numbers < input odd even
@@ -30,7 +30,7 @@
 # Add an odd number, and check that only the odd side rebuilds.
 # 
 # RUN: echo 1 >> %t.build/input
-# RUN: %{llbuild} ninja build --strict --no-parallel --chdir %t.build &> %t3.out
+# RUN: %{llbuild} ninja build --strict --jobs 1 --chdir %t.build &> %t3.out
 # RUN: %{FileCheck} --check-prefix CHECK-UPDATE-ODD --input-file %t3.out %s
 #
 # CHECK-UPDATE-ODD: [1/{{.*}}] ./split-numbers < input odd even

--- a/tests/Ninja/Build/multiple-targets.ninja
+++ b/tests/Ninja/Build/multiple-targets.ninja
@@ -7,7 +7,7 @@
 # RUN: mkdir -p %t.build
 # RUN: cp %s %t.build/build.ninja
 # RUN: cp %S/Inputs/wait-for-file %t.build
-# RUN: %{llbuild} ninja build --parallel --chdir %t.build node-A node-B node-A node-B &> %t.out
+# RUN: %{llbuild} ninja build --chdir %t.build node-A node-B node-A node-B &> %t.out
 # RUN: %{FileCheck} < %t.out %s
 #
 # CHECK: [1/{{.*}}] rm -f node-{A,B}-semaphore

--- a/tests/Ninja/Build/no-db.ninja
+++ b/tests/Ninja/Build/no-db.ninja
@@ -3,7 +3,7 @@
 # RUN: rm -rf %t.build
 # RUN: mkdir -p %t.build
 # RUN: cp %s %t.build/build.ninja
-# RUN: %{llbuild} ninja build --no-parallel --chdir %t.build --no-db
+# RUN: %{llbuild} ninja build --jobs 1 --chdir %t.build --no-db
 # RUN: test ! -f %t.build/build.db
 
 build output: phony

--- a/tests/Ninja/Build/no-inputs.ninja
+++ b/tests/Ninja/Build/no-inputs.ninja
@@ -5,14 +5,14 @@
 # RUN: mkdir -p %t.build
 # RUN: cp %s %t.build/build.ninja
 # RUN: touch %t.build/output
-# RUN: %{llbuild} ninja build --no-parallel --chdir %t.build &> %t1.out
+# RUN: %{llbuild} ninja build --jobs 1 --chdir %t.build &> %t1.out
 # RUN: %{FileCheck} --check-prefix CHECK-FIRST --input-file %t1.out %s
 #
 # CHECK-FIRST: [1/{{.*}}] date > output
 
 # Running again should do nothing.
 #
-# RUN: %{llbuild} ninja build --no-parallel --chdir %t.build &> %t2.out
+# RUN: %{llbuild} ninja build --jobs 1 --chdir %t.build &> %t2.out
 # RUN: %{FileCheck} --check-prefix CHECK-SECOND --input-file %t2.out %s
 #
 # CHECK-SECOND-NOT: date

--- a/tests/Ninja/Build/order-only-deps.ninja
+++ b/tests/Ninja/Build/order-only-deps.ninja
@@ -9,7 +9,7 @@
 # RUN: echo "input-1" > %t.build/input-1
 # RUN: echo "input-2" > %t.build/input-2
 # RUN: echo "input-3" > %t.build/input-3
-# RUN: %{llbuild} ninja build --no-parallel --chdir %t.build &> %t1.out
+# RUN: %{llbuild} ninja build --jobs 1 --chdir %t.build &> %t1.out
 # RUN: %{FileCheck} --check-prefix=CHECK-INITIAL --input-file=%t1.out %s
 # RUN: %{FileCheck} --check-prefix=CHECK-INITIAL-OUTPUT --input-file=%t.build/output %s
 
@@ -31,7 +31,7 @@
 # output should rebuild, since the dependencies are order only.
 #
 # RUN: echo "input-1-mod" >> %t.build/input-1
-# RUN: %{llbuild} ninja build --strict --no-parallel --chdir %t.build &> %t2.out
+# RUN: %{llbuild} ninja build --strict --jobs 1 --chdir %t.build &> %t2.out
 # RUN: %{FileCheck} --check-prefix=CHECK-AFTER-MOD --input-file=%t2.out %s
 
 # Check the second build.

--- a/tests/Ninja/Build/outputs.ninja
+++ b/tests/Ninja/Build/outputs.ninja
@@ -8,9 +8,9 @@
 # RUN: rm -rf %t.build
 # RUN: mkdir -p %t.build
 # RUN: cp %s %t.build/build.ninja
-# RUN: %{llbuild} ninja build --no-parallel --chdir %t.build no-output &> %t.out
+# RUN: %{llbuild} ninja build --jobs 1 --chdir %t.build no-output &> %t.out
 # RUN: %{FileCheck} --check-prefix=CHECK-FIRST < %t.out %s
-# RUN: %{llbuild} ninja build --no-parallel --chdir %t.build no-output &> %t.out
+# RUN: %{llbuild} ninja build --jobs 1 --chdir %t.build no-output &> %t.out
 # RUN: %{FileCheck} --check-prefix=CHECK-SECOND < %t.out %s
 
 # CHECK-FIRST: [1/{{.*}}] echo "built no-output"

--- a/tests/Ninja/Build/parallel.ninja
+++ b/tests/Ninja/Build/parallel.ninja
@@ -9,7 +9,7 @@
 # RUN: mkdir -p %t.build
 # RUN: cp %s %t.build/build.ninja
 # RUN: cp %S/Inputs/wait-for-file %t.build
-# RUN: %{llbuild} ninja build --parallel --chdir %t.build --no-db
+# RUN: %{llbuild} ninja build --chdir %t.build --no-db
 
 rule CUSTOM
   command = ${COMMAND}

--- a/tests/Ninja/Build/phony-extra-inputs.ninja
+++ b/tests/Ninja/Build/phony-extra-inputs.ninja
@@ -15,7 +15,7 @@
 # RUN: rm -rf %t.build
 # RUN: mkdir -p %t.build
 # RUN: cp %s %t.build/build.ninja
-# RUN: %{llbuild} ninja build --no-db --no-parallel --chdir %t.build &> %t1.out
+# RUN: %{llbuild} ninja build --no-db --jobs 1 --chdir %t.build &> %t1.out
 # RUN: %{FileCheck} --input-file %t1.out %s
 #
 # CHECK: llbuild: note: no work to do.

--- a/tests/Ninja/Build/phony-inputs.ninja
+++ b/tests/Ninja/Build/phony-inputs.ninja
@@ -12,7 +12,7 @@
 # Check that the initial build creates 'output' properly, even though 'input'
 # does not exist.
 #
-# RUN: %{llbuild} ninja build --no-parallel --chdir %t.build &> %t1.out
+# RUN: %{llbuild} ninja build --jobs 1 --chdir %t.build &> %t1.out
 # RUN: %{FileCheck} --check-prefix=CHECK-INITIAL < %t1.out %s
 # RUN: %{FileCheck} --check-prefix=CHECK-OUTPUT-INITIAL < %t.build/output %s
 #
@@ -22,7 +22,7 @@
 
 # Check that a rebuild continues to run the output rule.
 #
-# RUN: %{llbuild} ninja build --no-parallel --chdir %t.build &> %t1.out
+# RUN: %{llbuild} ninja build --jobs 1 --chdir %t.build &> %t1.out
 # RUN: %{FileCheck} --check-prefix=CHECK-NEXT < %t1.out %s
 # RUN: %{FileCheck} --check-prefix=CHECK-OUTPUT-NEXT < %t.build/output %s
 #
@@ -33,7 +33,7 @@
 # Check that the output rule gets rebuilt when we create 'input'.
 #
 # RUN: touch %t.build/input
-# RUN: %{llbuild} ninja build --strict --no-parallel --chdir %t.build &> %t1.out
+# RUN: %{llbuild} ninja build --strict --jobs 1 --chdir %t.build &> %t1.out
 # RUN: %{FileCheck} --check-prefix=CHECK-WITH-INPUT < %t1.out %s
 # RUN: %{FileCheck} --check-prefix=CHECK-OUTPUT-WITH-INPUT < %t.build/output %s
 #
@@ -43,7 +43,7 @@
 
 # Check that the output rule no longer gets rebuilt ever build.
 #
-# RUN: %{llbuild} ninja build --no-parallel --chdir %t.build &> %t1.out
+# RUN: %{llbuild} ninja build --jobs 1 --chdir %t.build &> %t1.out
 # RUN: %{FileCheck} --check-prefix=CHECK-NEXT-WITH-INPUT < %t1.out %s
 #
 # CHECK-NEXT-WITH-INPUT: no work to do
@@ -52,7 +52,7 @@
 # Check that the output rule does get rebuilt if input changes.
 #
 # RUN: echo -n "X" > %t.build/input
-# RUN: %{llbuild} ninja build --strict --no-parallel --chdir %t.build &> %t1.out
+# RUN: %{llbuild} ninja build --strict --jobs 1 --chdir %t.build &> %t1.out
 # RUN: %{FileCheck} --check-prefix=CHECK-WITH-NEW-INPUT < %t1.out %s
 # RUN: %{FileCheck} --check-prefix=CHECK-OUTPUT-WITH-NEW-INPUT < %t.build/output %s
 #

--- a/tests/Ninja/Build/rebuild-manifest.ninja
+++ b/tests/Ninja/Build/rebuild-manifest.ninja
@@ -5,7 +5,7 @@
 # RUN: mkdir -p %t.build
 # RUN: touch %t.build/input
 # RUN: cp %s %t.build/build.ninja
-# RUN: %{llbuild} ninja build --no-parallel --chdir %t.build &> %t1.out
+# RUN: %{llbuild} ninja build --jobs 1 --chdir %t.build &> %t1.out
 # RUN: %{FileCheck} < %t1.out %s
 
 # CHECK: [1/{{.*}}] GENERATE MANIFEST

--- a/tests/Ninja/Build/removed-makefile-implicit-dep.ninja
+++ b/tests/Ninja/Build/removed-makefile-implicit-dep.ninja
@@ -5,7 +5,7 @@
 # RUN: ln -s %s %t.build/build.ninja
 # RUN: echo "header-1" > %t.build/header-1
 # RUN: echo "input-1" > %t.build/input-1
-# RUN: %{llbuild} ninja build --no-parallel --chdir %t.build &> %t1.out
+# RUN: %{llbuild} ninja build --jobs 1 --chdir %t.build &> %t1.out
 # RUN: %{FileCheck} --check-prefix=CHECK-INITIAL --input-file=%t1.out %s
 
 # Check the first build.
@@ -16,7 +16,7 @@
 # Check a build that removes the header.
 #
 # RUN: rm %t.build/header-1
-# RUN: %{llbuild} ninja build --strict --no-parallel --chdir %t.build &> %t2.out
+# RUN: %{llbuild} ninja build --strict --jobs 1 --chdir %t.build &> %t2.out
 # RUN: %{FileCheck} --check-prefix=CHECK-AFTER-REMOVAL --input-file=%t2.out %s
 #
 # CHECK-AFTER-REMOVAL-NOT: missing input 'header-1'

--- a/tests/Ninja/Build/restat.ninja
+++ b/tests/Ninja/Build/restat.ninja
@@ -4,7 +4,7 @@
 # RUN: mkdir -p %t.build
 # RUN: cp %s %t.build/build.ninja
 # RUN: touch %t.build/input
-# RUN: %{llbuild} ninja build --no-parallel --chdir %t.build &> %t1.out
+# RUN: %{llbuild} ninja build --jobs 1 --chdir %t.build &> %t1.out
 # RUN: %{FileCheck} --check-prefix CHECK-INITIAL --input-file %t1.out %s
 #
 # CHECK-INITIAL: [1/{{.*}}] MKIFNOT
@@ -13,7 +13,7 @@
 # Modify the input (to triger a rebuild of "output-1") and rebuild.
 #
 # RUN: echo > %t.build/input
-# RUN: %{llbuild} ninja build --strict --no-parallel --chdir %t.build &> %t2.out
+# RUN: %{llbuild} ninja build --strict --jobs 1 --chdir %t.build &> %t2.out
 # RUN: %{FileCheck} --check-prefix CHECK-REBUILD --input-file %t2.out %s
 #
 # CHECK-REBUILD: [1/{{.*}}] MKIFNOT

--- a/tests/Ninja/Build/root-targets.ninja
+++ b/tests/Ninja/Build/root-targets.ninja
@@ -3,7 +3,7 @@
 # RUN: rm -rf %t.build
 # RUN: mkdir -p %t.build
 # RUN: cp %s %t.build/build.ninja
-# RUN: %{llbuild} ninja build --no-parallel --chdir %t.build &> %t.out
+# RUN: %{llbuild} ninja build --jobs 1 --chdir %t.build &> %t.out
 # RUN: %{FileCheck} < %t.out %s
 #
 # CHECK: [1/{{.*}}] touch output-A

--- a/tests/Ninja/Build/signal-handling.ninja
+++ b/tests/Ninja/Build/signal-handling.ninja
@@ -5,7 +5,7 @@
 # RUN: cp %s %t.build/build.ninja
 # RUN: cp %S/Inputs/wait-for-file %t.build
 # RUN: /bin/sh -c \
-# RUN:   "%{llbuild} ninja build --no-parallel --chdir %t.build &> %t.out & \
+# RUN:   "%{llbuild} ninja build --jobs 1 --chdir %t.build &> %t.out & \
 # RUN:    echo $! > %t.build/llbuild.pid; \
 # RUN:    wait $(cat %t.build/llbuild.pid)" || true
 # RUN: %{FileCheck} --input-file %t.out %s

--- a/tests/Ninja/Build/timestamp-collision.ninja
+++ b/tests/Ninja/Build/timestamp-collision.ninja
@@ -7,14 +7,14 @@
 # RUN: mkdir -p %t.build
 # RUN: cp %s %t.build/build.ninja
 # RUN: touch -r / %t.build/input %t.build/output
-# RUN: %{llbuild} ninja build --no-db --no-parallel --chdir %t.build &> %t1.out
+# RUN: %{llbuild} ninja build --no-db --jobs 1 --chdir %t.build &> %t1.out
 # RUN: %{FileCheck} --check-prefix CHECK-COLLISION --input-file %t1.out %s
 #
 # CHECK-COLLISION: no work to do
 
 # Verify that we perform a stricter check in --strict mode.
 #
-# RUN: %{llbuild} ninja build --strict --no-db --no-parallel --chdir %t.build &> %t2.out
+# RUN: %{llbuild} ninja build --strict --no-db --jobs 1 --chdir %t.build &> %t2.out
 # RUN: %{FileCheck} --check-prefix CHECK-STRICT --input-file %t2.out %s
 #
 # CHECK-STRICT: [1/{{.*}}] cat input > output

--- a/tests/Ninja/Build/tracing-scanning.ninja
+++ b/tests/Ninja/Build/tracing-scanning.ninja
@@ -5,12 +5,12 @@
 # RUN: cp %s %t.build/build.ninja
 # RUN: touch %t.build/input-1
 # RUN: touch %t.build/input-2
-# RUN: %{llbuild} ninja build --no-parallel --chdir %t.build --trace %t.trace-out
+# RUN: %{llbuild} ninja build --jobs 1 --chdir %t.build --trace %t.trace-out
 
 # Check dependency scanning on rebuild.
 #
 # RUN: echo "mod" >> %t.build/input-2
-# RUN: %{llbuild} ninja build --no-parallel --chdir %t.build --trace %t.trace-out
+# RUN: %{llbuild} ninja build --jobs 1 --chdir %t.build --trace %t.trace-out
 # RUN: %{FileCheck} --input-file %t.trace-out %s
 #
 # We scan "output", which pauses, then "input-1" (which doesn't need to run),

--- a/tests/Ninja/Build/tracing.ninja
+++ b/tests/Ninja/Build/tracing.ninja
@@ -6,7 +6,7 @@
 # RUN: rm -rf %t.build
 # RUN: mkdir -p %t.build
 # RUN: cp %s %t.build/build.ninja
-# RUN: %{llbuild} ninja build --no-parallel --chdir %t.build --no-db --trace %t.trace-out
+# RUN: %{llbuild} ninja build --jobs 1 --chdir %t.build --no-db --trace %t.trace-out
 # RUN: %{FileCheck} --input-file %t.trace-out %s
 
 # The first task we see is for the "dummy" rule...

--- a/tests/Ninja/Build/verbose.ninja
+++ b/tests/Ninja/Build/verbose.ninja
@@ -3,9 +3,9 @@
 # RUN: rm -rf %t.build
 # RUN: mkdir -p %t.build
 # RUN: cp %s %t.build/build.ninja
-# RUN: %{llbuild} ninja build --no-parallel -v --chdir %t.build &> %t.out
+# RUN: %{llbuild} ninja build --jobs 1 -v --chdir %t.build &> %t.out
 # RUN: %{FileCheck} --check-prefix=CHECK-VERBOSE --input-file %t.out %s
-# RUN: %{llbuild} ninja build --no-parallel --chdir %t.build &> %t.out
+# RUN: %{llbuild} ninja build --jobs 1 --chdir %t.build &> %t.out
 # RUN: %{FileCheck} --check-prefix=CHECK-NORMAL --input-file %t.out %s
 
 # CHECK-VERBOSE: [1/{{.*}}] echo some custom command


### PR DESCRIPTION
Many uses of Ninja pass -j to specify how many jobs to run in
parallel. Replace the non-standard --parallel and --no-parallel
options with -j (and an expanded form --jobs) to match Ninja.