### PR TITLE
Improve error handling in `SQLiteBuildDB`

### DIFF
--- a/include/llbuild/Core/BuildDB.h
+++ b/include/llbuild/Core/BuildDB.h
@@ -31,15 +31,21 @@ public:
   virtual ~BuildDB();
 
   /// Get the current build iteration.
-  virtual uint64_t getCurrentIteration() = 0;
+  ///
+  /// \param success_out [out] Whether or not the query succeeded.
+  /// \param error_out [out] Error string if success_out is false.
+  virtual uint64_t getCurrentIteration(bool* success_out, std::string* error_out) = 0;
 
   /// Set the current build iteration.
-  virtual void setCurrentIteration(uint64_t value) = 0;
+  ///
+  /// \param error_out [out] Error string if return value is false.
+  virtual bool setCurrentIteration(uint64_t value, std::string* error_out) = 0;
 
   /// Look up the result for a rule.
   ///
   /// \param rule The rule to look up the result for.
   /// \param result_out [out] The result, if found.
+  /// \param error_out [out] Error string if an error occurred.
   /// \returns True if the database had a stored result for the rule.
   //
   // FIXME: This might be more efficient if it returns Result.
@@ -47,14 +53,16 @@ public:
   // FIXME: Figure out if we want a more lazy approach where we make the
   // database cache result objects and we query them only when needed. This may
   // scale better to very large build graphs.
-  virtual bool lookupRuleResult(const Rule& rule, Result* result_out) = 0;
+  virtual bool lookupRuleResult(const Rule& rule, Result* result_out, std::string* error_out) = 0;
 
   /// Update the stored result for a rule.
   ///
   /// The BuildEngine does not enforce that the dependencies for a Rule are
   /// unique. However, duplicate dependencies have no semantic meaning for the
   /// engine, and the database may elect to discard them from storage.
-  virtual void setRuleResult(const Rule& rule, const Result& result) = 0;
+  ///
+  /// \param error_out [out] Error string if return value is false.
+  virtual bool setRuleResult(const Rule& rule, const Result& result, std::string* error_out) = 0;
 
   /// Called by the build engine to indicate that a build has started.
   ///

--- a/include/llbuild/Core/BuildEngine.h
+++ b/include/llbuild/Core/BuildEngine.h
@@ -257,7 +257,10 @@ public:
   /// A database should only be attached immediately after creating the engine,
   /// it is an error to attach a database after adding rules or initiating any
   /// builds, or to attempt to attach multiple databases.
-  void attachDB(std::unique_ptr<BuildDB> database);
+  ///
+  /// \param error_out [out] Error string if return value is false.
+  /// \returns false if the build database could not be attached.
+  bool attachDB(std::unique_ptr<BuildDB> database, std::string* error_out);
 
   /// Enable tracing into the given output file.
   ///

--- a/lib/BuildSystem/BuildSystem.cpp
+++ b/lib/BuildSystem/BuildSystem.cpp
@@ -256,8 +256,7 @@ public:
     if (!db)
       return false;
 
-    buildEngine.attachDB(std::move(db));
-    return true;
+    return buildEngine.attachDB(std::move(db), error_out);
   }
 
   bool enableTracing(StringRef filename, std::string* error_out) {

--- a/lib/Commands/NinjaBuildCommand.cpp
+++ b/lib/Commands/NinjaBuildCommand.cpp
@@ -1981,11 +1981,10 @@ int commands::executeNinjaBuildCommand(std::vector<std::string> args) {
         core::createSQLiteBuildDB(dbFilename,
                                   BuildValue::currentSchemaVersion,
                                   &error));
-      if (!db) {
+      if (!db || !context.engine.attachDB(std::move(db), &error)) {
         context.emitError("unable to open build database: %s", error.c_str());
         return 1;
       }
-      context.engine.attachDB(std::move(db));
     }
 
     // Enable tracing, if requested.

--- a/llbuild.xcodeproj/project.pbxproj
+++ b/llbuild.xcodeproj/project.pbxproj
@@ -75,6 +75,7 @@
 		C5740D0A1E03527B00567DD8 /* libllbuildCore.a in Frameworks */ = {isa = PBXBuildFile; fileRef = E1A2243E19F997150059043E /* libllbuildCore.a */; };
 		C5740D0B1E03528600567DD8 /* libllbuildBasic.a in Frameworks */ = {isa = PBXBuildFile; fileRef = E1A2242519F991B40059043E /* libllbuildBasic.a */; };
 		C5740D0C1E03529300567DD8 /* libsqlite3.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = E1E221081A00B82100957481 /* libsqlite3.dylib */; };
