### PR TITLE
Fix the `shorten-64-to-32` warnings

### DIFF
--- a/include/llbuild/BuildSystem/BuildExecutionQueue.h
+++ b/include/llbuild/BuildSystem/BuildExecutionQueue.h
@@ -230,7 +230,7 @@ public:
 /// Create an execution queue that schedules jobs to individual lanes with a
 /// capped limit on the number of concurrent lanes.
 BuildExecutionQueue *createLaneBasedExecutionQueue(
-    BuildExecutionQueueDelegate& delegate, int numLanes);
+    BuildExecutionQueueDelegate& delegate, unsigned long numLanes);
 
 }
 }

--- a/include/llbuild/BuildSystem/BuildKey.h
+++ b/include/llbuild/BuildSystem/BuildKey.h
@@ -60,8 +60,8 @@ private:
   }
   BuildKey(char kindCode, StringRef name, StringRef data) {
     // FIXME: We need good support infrastructure for binary encoding.
-    uint32_t nameSize = name.size();
-    uint32_t dataSize = data.size();
+    uint32_t nameSize = (uint32_t)name.size();
+    uint32_t dataSize = (uint32_t)data.size();
     key.resize(1 + sizeof(uint32_t) + nameSize + dataSize);
     uint32_t pos = 0;
     key[pos] = kindCode; pos += 1;
@@ -141,7 +141,7 @@ public:
     assert(isCustomTask());
     uint32_t nameSize;
     memcpy(&nameSize, &key[1], sizeof(uint32_t));
-    uint32_t dataSize = key.size() - 1 - sizeof(uint32_t) - nameSize;
+    uint32_t dataSize = (int)key.size() - 1 - sizeof(uint32_t) - nameSize;
     return StringRef(&key[1 + sizeof(uint32_t) + nameSize], dataSize);
   }
 

--- a/include/llbuild/BuildSystem/BuildValue.h
+++ b/include/llbuild/BuildSystem/BuildValue.h
@@ -96,7 +96,7 @@ private:
   }
   BuildValue(Kind kind, ArrayRef<FileInfo> outputInfos,
              uint64_t commandSignature = 0)
