### PR TITLE
Fix for building on linux-armv7

### DIFF
--- a/lib/Commands/NinjaBuildCommand.cpp
+++ b/lib/Commands/NinjaBuildCommand.cpp
@@ -29,6 +29,7 @@
 #include <atomic>
 #include <cerrno>
 #include <condition_variable>
+#include <cstdarg>
 #include <cstdlib>
 #include <deque>
 #include <mutex>


### PR DESCRIPTION
We have to include cstdarg to avoid build failures relating to va_lists on debian Jessie armv7. I'm surprised it wasn't needed before.

> [76/95] Building CXX object lib/Commands/CMakeFiles/llbuildCommands.dir/NinjaBuildCommand.cpp.o
FAILED: /Spring/Projects/3rdParty/OpenSource/Apple/build/Ninja-ReleaseAssert/llvm-macosx-x86_64/bin/clang++  --target=armv7-linux-gnueabihf --sysroot=/Spring/Projects/3rdParty/OpenSource/Apple/cross-compile/sysroots/sysroot.armhf.debian.jessie   -I/Spring/Projects/3rdParty/OpenSource/Apple/llbuild/include -isystem /Spring/Projects/3rdParty/OpenSource/Apple/cross-compile/sysroots/sysroot.armhf.debian.jessie/usr/include/c++/4.8 -isystem /Spring/Projects/3rdParty/OpenSource/Apple/cross-compile/sysroots/sysroot.armhf.debian.jessie/usr/include/arm-linux-gnueabihf/c++/4.8 -isystem /Spring/Projects/3rdParty/OpenSource/Apple/cross-compile/sysroots/sysroot.armhf.debian.jessie/usr/lib/gcc/arm-linux-gnueabihf/4.8/include -isystem /Spring/Projects/3rdParty/OpenSource/Apple/cross-compile/sysroots/sysroot.armhf.debian.jessie/usr/lib/gcc/arm-linux-gnueabihf/4.8/include-fixed -B /Spring/Projects/3rdParty/OpenSource/Apple/cross-compile/gcc-arm-none-eabi-5_2-2015q4/arm-linux-gnueabihf/bin -B /Spring/Projects/3rdParty/OpenSource/Apple/cross-compile/sysroots/sysroot.armhf.debian.jessie/usr/lib/gcc/arm-linux-gnueabihf/4.8 -B /Spring/Projects/3rdParty/OpenSource/Apple/cross-compile/gcc-arm-none-eabi-5_2-2015q4/arm-linux-gnueabihf/bin -B /Spring/Projects/3rdParty/OpenSource/Apple/cross-compile/sysroots/sysroot.armhf.debian.jessie/usr/lib/gcc/arm-linux-gnueabihf/4.8 -B /Spring/Projects/3rdParty/OpenSource/Apple/cross-compile/gcc-arm-none-eabi-5_2-2015q4/arm-linux-gnueabihf/bin -B /Spring/Projects/3rdParty/OpenSource/Apple/cross-compile/sysroots/sysroot.armhf.debian.jessie/usr/lib/gcc/arm-linux-gnueabihf/4.8 -B /Spring/Projects/3rdParty/OpenSource/Apple/cross-compile/gcc-arm-none-eabi-5_2-2015q4/arm-linux-gnueabihf/bin -B /Spring/Projects/3rdParty/OpenSource/Apple/cross-compile/sysroots/sysroot.armhf.debian.jessie/usr/lib/gcc/arm-linux-gnueabihf/4.8 -B /Spring/Projects/3rdParty/OpenSource/Apple/cross-compile/gcc-arm-none-eabi-5_2-2015q4/arm-linux-gnueabihf/bin -B /Spring/Projects/3rdParty/OpenSource/Apple/cross-compile/sysroots/sysroot.armhf.debian.jessie/usr/lib/gcc/arm-linux-gnueabihf/4.8 -B /Spring/Projects/3rdParty/OpenSource/Apple/cross-compile/gcc-arm-none-eabi-5_2-2015q4/arm-linux-gnueabihf/bin -B /Spring/Projects/3rdParty/OpenSource/Apple/cross-compile/sysroots/sysroot.armhf.debian.jessie/usr/lib/gcc/arm-linux-gnueabihf/4.8 -B /Spring/Projects/3rdParty/OpenSource/Apple/cross-compile/gcc-arm-none-eabi-5_2-2015q4/arm-linux-gnueabihf/bin -B /Spring/Projects/3rdParty/OpenSource/Apple/cross-compile/sysroots/sysroot.armhf.debian.jessie/usr/lib/gcc/arm-linux-gnueabihf/4.8 -B /Spring/Projects/3rdParty/OpenSource/Apple/cross-compile/gcc-arm-none-eabi-5_2-2015q4/arm-linux-gnueabihf/bin -B /Spring/Projects/3rdParty/OpenSource/Apple/cross-compile/sysroots/sysroot.armhf.debian.jessie/usr/lib/gcc/arm-linux-gnueabihf/4.8 -B /Spring/Projects/3rdParty/OpenSource/Apple/cross-compile/gcc-arm-none-eabi-5_2-2015q4/arm-linux-gnueabihf/bin -B /Spring/Projects/3rdParty/OpenSource/Apple/cross-compile/sysroots/sysroot.armhf.debian.jessie/usr/lib/gcc/arm-linux-gnueabihf/4.8 -B /Spring/Projects/3rdParty/OpenSource/Apple/cross-compile/gcc-arm-none-eabi-5_2-2015q4/arm-linux-gnueabihf/bin -B /Spring/Projects/3rdParty/OpenSource/Apple/cross-compile/sysroots/sysroot.armhf.debian.jessie/usr/lib/gcc/arm-linux-gnueabihf/4.8 -std=c++14 -fno-rtti -fno-exceptions -Wmost -Wdocumentation  -Woverloaded-virtual -Wparentheses -Wswitch -Wunused-function -Wunused-variable -Wunused-value -Wempty-body -Wuninitialized -Wconstant-conversion -Wint-conversion -Wbool-conversion -Wenum-conversion -Wsign-compare -Wnewline-eof -Wdeprecated-declarations -Winvalid-offsetof -Wnon-virtual-dtor -fPIC -include "/Spring/Projects/3rdParty/OpenSource/Apple/llbuild/include/libstdc++14-workaround.h" -Wdocumentation -Wimplicit-fallthrough -Wunreachable-code -Woverloaded-virtual -g -MMD -MT lib/Commands/CMakeFiles/llbuildCommands.dir/NinjaBuildCommand.cpp.o -MF lib/Commands/CMakeFiles/llbuildCommands.dir/NinjaBuildCommand.cpp.o.d -o lib/Commands/CMakeFiles/llbuildCommands.dir/NinjaBuildCommand.cpp.o -c /Spring/Projects/3rdParty/OpenSource/Apple/llbuild/lib/Commands/NinjaBuildCommand.cpp
/Spring/Projects/3rdParty/OpenSource/Apple/llbuild/lib/Commands/NinjaBuildCommand.cpp:73:3: error: use of undeclared identifier 'va_start'
  va_start(ap, fmt);
  ^