+		9DDD8BE11DDCAB9A00FB62D2 /* SQLiteBuildDBTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 9DDD8BDF1DDCAB9A00FB62D2 /* SQLiteBuildDBTest.cpp */; };
 		E104FAF71B655A97005C68A0 /* BuildSystemPerfTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = E104FAF61B655A97005C68A0 /* BuildSystemPerfTests.mm */; };
 		E104FAFA1B655BBA005C68A0 /* libllbuildBuildSystem.a in Frameworks */ = {isa = PBXBuildFile; fileRef = E1B839571B541BFD00DB876B /* libllbuildBuildSystem.a */; };
 		E104FAFB1B655C33005C68A0 /* libllvmSupport.a in Frameworks */ = {isa = PBXBuildFile; fileRef = E1B838A21B52E7DE00DB876B /* libllvmSupport.a */; };
@@ -697,6 +698,7 @@
 		9DB047A81DF9D43D006CDF52 /* BuildSystemTests */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = BuildSystemTests; sourceTree = BUILT_PRODUCTS_DIR; };
 		C5740D081E03523100567DD8 /* BuildSystemFrontendTest.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = BuildSystemFrontendTest.cpp; sourceTree = "<group>"; };
 		C5740D0D1E0352D800567DD8 /* CMakeLists.txt */ = {isa = PBXFileReference; lastKnownFileType = text; path = CMakeLists.txt; sourceTree = "<group>"; };
+		9DDD8BDF1DDCAB9A00FB62D2 /* SQLiteBuildDBTest.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = SQLiteBuildDBTest.cpp; sourceTree = "<group>"; };
 		E104FAF61B655A97005C68A0 /* BuildSystemPerfTests.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = BuildSystemPerfTests.mm; sourceTree = "<group>"; };
 		E104FAFF1B6568E0005C68A0 /* BuildSystem.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = BuildSystem.cpp; sourceTree = "<group>"; };
 		E1066C071BC5ACAB00B892CE /* LaneBasedExecutionQueue.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = LaneBasedExecutionQueue.cpp; sourceTree = "<group>"; };
@@ -1532,6 +1534,7 @@
 				E1A0B1001C9717BA006DA08F /* DependencyInfoParserTest.cpp */,
 				E10FE0D61B7313D50059D086 /* DepsBuildEngineTest.cpp */,
 				E19D79941A15DA06002604FB /* MakefileDepsParserTest.cpp */,
+				9DDD8BDF1DDCAB9A00FB62D2 /* SQLiteBuildDBTest.cpp */,
 			);
 			path = Core;
 			sourceTree = "<group>";
@@ -2707,6 +2710,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				9DDD8BE11DDCAB9A00FB62D2 /* SQLiteBuildDBTest.cpp in Sources */,
 				E19D79951A15DA06002604FB /* MakefileDepsParserTest.cpp in Sources */,
 				E1A0B1011C9717BA006DA08F /* DependencyInfoParserTest.cpp in Sources */,
 				E1A224F619F99D940059043E /* BuildEngineTest.cpp in Sources */,

--- a/products/libllbuild/Core-C-API.cpp
+++ b/products/libllbuild/Core-C-API.cpp
@@ -165,8 +165,9 @@ bool llb_buildengine_attach_db(llb_buildengine_t* engine_p,
     return false;
   }
 
