### PR TITLE
More verbosity if -v is specified repeatedly

### DIFF
--- a/include/llbuild/BuildSystem/BuildSystem.h
+++ b/include/llbuild/BuildSystem/BuildSystem.h
@@ -93,6 +93,8 @@ public:
   /// Called to determine whether to show verbose status.
   virtual bool showVerboseStatus() = 0;
 
+  virtual unsigned int verbosityLevel() = 0;
+
   /// @}
 };
 

--- a/include/llbuild/BuildSystem/BuildSystemFrontend.h
+++ b/include/llbuild/BuildSystem/BuildSystemFrontend.h
@@ -118,6 +118,10 @@ public:
   /// option.
   virtual bool showVerboseStatus() override;
 
+  /// Provides a default implementation that is connected to a command line
+  /// option.
+  virtual unsigned int verbosityLevel() override;
+
   /// @name Frontend-specific APIs
   /// @{
 
@@ -147,8 +151,9 @@ public:
   /// Whether command usage should be printed.
   bool showUsage = false;
 
-  /// Whether to show verbose output.
-  bool showVerboseStatus = false;
+  /// Whether to show verbose output, values greater than 0 indicate
+  /// verbose output. The larger the value the more verbose.
+  unsigned int verbosityLevel = 0;
 
   /// Whether to use a serial build.
   bool useSerialBuild = false;

--- a/lib/BuildSystem/BuildSystemFrontend.cpp
+++ b/lib/BuildSystem/BuildSystemFrontend.cpp
@@ -103,7 +103,7 @@ void BuildSystemInvocation::parse(llvm::ArrayRef<std::string> args,
     } else if (option == "--serial") {
       useSerialBuild = true;
     } else if (option == "-v" || option == "--verbose") {
-      showVerboseStatus = true;
+      verbosityLevel += 1;
     } else if (option == "--trace") {
       if (args.empty()) {
         error("missing argument to '" + option + "'");
@@ -258,7 +258,13 @@ void BuildSystemFrontendDelegate::hadCommandFailure() {
 bool BuildSystemFrontendDelegate::showVerboseStatus() {
   auto impl = static_cast<BuildSystemFrontendDelegateImpl*>(this->impl);
   
-  return impl->invocation.showVerboseStatus;
+  return impl->invocation.verbosityLevel > 0;
+}
+
+unsigned int BuildSystemFrontendDelegate::verbosityLevel() {
+    auto impl = static_cast<BuildSystemFrontendDelegateImpl*>(this->impl);
+  
+    return impl->invocation.verbosityLevel;
 }
 
 #pragma mark - BuildSystemFrontend implementation

--- a/lib/BuildSystem/SwiftTools.cpp
+++ b/lib/BuildSystem/SwiftTools.cpp
@@ -466,6 +466,8 @@ public:
     if (!bsci.getDelegate().showVerboseStatus()) {
       fprintf(stdout, "Compiling Swift Module '%s' (%d sources)\n",
               moduleName.c_str(), int(sourcesList.size()));
+    } else if (bsci.getDelegate().verbosityLevel() > 1) {
+        commandLine.push_back("-v");
     } else {
       SmallString<256> command;
       llvm::raw_svector_ostream commandOS(command);


### PR DESCRIPTION
Currently the only usage of twice -v is in the swift build frontend where we pass -v through to swiftc.