### PR TITLE
Add llvm-lit as a 'lit' name to search for.

### DIFF
--- a/cmake/modules/FindLit.cmake
+++ b/cmake/modules/FindLit.cmake
@@ -5,7 +5,7 @@
 # LIT_EXECUTABLE
 
 find_program(LIT_EXECUTABLE
-             NAMES lit
+             NAMES lit llvm-lit
              DOC "Path to 'lit' executable")
 
 # Handle REQUIRED and QUIET arguments, this will also set LIT_FOUND to true


### PR DESCRIPTION
In the LLVM build tree, 'lit' is built as 'llvm-lit'. Add the ability for CMake to find it using this name, too.