-  engine->attachDB(std::move(db));
-  return true;
+  bool result = engine->attachDB(std::move(db), &error);
+  *error_out = strdup(error.c_str());
+  return result;
 }
 
 void llb_buildengine_build(llb_buildengine_t* engine_p, const llb_data_t* key,

--- a/unittests/Core/BuildEngineTest.cpp
+++ b/unittests/Core/BuildEngineTest.cpp
@@ -416,23 +416,27 @@ TEST(BuildEngineTest, incrementalDependency) {
   public:
     std::unordered_map<core::KeyType, Result> ruleResults;
 
-    virtual uint64_t getCurrentIteration() override {
+    virtual uint64_t getCurrentIteration(bool* success_out, std::string* error_out) override {
       return 0;
     }
-    virtual void setCurrentIteration(uint64_t value) override {}
+    virtual bool setCurrentIteration(uint64_t value, std::string* error_out) override { return true; }
     virtual bool lookupRuleResult(const Rule& rule,
-                                  Result* result_out) override {
+                                  Result* result_out,
+                                  std::string* error_out) override {
       return false;
     }
-    virtual void setRuleResult(const Rule& rule,
-                               const Result& result) override {
+    virtual bool setRuleResult(const Rule& rule,
+                               const Result& result,
+                               std::string* error_out) override {
       ruleResults[rule.key] = result;
+      return true;
     }
     virtual void buildStarted() override {}
     virtual void buildComplete() override {}
   };
   CustomDB *db = new CustomDB();
-  engine.attachDB(std::unique_ptr<CustomDB>(db));
+  std::string error;
+  engine.attachDB(std::unique_ptr<CustomDB>(db), &error);
 
   int valueA = 2;
   engine.addRule({

--- a/unittests/Core/DepsBuildEngineTest.cpp
+++ b/unittests/Core/DepsBuildEngineTest.cpp
@@ -246,7 +246,7 @@ TEST(DepsBuildEngineTest, KeysWithNull) {
     core::BuildEngine engine(delegate);
     // FIXME: Don't put database in temp.
     std::string error;
-    engine.attachDB(createSQLiteBuildDB(dbPath, 1, &error));
+    engine.attachDB(createSQLiteBuildDB(dbPath, 1, &error), &error);
 
     std::string inputA{"i\0A", 3};
     std::string inputB{"i\0B", 3};

--- a/unittests/Core/SQLiteBuildDBTest.cpp
+++ b/unittests/Core/SQLiteBuildDBTest.cpp
@@ -1,0 +1,52 @@
+//===- unittests/Core/SQLiteBuildDBTest.cpp -----------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2015 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#include "llbuild/Core/BuildDB.h"
+
+#include "llvm/ADT/SmallString.h"
+#include "llvm/Support/FileSystem.h"
+
+#include "gtest/gtest.h"
+
+#include <sstream>
+
+#include <sqlite3.h>
+
+using namespace llbuild;
+using namespace llbuild::core;
+
+TEST(SQLiteBuildDBTest, ErrorHandling) {
+    // Create a temporary file.
+    llvm::SmallString<256> dbPath;
+    auto ec = llvm::sys::fs::createTemporaryFile("build", "db", dbPath);
+    EXPECT_EQ(bool(ec), false);
+    const char* path = dbPath.c_str();
+    fprintf(stderr, "using db: %s\n", path);
+
+    std::string error;
+    std::unique_ptr<BuildDB> buildDB = createSQLiteBuildDB(dbPath, 1, &error);
+    EXPECT_TRUE(buildDB != nullptr);
+    EXPECT_EQ(error, "");
+
+    sqlite3 *db = nullptr;
+    sqlite3_open(path, &db);
+    sqlite3_exec(db, "PRAGMA locking_mode = EXCLUSIVE; BEGIN EXCLUSIVE;", nullptr, nullptr, nullptr);
+
+    buildDB = createSQLiteBuildDB(dbPath, 1, &error);
+    EXPECT_TRUE(buildDB == nullptr);
+    std::stringstream out;
+    out << "error: accessing build database \"" << path << "\": database is locked Possibly there are two concurrent builds running in the same filesystem location.";
+    EXPECT_EQ(error, out.str());
+
+    ec = llvm::sys::fs::remove(dbPath.str());
+    EXPECT_EQ(bool(ec), false);
+}


### PR DESCRIPTION
- Extend DB APIs with out error parameters
- The error message will point users to potentially concurrently running builds if the cause of the error is multiple DB connections
- Handling of errors in `BuildEngine` is pretty basic, but that matches all the current error handling in that class

see rdar://problem/27615139