### PR TITLE
Add FreeBSD build support.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -112,6 +112,13 @@ endif()
 include_directories(BEFORE
   ${CMAKE_SOURCE_DIR}/include)
 
+# On FreeBSD, /usr/local/* is not used by default. In order to build LLVM
+# with sqlite3, etc., we must add /usr/local paths.
+if(${CMAKE_SYSTEM_NAME} MATCHES "(FreeBSD|DragonFly)")
+  include_directories("/usr/local/include")
+  link_directories("/usr/local/lib")
+endif(${CMAKE_SYSTEM_NAME} MATCHES "(FreeBSD|DragonFly)")
+
 # Xcode: Use libc++ and c++14 using proper build settings.
 if (XCODE)
   # Force usage of Clang.
@@ -170,8 +177,8 @@ else ()
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wnon-virtual-dtor")
 endif ()
 
-# On Linux, always build with PIC.
-if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
+# On BSD and Linux, always build with PIC.
+if(${CMAKE_SYSTEM_NAME} MATCHES ".*BSD" OR ${CMAKE_SYSTEM_NAME} MATCHES "Linux")
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC")
 endif ()

--- a/lib/Basic/CMakeLists.txt
+++ b/lib/Basic/CMakeLists.txt
@@ -7,6 +7,6 @@ add_llbuild_library(llbuildBasic
   ShellUtility.cpp
   )
 
-if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
+if(${CMAKE_SYSTEM_NAME} MATCHES ".*BSD" OR ${CMAKE_SYSTEM_NAME} MATCHES "Linux")
   target_link_libraries(llbuildBasic pthread)
 endif()

--- a/lib/Ninja/CMakeLists.txt
+++ b/lib/Ninja/CMakeLists.txt
@@ -4,3 +4,5 @@ add_llbuild_library(llbuildNinja
   ManifestLoader.cpp
   Parser.cpp
   )
+
+target_link_libraries(llbuildNinja llvmSupport curses)

--- a/lib/Ninja/CMakeLists.txt
+++ b/lib/Ninja/CMakeLists.txt
@@ -5,4 +5,4 @@ add_llbuild_library(llbuildNinja
   Parser.cpp
   )
 
-target_link_libraries(llbuildNinja llvmSupport curses)
+target_link_libraries(llbuildNinja llvmSupport)

--- a/lib/llvm/Support/CMakeLists.txt
+++ b/lib/llvm/Support/CMakeLists.txt
@@ -38,6 +38,10 @@ circular_raw_ostream.cpp
 raw_ostream.cpp
 )
 
+if(${CMAKE_SYSTEM_NAME} MATCHES "FreeBSD")
+  target_link_libraries(llvmSupport execinfo pthread)
+endif()
+
 if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
   target_link_libraries(llvmSupport pthread dl)
 endif()

--- a/lib/llvm/Support/Unix/Process.inc
+++ b/lib/llvm/Support/Unix/Process.inc
@@ -33,10 +33,10 @@
 #if HAVE_SIGNAL_H
 #include <signal.h>
 #endif
-// DragonFlyBSD, OpenBSD, and Bitrig have deprecated <malloc.h> for
+// DragonFlyBSD, FreeBSD, OpenBSD, and Bitrig have deprecated <malloc.h> for
 // <stdlib.h> instead. Unix.h includes this for us already.
 #if defined(HAVE_MALLOC_H) && !defined(__DragonFly__) && \
-    !defined(__OpenBSD__) && !defined(__Bitrig__)
+    !defined(__FreeBSD__) && !defined(__OpenBSD__) && !defined(__Bitrig__)
 #include <malloc.h>
 #endif
 #if defined(HAVE_MALLCTL)

--- a/unittests/Ninja/CMakeLists.txt
+++ b/unittests/Ninja/CMakeLists.txt
@@ -2,4 +2,4 @@ add_llbuild_unittest(NinjaTests
   LexerTest.cpp
   )
 
-target_link_libraries(NinjaTests llbuildNinja)
+target_link_libraries(NinjaTests llbuildNinja curses)


### PR DESCRIPTION
Many of the places in the CMake files that check for Linux really ought to check for *BSD or Linux, but a few of them are FreeBSD-specific (e.g., libexecinfo).