### PR TITLE
[docs] Clang tool does not execute bin/sh

### DIFF
--- a/docs/buildsystem.rst
+++ b/docs/buildsystem.rst
@@ -337,8 +337,7 @@ A tool used to invoke the Clang compiler.
      - Description
 
    * - args
-     - A string or string list indicating the command line to be executed. If a
-       single string is provided, it will be executed using ``/bin/sh -c``.
+     - A string indicating the command line to be executed.
 
    * - deps
      - The path to a Makefile fragment (presumed to be output by the compiler)


### PR DESCRIPTION
Unlike the shell tool, the Clang tool only takes a single argument. That argument is not executed using `/bin/sh`.

---

I wasn't able to find many examples of usages of the Clang tool, aside from `tests/BuildSystem/Build/discovered-compiler-deps.llbuild`. Am I right in understanding that the Clang tool merely executes a shell command, and doesn't have any Clang-specific logic? I feel like I'm misunderstanding something, so advice appreciated. :bow: