### PR TITLE
[Core] Remove escaped spaces if present in MakefileDepsParser

### DIFF
--- a/include/llbuild/Core/MakefileDepsParser.h
+++ b/include/llbuild/Core/MakefileDepsParser.h
@@ -13,7 +13,10 @@
 #ifndef LLBUILD_CORE_MAKEFILEDEPSPARSER_H
 #define LLBUILD_CORE_MAKEFILEDEPSPARSER_H
 
+#include "llvm/ADT/SmallString.h"
 #include <cstdint>
+
+using namespace llvm;
 
 namespace llbuild {
 namespace core {
@@ -36,13 +39,14 @@ public:
     virtual void error(const char* message, uint64_t position) = 0;
 
     /// Called when a new rule is encountered.
-    virtual void actOnRuleStart(const char* name, uint64_t length) = 0;
+    virtual void actOnRuleStart(const char* name, uint64_t length, const SmallString<256> &unescapedWord) = 0;
     /// Called when a new dependency is found for the current rule.
     ///
     /// This is only called between paired calls to \see actOnRuleStart() and
     /// \see actOnRuleEnd().
     virtual void actOnRuleDependency(const char* dependency,
-                                     uint64_t length) = 0;
+                                     uint64_t length, const SmallString<256> &unescapedWord) = 0;
+
     /// Called when a rule is complete.
     virtual void actOnRuleEnd() = 0;
   };

--- a/lib/BuildSystem/BuildSystem.cpp
+++ b/lib/BuildSystem/BuildSystem.cpp
@@ -997,12 +997,12 @@ class ShellCommand : public ExternalCommand {
       }
 
       virtual void actOnRuleDependency(const char* dependency,
-                                       uint64_t length) override {
+                                       uint64_t length, const SmallString<256> &unescapedWord) override {
         bsci.taskDiscoveredDependency(
-            task, BuildKey::makeNode(StringRef(dependency, length)));
+            task, BuildKey::makeNode(unescapedWord.str()));
       }
 
-      virtual void actOnRuleStart(const char* name, uint64_t length) override {}
+      virtual void actOnRuleStart(const char* name, uint64_t length, const SmallString<256> &unescapedWord) override {}
       virtual void actOnRuleEnd() override {}
     };
 
@@ -1241,12 +1241,12 @@ class ClangShellCommand : public ExternalCommand {
       }
 
       virtual void actOnRuleDependency(const char* dependency,
-                                       uint64_t length) override {
+                                       uint64_t length, const SmallString<256> &unescapedWord) override {
         bsci.taskDiscoveredDependency(
-            task, BuildKey::makeNode(StringRef(dependency, length)));
+            task, BuildKey::makeNode(unescapedWord.str()));
       }
 
-      virtual void actOnRuleStart(const char* name, uint64_t length) override {}
+      virtual void actOnRuleStart(const char* name, uint64_t length, const SmallString<256> &unescapedWord) override {}
       virtual void actOnRuleEnd() override {}
     };
 

--- a/lib/BuildSystem/SwiftTools.cpp
+++ b/lib/BuildSystem/SwiftTools.cpp
@@ -465,16 +465,16 @@ public:
       }
 
       virtual void actOnRuleDependency(const char* dependency,
-                                       uint64_t length) override {
+                                       uint64_t length, const SmallString<256> &unescapedWord) override {
         // Only process dependencies for the first rule (the output file), the
         // rest are identical.
         if (ruleNumber == 0) {
           bsci.taskDiscoveredDependency(
-              task, BuildKey::makeNode(StringRef(dependency, length)));
+              task, BuildKey::makeNode(unescapedWord.str()));
         }
       }
 
-      virtual void actOnRuleStart(const char* name, uint64_t length) override {}
+      virtual void actOnRuleStart(const char* name, uint64_t length, const SmallString<256> &unescapedWord) override {}
       virtual void actOnRuleEnd() override {
         ++ruleNumber;
       }

--- a/lib/Commands/NinjaBuildCommand.cpp
+++ b/lib/Commands/NinjaBuildCommand.cpp
@@ -1375,13 +1375,13 @@ buildCommand(BuildContext& context, ninja::Command* command) {
           }
 
           virtual void actOnRuleDependency(const char* dependency,
-                                           uint64_t length) override {
+                                           uint64_t length, const SmallString<256> &unescapedWord) override {
             context.engine.taskDiscoveredDependency(
-              task, std::string(dependency, dependency+length));
+              task, unescapedWord.str().str());
           }
 
           virtual void actOnRuleStart(const char* name,
-                                      uint64_t length) override {}
+                                      uint64_t length, const SmallString<256> &unescapedWord) override {}
           virtual void actOnRuleEnd() override {}
         };
 


### PR DESCRIPTION
Fixes https://bugs.swift.org/browse/SR-1468

I am not too sure about this fix