-      : kind(kind), numOutputInfos(outputInfos.size()),
+      : kind(kind), numOutputInfos((uint32_t)outputInfos.size()),
         commandSignature(commandSignature)
   {
     assert(numOutputInfos >= 1);

--- a/include/llbuild/Ninja/Lexer.h
+++ b/include/llbuild/Ninja/Lexer.h
@@ -46,11 +46,11 @@ struct Token {
     KWKindLast = KWSubninja
   };
 
-  const char* start;          /// The beginning of the token string.
-  Kind        tokenKind;      /// The token kind.
-  unsigned    length;         /// The length of the token.
-  unsigned    line;           /// The line number of the start of this token.
-  unsigned    column;         /// The column number at the start of this token.
+  const char* start;                /// The beginning of the token string.
+  Kind              tokenKind;      /// The token kind.
+  unsigned long     length;         /// The length of the token.
+  unsigned long     line;           /// The line number of the start of this token.
+  unsigned long     column;         /// The column number at the start of this token.
 
   /// The name of this token's kind.
   const char *getKindName() const;

--- a/include/llbuild/Ninja/Manifest.h
+++ b/include/llbuild/Ninja/Manifest.h
@@ -209,7 +209,7 @@ public:
   unsigned getNumExplicitInputs() const { return numExplicitInputs; }
   unsigned getNumImplicitInputs() const { return numImplicitInputs; }
   unsigned getNumOrderOnlyInputs() const {
-    return inputs.size() - getNumExplicitInputs() - getNumImplicitInputs();
+    return (unsigned)inputs.size() - getNumExplicitInputs() - getNumImplicitInputs();
   }
 
   llvm::StringMap<std::string>& getParameters() {

--- a/lib/BuildSystem/BuildSystemFrontend.cpp
+++ b/lib/BuildSystem/BuildSystemFrontend.cpp
@@ -286,7 +286,7 @@ BuildSystemFrontendDelegate::error(StringRef filename,
     // to SourceMgr completely.
     auto buffer = getFileSystem().getFileContents(filename);
     if (buffer) {
-      unsigned offset = at.start - impl->bufferBeingParsed.data();
+      unsigned long offset = at.start - impl->bufferBeingParsed.data();
       if (offset + at.length < buffer->getBufferSize()) {
         range.Start = loc = llvm::SMLoc::getFromPointer(
             buffer->getBufferStart() + offset);
@@ -316,7 +316,7 @@ BuildSystemFrontendDelegate::createExecutionQueue() {
     
   // Get the number of CPUs to use.
   long numCPUs = sysconf(_SC_NPROCESSORS_ONLN);
-  unsigned numLanes;
+  unsigned long numLanes;
   if (numCPUs < 0) {
     error("<unknown>", {}, "unable to detect number of CPUs");
     numLanes = 1;

--- a/lib/BuildSystem/ExternalCommand.cpp
+++ b/lib/BuildSystem/ExternalCommand.cpp
@@ -140,7 +140,7 @@ getResultForOutput(Node* node, const BuildValue& value) {
   auto idx = it - outputs.begin();
   assert(idx < value.getNumOutputs());
 
-  auto& info = value.getNthOutputInfo(idx);
+  auto& info = value.getNthOutputInfo((unsigned int)idx);
   if (info.isMissing())
     return BuildValue::makeMissingOutput();
     
@@ -162,7 +162,7 @@ bool ExternalCommand::isResultValid(BuildSystem& system,
     return false;
 
   // Check the timestamps on each of the outputs.
-  for (unsigned i = 0, e = outputs.size(); i != e; ++i) {
+  for (unsigned long i = 0, e = outputs.size(); i != e; ++i) {
     auto* node = outputs[i];
 
     // Ignore virtual outputs.
@@ -184,7 +184,7 @@ bool ExternalCommand::isResultValid(BuildSystem& system,
     // could enable behavior to remove such output files if annotated prior to
     // running the command.
     auto info = node->getFileInfo(system.getDelegate().getFileSystem());
-    if (value.getNthOutputInfo(i) != info)
+    if (value.getNthOutputInfo((unsigned int)i) != info)
       return false;
   }
 

--- a/lib/BuildSystem/LaneBasedExecutionQueue.cpp
+++ b/lib/BuildSystem/LaneBasedExecutionQueue.cpp
@@ -54,7 +54,7 @@ struct LaneBasedExecutionQueueJobContext {
 // FIXME: Consider trying to share this with the Ninja implementation.
 class LaneBasedExecutionQueue : public BuildExecutionQueue {
   /// The number of lanes the queue was configured with.
-  unsigned numLanes;
+  unsigned long numLanes;
 
   /// A thread for each lane.
   std::vector<std::unique_ptr<std::thread>> lanes;
@@ -108,10 +108,10 @@ class LaneBasedExecutionQueue : public BuildExecutionQueue {
 
 public:
   LaneBasedExecutionQueue(BuildExecutionQueueDelegate& delegate,
-                          unsigned numLanes)
+                          unsigned long numLanes)
       : BuildExecutionQueue(delegate), numLanes(numLanes)
   {
-    for (unsigned i = 0; i != numLanes; ++i) {
+    for (unsigned long i = 0; i != numLanes; ++i) {
       lanes.push_back(std::unique_ptr<std::thread>(
                           new std::thread(
                               &LaneBasedExecutionQueue::executeLane, this, i)));
@@ -351,6 +351,6 @@ public:
 
 BuildExecutionQueue*
 llbuild::buildsystem::createLaneBasedExecutionQueue(
-    BuildExecutionQueueDelegate& delegate, int numLanes) {
+    BuildExecutionQueueDelegate& delegate, unsigned long numLanes) {
   return new LaneBasedExecutionQueue(delegate, numLanes);
 }

--- a/lib/Commands/BuildEngineCommand.cpp
+++ b/lib/Commands/BuildEngineCommand.cpp
@@ -233,7 +233,7 @@ static int runAckermannBuild(int m, int n, int recomputeCount,
   llvm::outs() << "ack(" << m << ", " << n << ") = " << result << "\n";
   if (n < 10) {
 #ifndef NDEBUG
-    int expected = ack(m, n);
+    uint64_t expected = ack(m, n);
     assert(result == expected);
 #endif
   }
@@ -270,7 +270,7 @@ static void ackermannUsage() {
 }
 
 static int executeAckermannCommand(std::vector<std::string> args) {
-  int recomputeCount = 0;
+  long recomputeCount = 0;
   std::string dumpGraphPath, traceFilename;
   while (!args.empty() && args[0][0] == '-') {
     const std::string option = args[0];
@@ -324,14 +324,14 @@ static int executeAckermannCommand(std::vector<std::string> args) {
   }
 
   const char *str = args[0].c_str();
-  int m = ::strtol(str, (char**)&str, 10);
+  long m = ::strtol(str, (char**)&str, 10);
   if (*str != '\0') {
     fprintf(stderr, "error: %s: invalid argument '%s' (expected integer)\n",
             getProgramName(), args[0].c_str());
     return 1;
   }
   str = args[1].c_str();
-  int n = ::strtol(str, (char**)&str, 10);
+  long n = ::strtol(str, (char**)&str, 10);
   if (*str != '\0') {
     fprintf(stderr, "error: %s: invalid argument '%s' (expected integer)\n",
             getProgramName(), args[1].c_str());
@@ -339,18 +339,18 @@ static int executeAckermannCommand(std::vector<std::string> args) {
   }
 
   if (m >= 4) {
-    fprintf(stderr, "error: %s: invalid argument M = '%d' (too large)\n",
+    fprintf(stderr, "error: %s: invalid argument M = '%ldd' (too large)\n",
             getProgramName(), m);
     return 1;
   }
 
   if (n >= 1024) {
-    fprintf(stderr, "error: %s: invalid argument N = '%d' (too large)\n",
+    fprintf(stderr, "error: %s: invalid argument N = '%ld' (too large)\n",
             getProgramName(), n);
     return 1;
   }
 
-  return runAckermannBuild(m, n, recomputeCount, traceFilename, dumpGraphPath);
+  return runAckermannBuild((int)m, (int)n, (int)recomputeCount, traceFilename, dumpGraphPath);
 }
 
 }

--- a/lib/Commands/CommandLineStatusOutput.cpp
+++ b/lib/Commands/CommandLineStatusOutput.cpp
@@ -33,7 +33,7 @@ struct CommandLineStatusOutputImpl {
   bool isClosed{false};
 
   /// The number of characters written to the current line.
-  int numCurrentCharacters{0};
+  unsigned long numCurrentCharacters{0};
 
   CommandLineStatusOutputImpl() {}
 
@@ -92,7 +92,7 @@ struct CommandLineStatusOutputImpl {
     if (hasOutput) {
       // Clear the line before writing, this tends to produce better results
       // than clearing the unwritten tail of the line written below.
-      fprintf(fp, "\r%*s\r", numCurrentCharacters, "");
+      fprintf(fp, "\r%*s\r", (int)numCurrentCharacters, "");
       fflush(fp);
       hasOutput = false;
     }

--- a/lib/Commands/CommandUtil.cpp
+++ b/lib/Commands/CommandUtil.cpp
@@ -43,9 +43,9 @@ static char hexdigit(unsigned input) {
   return (input < 10) ? '0' + input : 'A' + input - 10;
 }
 
-std::string util::escapedString(const char* start, unsigned length) {
+std::string util::escapedString(const char* start, unsigned long length) {
   std::stringstream result;
-  for (unsigned i = 0; i != length; ++i) {
+  for (unsigned long i = 0; i != length; ++i) {
     char c = start[i];
     if (c == '"') {
       result << "\\\"";
@@ -126,7 +126,7 @@ static void emitError(const std::string& filename, const std::string& message,
 
 void util::emitError(const std::string& filename, const std::string& message,
                      const ninja::Token& at, const ninja::Parser* parser) {
-  ::emitError(filename, message, at.start, at.length, at.line, at.column,
+  ::emitError(filename, message, at.start, (int)at.length, (int)at.line, (int)at.column,
             parser->getLexer().getBuffer());
 }
 

--- a/lib/Commands/CommandUtil.h
+++ b/lib/Commands/CommandUtil.h
@@ -33,7 +33,7 @@ struct Token;
 namespace commands {
 namespace util {
 
-std::string escapedString(const char* start, unsigned length);
+std::string escapedString(const char* start, unsigned long length);
 
 std::string escapedString(const std::string& string);
 

--- a/lib/Core/SQLiteBuildDB.cpp
+++ b/lib/Core/SQLiteBuildDB.cpp
@@ -330,7 +330,7 @@ public:
     result = sqlite3_clear_bindings(findRuleResultStmt);
     assert(result == SQLITE_OK);
     result = sqlite3_bind_text(findRuleResultStmt, /*index=*/1,
-                               rule.key.data(), rule.key.size(),
+                               rule.key.data(), (int)rule.key.size(),
                                SQLITE_STATIC);
     assert(result == SQLITE_OK);
 
@@ -427,7 +427,7 @@ public:
     result = sqlite3_clear_bindings(findKeyIDForKeyStmt);
     assert(result == SQLITE_OK);
     result = sqlite3_bind_text(findKeyIDForKeyStmt, /*index=*/1,
-                               key.data(), key.size(),
+                               key.data(), (int)key.size(),
                                SQLITE_STATIC);
     assert(result == SQLITE_OK);
 
@@ -444,7 +444,7 @@ public:
     result = sqlite3_clear_bindings(insertIntoKeysStmt);
     assert(result == SQLITE_OK);
     result = sqlite3_bind_text(insertIntoKeysStmt, /*index=*/1,
-                               key.data(), key.size(),
+                               key.data(), (int)key.size(),
                                SQLITE_STATIC);
     assert(result == SQLITE_OK);
     result = sqlite3_step(insertIntoKeysStmt);
@@ -521,7 +521,7 @@ public:
     assert(result == SQLITE_OK);
     result = sqlite3_bind_blob(insertIntoRuleResultsStmt, /*index=*/2,
                                ruleResult.value.data(),
-                               ruleResult.value.size(),
+                               (int)ruleResult.value.size(),
                                SQLITE_STATIC);
     assert(result == SQLITE_OK);
     result = sqlite3_bind_int64(insertIntoRuleResultsStmt, /*index=*/3,

--- a/lib/Ninja/Lexer.cpp
+++ b/lib/Ninja/Lexer.cpp
@@ -116,7 +116,7 @@ void Lexer::skipToEndOfLine() {
 }
 
 Token& Lexer::setIdentifierTokenKind(Token& result) const {
-  unsigned length = bufferPos - result.start;
+  unsigned long length = bufferPos - result.start;
   switch (length) {
   case 4:
     if (memcmp("rule", result.start, 4) == 0)

--- a/lib/Ninja/ManifestLoader.cpp
+++ b/lib/Ninja/ManifestLoader.cpp
@@ -402,7 +402,7 @@ public:
       }
       return;
     } else if (name == "out") {
-      for (unsigned i = 0, ie = decl->getOutputs().size(); i != ie; ++i) {
+      for (unsigned long i = 0, ie = decl->getOutputs().size(); i != ie; ++i) {
         if (i != 0)
           result << " ";
         result << decl->getOutputs()[i]->getPath();

--- a/lib/Ninja/Parser.cpp
+++ b/lib/Ninja/Parser.cpp
@@ -422,7 +422,7 @@ bool ParserImpl::parseBuildSpecifier(ParseActions::BuildResult *decl_out) {
   while (tok.tokenKind == Token::Kind::String) {
     inputs.push_back(consumeExpectedToken(Token::Kind::String));
   }
-  unsigned numExplicitInputs = inputs.size();
+  unsigned long numExplicitInputs = inputs.size();
 
   // Parse the implicit inputs, if present.
   if (consumeIfToken(Token::Kind::Pipe)) {
@@ -430,7 +430,7 @@ bool ParserImpl::parseBuildSpecifier(ParseActions::BuildResult *decl_out) {
       inputs.push_back(consumeExpectedToken(Token::Kind::String));
     }
   }
-  unsigned numImplicitInputs = inputs.size() - numExplicitInputs;
+  unsigned long numImplicitInputs = inputs.size() - numExplicitInputs;
 
   // Parse the order-only inputs, if present.
   if (consumeIfToken(Token::Kind::PipePipe)) {
@@ -448,7 +448,7 @@ bool ParserImpl::parseBuildSpecifier(ParseActions::BuildResult *decl_out) {
   }
 
   *decl_out = actions.actOnBeginBuildDecl(name, outputs, inputs,
-                                          numExplicitInputs, numImplicitInputs);
+                                          (unsigned)numExplicitInputs, (unsigned)numImplicitInputs);
 
   return true;
 }

--- a/llbuild.xcodeproj/project.pbxproj
+++ b/llbuild.xcodeproj/project.pbxproj
@@ -2973,6 +2973,7 @@
 					"$(inherited)",
 					"GTEST_HAS_RTTI=0",
 				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = NO;
 				LIBRARY_SEARCH_PATHS = "$(BUILD_DIR)/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				USER_HEADER_SEARCH_PATHS = "$(SRCROOT)/include $(SRCROOT)/utils/unittest/googletest/include";
@@ -2986,6 +2987,7 @@
 					"$(inherited)",
 					"GTEST_HAS_RTTI=0",
 				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = NO;
 				LIBRARY_SEARCH_PATHS = "$(BUILD_DIR)/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				USER_HEADER_SEARCH_PATHS = "$(SRCROOT)/include $(SRCROOT)/utils/unittest/googletest/include";
@@ -2995,6 +2997,7 @@
 		E1604CAF1BB9E01D001153A1 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				GCC_WARN_64_TO_32_BIT_CONVERSION = NO;
 				INSTALL_PATH = "$(DT_TOOLCHAIN_DIR)/usr/local/bin";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = NO;
@@ -3004,6 +3007,7 @@
 		E1604CB01BB9E01D001153A1 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				GCC_WARN_64_TO_32_BIT_CONVERSION = NO;
 				INSTALL_PATH = "$(DT_TOOLCHAIN_DIR)/usr/local/bin";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = NO;
@@ -3169,6 +3173,7 @@
 					"$(inherited)",
 					"LLBUILD_VERSION_STRING=\\\"$(LLBUILD_VERSION_STRING)\\\"",
 				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = NO;
 				LLBUILD_VERSION_STRING = "llbuild-$(PROJECT_SOURCE_VERSION)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
@@ -3182,6 +3187,7 @@
 					"$(inherited)",
 					"LLBUILD_VERSION_STRING=\\\"$(LLBUILD_VERSION_STRING)\\\"",
 				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = NO;
 				LLBUILD_VERSION_STRING = "llbuild-$(PROJECT_SOURCE_VERSION)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
@@ -3191,6 +3197,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				EXECUTABLE_PREFIX = lib;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = NO;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Debug;
@@ -3199,6 +3206,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				EXECUTABLE_PREFIX = lib;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = NO;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Release;
@@ -3207,6 +3215,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				EXECUTABLE_PREFIX = lib;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = NO;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Debug;
@@ -3215,6 +3224,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				EXECUTABLE_PREFIX = lib;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = NO;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Release;
@@ -3223,6 +3233,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				EXECUTABLE_PREFIX = lib;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = NO;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Debug;
@@ -3231,6 +3242,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				EXECUTABLE_PREFIX = lib;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = NO;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Release;
@@ -3238,6 +3250,7 @@
 		E1A224C819F999B80059043E /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				GCC_WARN_64_TO_32_BIT_CONVERSION = NO;
 				INSTALL_PATH = "$(DT_TOOLCHAIN_DIR)/usr/local/bin";
 				PRODUCT_NAME = llbuild;
 				SKIP_INSTALL = NO;
@@ -3247,6 +3260,7 @@
 		E1A224C919F999B80059043E /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				GCC_WARN_64_TO_32_BIT_CONVERSION = NO;
 				INSTALL_PATH = "$(DT_TOOLCHAIN_DIR)/usr/local/bin";
 				PRODUCT_NAME = llbuild;
 				SKIP_INSTALL = NO;
@@ -3314,6 +3328,7 @@
 					"$(inherited)",
 					"GTEST_HAS_RTTI=0",
 				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = NO;
 				LIBRARY_SEARCH_PATHS = "$(BUILD_DIR)/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				USER_HEADER_SEARCH_PATHS = "$(SRCROOT)/include $(SRCROOT)/utils/unittest/googletest/include";
@@ -3328,6 +3343,7 @@
 					"$(inherited)",
 					"GTEST_HAS_RTTI=0",
 				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = NO;
 				LIBRARY_SEARCH_PATHS = "$(BUILD_DIR)/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				USER_HEADER_SEARCH_PATHS = "$(SRCROOT)/include $(SRCROOT)/utils/unittest/googletest/include";
@@ -3382,6 +3398,7 @@
 				DYLIB_CURRENT_VERSION = "$(PROJECT_SOURCE_VERSION)";
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				EXECUTABLE_PREFIX = lib;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = NO;
 				HEADER_SEARCH_PATHS = "$(SRCROOT)/products/libllbuild/public-api";
 				INSTALL_PATH = "$(DT_TOOLCHAIN_DIR)/usr/local/lib";
 				MACOSX_DEPLOYMENT_TARGET = 10.10;
@@ -3398,6 +3415,7 @@
 				DYLIB_CURRENT_VERSION = "$(PROJECT_SOURCE_VERSION)";
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				EXECUTABLE_PREFIX = lib;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = NO;
 				HEADER_SEARCH_PATHS = "$(SRCROOT)/products/libllbuild/public-api";
 				INSTALL_PATH = "$(DT_TOOLCHAIN_DIR)/usr/local/lib";
 				MACOSX_DEPLOYMENT_TARGET = 10.10;
@@ -3412,6 +3430,7 @@
 			buildSettings = {
 				CLANG_ENABLE_CODE_COVERAGE = NO;
 				EXECUTABLE_PREFIX = lib;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = NO;
 				HEADER_SEARCH_PATHS = "$(SRCROOT)/include";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
@@ -3422,6 +3441,7 @@
 			buildSettings = {
 				CLANG_ENABLE_CODE_COVERAGE = NO;
 				EXECUTABLE_PREFIX = lib;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = NO;
 				HEADER_SEARCH_PATHS = "$(SRCROOT)/include";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
@@ -3431,6 +3451,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				EXECUTABLE_PREFIX = lib;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = NO;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Debug;
@@ -3439,6 +3460,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				EXECUTABLE_PREFIX = lib;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = NO;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Release;
@@ -3488,6 +3510,7 @@
 				DYLIB_CURRENT_VERSION = "$(PROJECT_SOURCE_VERSION)";
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = NO;
 				HEADER_SEARCH_PATHS = "$(SRCROOT)/products/libllbuild/public-api";
 				INFOPLIST_FILE = "$(SRCROOT)/products/llbuild-framework/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
@@ -3508,6 +3531,7 @@
 				DYLIB_CURRENT_VERSION = "$(PROJECT_SOURCE_VERSION)";
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = NO;
 				HEADER_SEARCH_PATHS = "$(SRCROOT)/products/libllbuild/public-api";
 				INFOPLIST_FILE = "$(SRCROOT)/products/llbuild-framework/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";

--- a/perftests/Xcode/PerfTests/CorePerfTests.mm
+++ b/perftests/Xcode/PerfTests/CorePerfTests.mm
@@ -63,7 +63,7 @@ public:
 
   virtual void start(BuildEngine& Engine) override {
     // Request all of the inputs.
-    for (int i = 0, e = Inputs.size(); i != e; ++i) {
+    for (size_t i = 0, e = Inputs.size(); i != e; ++i) {
       Engine.taskNeedsInput(this, Inputs[i], i);
     }
   }
@@ -198,8 +198,8 @@ static int64_t i64pow(int64_t Value, int64_t Exponent) {
   //         \-> i2,N          iM,{N**(M-1)}
 
   int M = 13, N = 3; // Use a graph of 797,161 nodes.
-  int NumTotalNodes = (i64pow(N, M) - 1) / (N - 1);
-  NSLog(@"running test with %d-ary tree of depth %d (%d nodes)\n",
+  size_t NumTotalNodes = (i64pow(N, M) - 1) / (N - 1);
+  NSLog(@"running test with %d-ary tree of depth %d (%zu nodes)\n",
          N, M, NumTotalNodes);
 
   // Set up the build rules.
@@ -221,7 +221,7 @@ static int64_t i64pow(int64_t Value, int64_t Exponent) {
   int LastInputValue = 0;
   for (int i = 1; i <= M; ++i) {
     // Compute the total number of groups at this depth.
-    int NumNodes = i64pow(N, i - 1);
+    int64_t NumNodes = i64pow(N, i - 1);
     for (int j = 1; j <= NumNodes; ++j) {
       char Name[32];
       sprintf(Name, "i%d,%d", i, j);

--- a/unittests/Core/BuildEngineTest.cpp
+++ b/unittests/Core/BuildEngineTest.cpp
@@ -87,7 +87,7 @@ public:
 
     // Request all of the inputs.
     inputValues.resize(inputs.size());
-    for (int i = 0, e = inputs.size(); i != e; ++i) {
+    for (unsigned long i = 0, e = inputs.size(); i != e; ++i) {
       engine.taskNeedsInput(this, inputs[i], i);
     }
   }

--- a/unittests/Core/DepsBuildEngineTest.cpp
+++ b/unittests/Core/DepsBuildEngineTest.cpp
@@ -81,7 +81,7 @@ public:
 
   virtual void start(BuildEngine& engine) override {
     // Request all of the inputs.
-    for (int i = 0, e = inputs.size(); i != e; ++i) {
+    for (unsigned long i = 0, e = inputs.size(); i != e; ++i) {
       engine.taskNeedsInput(this, inputs[i], i);
     }
   }


### PR DESCRIPTION
- Disable warnings for any target using LLVM sources
- Fix warnings in the actual llbuild codebase