### PR TITLE
Consistent tense for Compile/Link

### DIFF
--- a/lib/BuildSystem/SwiftTools.cpp
+++ b/lib/BuildSystem/SwiftTools.cpp
@@ -238,7 +238,7 @@ public:
 
   virtual void getShortDescription(SmallVectorImpl<char> &result) override {
       llvm::raw_svector_ostream(result)
-        << "Compiling Swift Module '" << moduleName
+        << "Compile Swift Module '" << moduleName
         << "' (" << sourcesList.size() << " sources)";
   }
 


### PR DESCRIPTION
We were saying "Link foo" but "Compiling bar", this makes it "Compile bar", but I am not fussed if you'd rather the other way.