### PR TITLE
Add .clang-format file

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,3 @@
+BasedOnStyle: LLVM
+DerivePointerAlignment: true
+PointerAlignment: Left


### PR DESCRIPTION
Hello `swift-llbuild`! :)

#### What's in this pull request?

Adds a `.clang-format` file using LLVM style as does the [Swift compiler](https://github.com/apple/swift/blob/master/.clang-format). Assuming there is a desire to use it! If not, my apologies!

#### Why merge this pull request?

Defines the coding style desired, and will be picked up by `clang-format` if used (with the `-style=file` option that is).

#### What are the downsides to merging this pull request?

If `clang-format` is never used, it's a wasted file.

#### Resolved bug number: (None)