/Spring/Projects/3rdParty/OpenSource/Apple/llbuild/lib/Commands/NinjaBuildCommand.cpp:75:3: error: use of undeclared identifier 'va_end'
  va_end(ap);
  ^
/Spring/Projects/3rdParty/OpenSource/Apple/llbuild/lib/Commands/NinjaBuildCommand.cpp:597:5: error: use of undeclared identifier 'va_start'
    va_start(ap, fmt);
    ^
/Spring/Projects/3rdParty/OpenSource/Apple/llbuild/lib/Commands/NinjaBuildCommand.cpp:599:5: error: use of undeclared identifier 'va_end'
    va_end(ap);
    ^
/Spring/Projects/3rdParty/OpenSource/Apple/llbuild/lib/Commands/NinjaBuildCommand.cpp:643:5: error: use of undeclared identifier 'va_start'
    va_start(ap, fmt);
    ^
/Spring/Projects/3rdParty/OpenSource/Apple/llbuild/lib/Commands/NinjaBuildCommand.cpp:645:5: error: use of undeclared identifier 'va_end'
    va_end(ap);
    ^
/Spring/Projects/3rdParty/OpenSource/Apple/llbuild/lib/Commands/NinjaBuildCommand.cpp:660:5: error: use of undeclared identifier 'va_start'
    va_start(ap, fmt);
    ^
/Spring/Projects/3rdParty/OpenSource/Apple/llbuild/lib/Commands/NinjaBuildCommand.cpp:662:5: error: use of undeclared identifier 'va_end'
    va_end(ap);
    ^
/Spring/Projects/3rdParty/OpenSource/Apple/llbuild/lib/Commands/NinjaBuildCommand.cpp:671:5: error: use of undeclared identifier 'va_start'
    va_start(ap, fmt);
    ^
/Spring/Projects/3rdParty/OpenSource/Apple/llbuild/lib/Commands/NinjaBuildCommand.cpp:673:5: error: use of undeclared identifier 'va_end'
    va_end(ap);
    ^
10 errors generated.