### PR TITLE
Update Swift bindings for llbuild to 2.2

### DIFF
--- a/bindings/swift/llbuild.swift
+++ b/bindings/swift/llbuild.swift
@@ -26,9 +26,9 @@ private func stringFromData(data: llb_data_t) -> String {
   return String([UInt8](UnsafeBufferPointer(start: data.data, count: Int(data.length))))
 }
 
-private func stringFromUInt8Array(var data: [UInt8]) -> String {
+private func stringFromUInt8Array(data: [UInt8]) -> String {
   // Convert as a UTF8 string, if possible.
-  let tmp = NSData(bytes: &data, length: Int(data.count))
+  let tmp = NSData(bytes: data, length: data.count)
   if let str = NSString(data: tmp, encoding: NSUTF8StringEncoding) {
     return String(str)
   }
@@ -468,7 +468,7 @@ public class BuildEngine {
   }
   
   private func lookupRule(key: UnsafePointer<llb_data_t>, _ ruleOut: UnsafeMutablePointer<llb_rule_t>) {
-    ++numRules
+    numRules += 1
     
     // Get the rule from the client.
     let rule = delegate.lookupRule(Key.fromInternalData(key.memory))


### PR DESCRIPTION
#### What's in this pull request?

Updates the Swift bindings for `llbuild` to version `2.2`.

#### Why merge this pull request?

To address the following deprecation warnings:

* [_Removing `var` from Function Parameters_](https://github.com/apple/swift-evolution/blob/master/proposals/0003-remove-var-parameters.md)
* [_Remove the `++` and `--` operators_](https://github.com/apple/swift-evolution/blob/master/proposals/0004-remove-pre-post-inc-decrement.md)

#### What are the downsides to merging this pull request?

None that I can think of!

#### Resolved bug number: (None)