### PR TITLE
Add “archive” tool

### DIFF
--- a/docs/buildsystem.rst
+++ b/docs/buildsystem.rst
@@ -564,3 +564,21 @@ exact version of the Swift compiler in use (as reported by ``swiftc
      - A string or string list indicating other arguments passed to the
        ``swiftc`` executable. Examples of individual values include
        ``"-enable-testing"`` or ``"-Onone"``.
+
+Archive Tool
+------------
+
+**Identifier**: *archive*
+
+A tool used to create an archive (``.a``)
+
+All non-virtual inputs are archived. Only one non-virtual output may be
+specified, this is inferred to be the archive file that this tool produces.
+
+A typical use for this tool is creating static libraries.
+
+.. note::
+
+   FIXME: currently the archive is always recreated entirely, it would be
+   preferable in future to correctly update/delete/create the archive file
+   as required.

--- a/lib/BuildSystem/BuildSystem.cpp
+++ b/lib/BuildSystem/BuildSystem.cpp
@@ -1790,7 +1790,11 @@ class ArchiveShellCommand : public ExternalCommand {
   }
 
   virtual void getShortDescription(SmallVectorImpl<char> &result) override {
-    llvm::raw_svector_ostream(result) << "Archiving " << archiveName;
+    auto desc = getDescription();
+    if (desc.empty()) {
+      desc = "Archiving " + archiveName;
+    }
+    llvm::raw_svector_ostream(result) << desc;
   }
 
   virtual void getVerboseDescription(SmallVectorImpl<char> &result) override {

--- a/tests/BuildSystem/Build/archive.llbuild
+++ b/tests/BuildSystem/Build/archive.llbuild
@@ -1,0 +1,53 @@
+# Check the 'archive' tool.
+#
+# RUN: rm -rf %t.build
+# RUN: mkdir -p %t.build
+# RUN: cp %s %t.build/build.llbuild
+# RUN: mkdir -p %t.build/archive-target
+# RUN: %{llbuild} buildsystem build --serial --chdir %t.build > %t.out
+# RUN: test -f %t.build/foo
+# RUN: test -f %t.build/archive-target/file
+# RUN: %{FileCheck} --input-file=%t.out %s
+#
+# CHECK: MUTATE
+# CHECK: Archiving foo
+
+
+# Check that a null build does nothing.
+#
+# RUN: echo "START." > %t2.out
+# RUN: %{llbuild} buildsystem build --serial --chdir %t.build >> %t2.out
+# RUN: echo "EOF" >> %t2.out
+# RUN: %{FileCheck} --input-file=%t2.out %s --check-prefix=CHECK-REBUILD
+#
+# CHECK-REBUILD: START
+# CHECK-REBUILD-NOT: Archiving foo
+# CHECK-REBUILD-NOT: MUTATE
+# CHECK-REBUILD-NEXT: EOF
+
+
+# Ensure the archive is recreated if necessary.
+#
+# RUN: rm -rf %t.build/foo
+# RUN: %{llbuild} buildsystem build --serial --chdir %t.build > %t3.out
+# RUN: %{FileCheck} --input-file=%t3.out %s --check-prefix=CHECK-RECREATE
+#
+# CHECK-RECREATE: Archiving foo
+
+client:
+  name: basic
+
+targets:
+  "": [foo]
+
+commands:
+  C.archive:
+    tool: archive
+    inputs: [archive-target/file]
+    outputs: [foo]
+  C.mutate:
+    tool: shell
+    description: MUTATE
+    outputs: [archive-target/file]
+    # We use touch -r here to ensure the file time is modified to something different than the symlink.
+    args: touch archive-target/file && touch -r / archive-target


### PR DESCRIPTION
Constructs an archive from provided inputs, intended for static library archives.

Takes `inputs` and `outputs` only.

Any virtual nodes are ignored when constructing the `ar` instantiation.

I consider this PR incomplete:

- [x] documentation (where to put it?)
- [x] using `inputs`/`outputs` as the only attributes seems inconsistent, so should I do something else?
- [x] `ArchiveShellCommand` probably is lacking some basic checks
- [x] should I add tests, if so, where?

So I await some feedback.