### PR TITLE
Command skipping

### DIFF
--- a/include/llbuild/BuildSystem/BuildSystem.h
+++ b/include/llbuild/BuildSystem/BuildSystem.h
@@ -151,6 +151,21 @@ public:
   /// commands).
   virtual void commandPreparing(Command*) = 0;
 
+  /// Called by the build system to allow the delegate to skip a command without
+  /// implicitly skipping its dependents.
+  ///
+  /// WARNING: Clients need to take special care when using this. Skipping
+  /// commands without considering their dependencies or dependents can easily
+  /// produce an inconsistent build.
+  ///
+  /// This method is called before the command starts, when the system has
+  /// identified that it will eventually need to run (after all of its inputs
+  /// have been satisfied).
+  ///
+  /// The system guarantees that all such calls will be paired with a
+  /// corresponding \see commandFinished() call.
+  virtual bool shouldCommandStart(Command*) = 0;
+
   /// Called by the build system to report that a declared command has started.
   ///
   /// The system guarantees that all such calls will be paired with a

--- a/include/llbuild/BuildSystem/BuildSystemFrontend.h
+++ b/include/llbuild/BuildSystem/BuildSystemFrontend.h
@@ -167,6 +167,21 @@ public:
   /// corresponding \see commandFinished() call.
   virtual void commandPreparing(Command*) override;
 
+  /// Called by the build system to allow the delegate to skip a command without
+  /// implicitly skipping its dependents.
+  ///
+  /// WARNING: Clients need to take special care when using this. Skipping
+  /// commands without considering their dependencies or dependents can easily
+  /// produce an inconsistent build.
+  ///
+  /// This method is called before the command starts, when the system has
+  /// identified that it will eventually need to run (after all of its inputs
+  /// have been satisfied).
+  ///
+  /// The system guarantees that all such calls will be paired with a
+  /// corresponding \see commandFinished() call.
+  virtual bool shouldCommandStart(Command*) override;
+
   /// Called by the build system to report that a declared command has started.
   ///
   /// The system guarantees that all such calls will be paired with a

--- a/include/llbuild/BuildSystem/BuildValue.h
+++ b/include/llbuild/BuildSystem/BuildValue.h
@@ -66,6 +66,9 @@ class BuildValue {
     /// A value produced by a command which was cancelled.
     CancelledCommand,
 
+    /// A value produced by a command which was skipped.
+    SkippedCommand,
+
     /// Sentinel value representing the result of "building" a top-level target.
     Target,
   };
@@ -184,6 +187,9 @@ public:
   static BuildValue makeCancelledCommand() {
     return BuildValue(Kind::CancelledCommand);
   }
+  static BuildValue makeSkippedCommand() {
+    return BuildValue(Kind::SkippedCommand);
+  }
   static BuildValue makeTarget() {
     return BuildValue(Kind::Target);
   }
@@ -204,6 +210,7 @@ public:
   bool isFailedCommand() const { return kind == Kind::FailedCommand; }
   bool isPropagatedFailureCommand() const { return kind == Kind::PropagatedFailureCommand; }
   bool isCancelledCommand() const { return kind == Kind::CancelledCommand; }
+  bool isSkippedCommand() const { return kind == Kind::SkippedCommand; }
   bool isTarget() const { return kind == Kind::Target; }
 
   bool hasMultipleOutputs() const {

--- a/include/llbuild/BuildSystem/BuildValue.h
+++ b/include/llbuild/BuildSystem/BuildValue.h
@@ -50,7 +50,7 @@ class BuildValue {
     /// missing.
     MissingOutput,
 
-    /// A value for a produced output whose command failed.
+    /// A value for a produced output whose command failed or was cancelled.
     FailedInput,
 
     /// A value produced by a successful command.
@@ -58,9 +58,13 @@ class BuildValue {
 
     /// A value produced by a failing command.
     FailedCommand,
-      
-    /// A value produced by a command which was skipped.
-    SkippedCommand,
+
+    /// A value produced by a command which was skipped because one of its
+    /// dependencies failed.
+    PropagatedFailureCommand,
+
+    /// A value produced by a command which was cancelled.
+    CancelledCommand,
 
     /// Sentinel value representing the result of "building" a top-level target.
     Target,
@@ -174,8 +178,11 @@ public:
   static BuildValue makeFailedCommand() {
     return BuildValue(Kind::FailedCommand);
   }
-  static BuildValue makeSkippedCommand() {
-    return BuildValue(Kind::SkippedCommand);
+  static BuildValue makePropagatedFailureCommand() {
+    return BuildValue(Kind::PropagatedFailureCommand);
+  }
+  static BuildValue makeCancelledCommand() {
+    return BuildValue(Kind::CancelledCommand);
   }
   static BuildValue makeTarget() {
     return BuildValue(Kind::Target);
@@ -195,7 +202,8 @@ public:
   bool isFailedInput() const { return kind == Kind::FailedInput; }
   bool isSuccessfulCommand() const {return kind == Kind::SuccessfulCommand; }
   bool isFailedCommand() const { return kind == Kind::FailedCommand; }
-  bool isSkippedCommand() const { return kind == Kind::SkippedCommand; }
+  bool isPropagatedFailureCommand() const { return kind == Kind::PropagatedFailureCommand; }
+  bool isCancelledCommand() const { return kind == Kind::CancelledCommand; }
   bool isTarget() const { return kind == Kind::Target; }
 
   bool hasMultipleOutputs() const {

--- a/include/llbuild/BuildSystem/ExternalCommand.h
+++ b/include/llbuild/BuildSystem/ExternalCommand.h
@@ -15,7 +15,9 @@
 
 #include "llbuild/BuildSystem/BuildFile.h"
 #include "llbuild/BuildSystem/BuildSystem.h"
+#include "llbuild/BuildSystem/BuildValue.h"
 
+#include "llvm/ADT/Optional.h"
 #include "llvm/ADT/StringRef.h"
 
 #include <string>
@@ -65,8 +67,8 @@ class ExternalCommand : public Command {
   /// The previous build result command signature, if available.
   uint64_t priorResultCommandSignature;
   
-  /// If true, the command should be skipped (because of an error in an input).
-  bool shouldSkip = false;
+  /// If not None, the command should be skipped with the provided BuildValue.
+  llvm::Optional<BuildValue> skipValue;
 
   /// If true, the command had a missing input (this implies ShouldSkip is
   /// true).

--- a/lib/BuildSystem/BuildSystem.cpp
+++ b/lib/BuildSystem/BuildSystem.cpp
@@ -128,7 +128,7 @@ public:
 
 class BuildSystemImpl : public BuildSystemCommandInterface {
   /// The internal schema version.
-  static const uint32_t internalSchemaVersion = 1;
+  static const uint32_t internalSchemaVersion = 2;
   
   BuildSystem& buildSystem;
 
@@ -1468,8 +1468,9 @@ class MkdirCommand : public Command {
 
   virtual BuildValue getResultForOutput(Node* node,
                                         const BuildValue& value) override {
-    // If the value was a failed or skipped command, propagate the failure.
-    if (value.isFailedCommand() || value.isSkippedCommand())
+    // If the value was a failed command, propagate the failure.
+    if (value.isFailedCommand() || value.isPropagatedFailureCommand() ||
+        value.isCancelledCommand())
       return BuildValue::makeFailedInput();
 
     // Otherwise, we should have a successful command -- return the actual
@@ -1528,7 +1529,7 @@ class MkdirCommand : public Command {
                                core::Task* task) override {
     // If the build should cancel, do nothing.
     if (bsci.getDelegate().isCancelled()) {
-      bsci.taskIsComplete(task, BuildValue::makeSkippedCommand());
+      bsci.taskIsComplete(task, BuildValue::makeCancelledCommand());
       return;
     }
     
@@ -1685,8 +1686,9 @@ class SymlinkCommand : public Command {
 
   virtual BuildValue getResultForOutput(Node* node,
                                         const BuildValue& value) override {
-    // If the value was a failed or skipped command, propagate the failure.
-    if (value.isFailedCommand() || value.isSkippedCommand())
+    // If the value was a failed command, propagate the failure.
+    if (value.isFailedCommand() || value.isPropagatedFailureCommand() ||
+        value.isCancelledCommand())
       return BuildValue::makeFailedInput();
 
     // Otherwise, we should have a successful command -- return the actual
@@ -1732,7 +1734,7 @@ class SymlinkCommand : public Command {
                                core::Task* task) override {
     // If the build should cancel, do nothing.
     if (bsci.getDelegate().isCancelled()) {
-      bsci.taskIsComplete(task, BuildValue::makeSkippedCommand());
+      bsci.taskIsComplete(task, BuildValue::makeCancelledCommand());
       return;
     }
     

--- a/lib/BuildSystem/BuildSystemFrontend.cpp
+++ b/lib/BuildSystem/BuildSystemFrontend.cpp
@@ -359,6 +359,10 @@ void BuildSystemFrontendDelegate::commandStatusChanged(Command*,
 void BuildSystemFrontendDelegate::commandPreparing(Command*) {
 }
 
+bool BuildSystemFrontendDelegate::shouldCommandStart(Command*) {
+  return true;
+}
+
 void BuildSystemFrontendDelegate::commandStarted(Command* command) {
   // Don't report status if opted out by the command.
   if (!command->shouldShowStatus()) {

--- a/lib/BuildSystem/BuildValue.cpp
+++ b/lib/BuildSystem/BuildValue.cpp
@@ -30,7 +30,8 @@ StringRef BuildValue::stringForKind(BuildValue::Kind kind) {
     CASE(FailedInput);
     CASE(SuccessfulCommand);
     CASE(FailedCommand);
-    CASE(SkippedCommand);
+    CASE(PropagatedFailureCommand);
+    CASE(CancelledCommand);
     CASE(Target);
 #undef CASE
   }

--- a/lib/BuildSystem/BuildValue.cpp
+++ b/lib/BuildSystem/BuildValue.cpp
@@ -32,6 +32,7 @@ StringRef BuildValue::stringForKind(BuildValue::Kind kind) {
     CASE(FailedCommand);
     CASE(PropagatedFailureCommand);
     CASE(CancelledCommand);
+    CASE(SkippedCommand);
     CASE(Target);
 #undef CASE
   }

--- a/lib/BuildSystem/ExternalCommand.cpp
+++ b/lib/BuildSystem/ExternalCommand.cpp
@@ -117,8 +117,9 @@ bool ExternalCommand::configureAttribute(
 
 BuildValue ExternalCommand::
 getResultForOutput(Node* node, const BuildValue& value) {
-  // If the value was a failed or skipped command, propagate the failure.
-  if (value.isFailedCommand() || value.isSkippedCommand())
+  // If the value was a failed or cancelled command, propagate the failure.
+  if (value.isFailedCommand() || value.isPropagatedFailureCommand() ||
+      value.isCancelledCommand())
     return BuildValue::makeFailedInput();
 
   // Otherwise, we should have a successful command -- return the actual
@@ -198,7 +199,7 @@ void ExternalCommand::start(BuildSystemCommandInterface& bsci,
   bsci.getDelegate().commandPreparing(this);
     
   // Initialize the build state.
-  shouldSkip = false;
+  skipValue = llvm::None;
   hasMissingInput = false;
 
   // Request all of the inputs.
@@ -229,11 +230,11 @@ void ExternalCommand::provideValue(BuildSystemCommandInterface& bsci,
          value.isMissingOutput() || value.isFailedInput() ||
          value.isVirtualInput());
 
-  // Predicate for whether the input should cause the command to skip.
-  auto shouldSkipForInput = [&] {
+  // If the input should cause this command to skip, how should it skip?
+  auto skipValueForInput = [&]() -> llvm::Optional<BuildValue> {
     // If the value is an existing or virtual input, we are always good.
     if (value.isExistingInput() || value.isVirtualInput())
-      return false;
+      return llvm::None;
 
     // We explicitly allow running the command against a missing output, under
     // the expectation that responsibility for reporting this situation falls to
@@ -242,19 +243,26 @@ void ExternalCommand::provideValue(BuildSystemCommandInterface& bsci,
     // FIXME: Eventually, it might be nice to harden the format so that we know
     // when an output was actually required versus optional.
     if (value.isMissingOutput())
-      return false;
+      return llvm::None;
 
     // If the value is a missing input, but those are allowed, it is ok.
-    if (allowMissingInputs && value.isMissingInput())
-      return false;
+    if (value.isMissingInput()) {
+      if (allowMissingInputs)
+        return llvm::None;
+      else
+        return BuildValue::makeMissingInput();
+    }
 
-    // For anything else, this is an error and the command should be skipped.
-    return true;
+    // Propagate failure.
+    if (value.isFailedInput())
+      return BuildValue::makePropagatedFailureCommand();
+
+    llvm_unreachable("unexpected input");
   };
 
   // Check if we need to skip the command because of this input.
-  if (shouldSkipForInput()) {
-    shouldSkip = true;
+  skipValue = skipValueForInput();
+  if (skipValue.hasValue()) {
     if (value.isMissingInput()) {
       hasMissingInput = true;
 
@@ -309,12 +317,12 @@ void ExternalCommand::inputsAvailable(BuildSystemCommandInterface& bsci,
                                       core::Task* task) {
   // If the build should cancel, do nothing.
   if (bsci.getDelegate().isCancelled()) {
-    bsci.taskIsComplete(task, BuildValue::makeSkippedCommand());
+    bsci.taskIsComplete(task, BuildValue::makeCancelledCommand());
     return;
   }
     
   // If this command should be skipped, do nothing.
-  if (shouldSkip) {
+  if (skipValue.hasValue()) {
     // If this command had a failed input, treat it as having failed.
     if (hasMissingInput) {
       // FIXME: Design the logging and status output APIs.
@@ -326,7 +334,7 @@ void ExternalCommand::inputsAvailable(BuildSystemCommandInterface& bsci,
       bsci.getDelegate().hadCommandFailure();
     }
 
-    bsci.taskIsComplete(task, BuildValue::makeSkippedCommand());
+    bsci.taskIsComplete(task, skipValue.getValue());
     return;
   }
   assert(!hasMissingInput);

--- a/lib/BuildSystem/ExternalCommand.cpp
+++ b/lib/BuildSystem/ExternalCommand.cpp
@@ -121,6 +121,8 @@ getResultForOutput(Node* node, const BuildValue& value) {
   if (value.isFailedCommand() || value.isPropagatedFailureCommand() ||
       value.isCancelledCommand())
     return BuildValue::makeFailedInput();
+  if (value.isSkippedCommand())
+      return BuildValue::makeSkippedCommand();
 
   // Otherwise, we should have a successful command -- return the actual
   // result for the output.
@@ -228,7 +230,7 @@ void ExternalCommand::provideValue(BuildSystemCommandInterface& bsci,
   assert(!value.hasMultipleOutputs());
   assert(value.isExistingInput() || value.isMissingInput() ||
          value.isMissingOutput() || value.isFailedInput() ||
-         value.isVirtualInput());
+         value.isVirtualInput()  || value.isSkippedCommand());
 
   // If the input should cause this command to skip, how should it skip?
   auto skipValueForInput = [&]() -> llvm::Optional<BuildValue> {
@@ -256,6 +258,10 @@ void ExternalCommand::provideValue(BuildSystemCommandInterface& bsci,
     // Propagate failure.
     if (value.isFailedInput())
       return BuildValue::makePropagatedFailureCommand();
+
+    // A skipped dependency doesn't cause this command to skip.
+    if (value.isSkippedCommand())
+        return llvm::None;
 
     llvm_unreachable("unexpected input");
   };

--- a/llbuild.xcodeproj/project.pbxproj
+++ b/llbuild.xcodeproj/project.pbxproj
@@ -70,6 +70,10 @@
 		9DB047BC1DF9D4AA006CDF52 /* libllvmSupport.a in Frameworks */ = {isa = PBXBuildFile; fileRef = E1B838A21B52E7DE00DB876B /* libllvmSupport.a */; };
 		9DB047BD1DF9D4B0006CDF52 /* libllbuildBuildSystem.a in Frameworks */ = {isa = PBXBuildFile; fileRef = E1B839571B541BFD00DB876B /* libllbuildBuildSystem.a */; };
 		9DB047C01DF9F592006CDF52 /* LaneBasedExecutionQueueTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 9DB0478B1DF9D3E2006CDF52 /* LaneBasedExecutionQueueTest.cpp */; };
+		C5740D091E03523100567DD8 /* BuildSystemFrontendTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C5740D081E03523100567DD8 /* BuildSystemFrontendTest.cpp */; };
+		C5740D0A1E03527B00567DD8 /* libllbuildCore.a in Frameworks */ = {isa = PBXBuildFile; fileRef = E1A2243E19F997150059043E /* libllbuildCore.a */; };
+		C5740D0B1E03528600567DD8 /* libllbuildBasic.a in Frameworks */ = {isa = PBXBuildFile; fileRef = E1A2242519F991B40059043E /* libllbuildBasic.a */; };
+		C5740D0C1E03529300567DD8 /* libsqlite3.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = E1E221081A00B82100957481 /* libsqlite3.dylib */; };
 		E104FAF71B655A97005C68A0 /* BuildSystemPerfTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = E104FAF61B655A97005C68A0 /* BuildSystemPerfTests.mm */; };
 		E104FAFA1B655BBA005C68A0 /* libllbuildBuildSystem.a in Frameworks */ = {isa = PBXBuildFile; fileRef = E1B839571B541BFD00DB876B /* libllbuildBuildSystem.a */; };
 		E104FAFB1B655C33005C68A0 /* libllvmSupport.a in Frameworks */ = {isa = PBXBuildFile; fileRef = E1B838A21B52E7DE00DB876B /* libllvmSupport.a */; };
@@ -688,6 +692,8 @@
 		54E187B81CD296EA00F7EC89 /* SwiftTools.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SwiftTools.h; sourceTree = "<group>"; };
 		9DB0478B1DF9D3E2006CDF52 /* LaneBasedExecutionQueueTest.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = LaneBasedExecutionQueueTest.cpp; sourceTree = "<group>"; };
 		9DB047A81DF9D43D006CDF52 /* BuildSystemTests */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = BuildSystemTests; sourceTree = BUILT_PRODUCTS_DIR; };
+		C5740D081E03523100567DD8 /* BuildSystemFrontendTest.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = BuildSystemFrontendTest.cpp; sourceTree = "<group>"; };
+		C5740D0D1E0352D800567DD8 /* CMakeLists.txt */ = {isa = PBXFileReference; lastKnownFileType = text; path = CMakeLists.txt; sourceTree = "<group>"; };
 		E104FAF61B655A97005C68A0 /* BuildSystemPerfTests.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = BuildSystemPerfTests.mm; sourceTree = "<group>"; };
 		E104FAFF1B6568E0005C68A0 /* BuildSystem.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = BuildSystem.cpp; sourceTree = "<group>"; };
 		E1066C071BC5ACAB00B892CE /* LaneBasedExecutionQueue.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = LaneBasedExecutionQueue.cpp; sourceTree = "<group>"; };
@@ -976,6 +982,9 @@
 			buildActionMask = 2147483647;
 			files = (
 				9D2107C61DFADDFA00BE26FF /* libcurses.dylib in Frameworks */,
+				C5740D0C1E03529300567DD8 /* libsqlite3.dylib in Frameworks */,
+				C5740D0B1E03528600567DD8 /* libllbuildBasic.a in Frameworks */,
+				C5740D0A1E03527B00567DD8 /* libllbuildCore.a in Frameworks */,
 				9DB047BD1DF9D4B0006CDF52 /* libllbuildBuildSystem.a in Frameworks */,
 				9DB047BC1DF9D4AA006CDF52 /* libllvmSupport.a in Frameworks */,
 				9DB047BA1DF9D4A4006CDF52 /* libgtest_main.a in Frameworks */,
@@ -1159,6 +1168,8 @@
 		9DB0478A1DF9D39E006CDF52 /* BuildSystem */ = {
 			isa = PBXGroup;
 			children = (
+				C5740D0D1E0352D800567DD8 /* CMakeLists.txt */,
+				C5740D081E03523100567DD8 /* BuildSystemFrontendTest.cpp */,
 				9DB0478B1DF9D3E2006CDF52 /* LaneBasedExecutionQueueTest.cpp */,
 			);
 			path = BuildSystem;
@@ -2583,6 +2594,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				9DB047C01DF9F592006CDF52 /* LaneBasedExecutionQueueTest.cpp in Sources */,
+				C5740D091E03523100567DD8 /* BuildSystemFrontendTest.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/products/libllbuild/BuildSystem-C-API.cpp
+++ b/products/libllbuild/BuildSystem-C-API.cpp
@@ -187,6 +187,15 @@ public:
     }
   }
 
+  virtual bool shouldCommandStart(Command * command) override {
+    if (cAPIDelegate.should_command_start) {
+      return cAPIDelegate.should_command_start(
+          cAPIDelegate.context, (llb_buildsystem_command_t*) command);
+    } else {
+      return true;
+    }
+  }
+
   virtual void commandStarted(Command* command) override {
     if (cAPIDelegate.command_started) {
       cAPIDelegate.command_started(

--- a/products/libllbuild/public-api/llbuild/buildsystem.h
+++ b/products/libllbuild/public-api/llbuild/buildsystem.h
@@ -227,6 +227,21 @@ typedef struct llb_buildsystem_delegate_t_ {
   /// with exactly one \see command_finished() call.
   void (*command_preparing)(void* context, llb_buildsystem_command_t* command);
 
+  /// Called by the build system to allow the delegate to skip a command without
+  /// implicitly skipping its dependents.
+  ///
+  /// WARNING: Clients need to take special care when using this. Skipping
+  /// commands without considering their dependencies or dependents can easily
+  /// produce an inconsistent build.
+  ///
+  /// This method is called before the command starts, when the system has
+  /// identified that it will eventually need to run (after all of its inputs
+  /// have been satisfied).
+  ///
+  /// The system guarantees that all such calls will be paired with a
+  /// corresponding \see commandFinished() call.
+  bool (*should_command_start)(void* context, llb_buildsystem_command_t* command);
+
   /// Called when a command has been started.
   ///
   /// The system guarantees that any commandStart() call will be paired with

--- a/unittests/BuildSystem/BuildSystemFrontendTest.cpp
+++ b/unittests/BuildSystem/BuildSystemFrontendTest.cpp
@@ -1,0 +1,451 @@
+//===- unittests/BuildSystem/BuildSystemFrontendTest.cpp ------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#include "llbuild/Basic/FileSystem.h"
+#include "llbuild/BuildSystem/BuildSystemFrontend.h"
+#include "llbuild/BuildSystem/BuildFile.h"
+
+#include "llvm/Support/ErrorHandling.h"
+#include "llvm/Support/FileSystem.h"
+#include "llvm/Support/SourceMgr.h"
+#include "llvm/Support/raw_ostream.h"
+#include "llvm/Support/Path.h"
+#include "llvm/ADT/StringRef.h"
+
+#include "gtest/gtest.h"
+
+#include <unordered_set>
+
+using namespace llbuild;
+using namespace llbuild::basic;
+using namespace llbuild::buildsystem;
+using namespace llvm;
+
+
+// TODO Move this into some kind of libtestSupport?
+#define ASSERT_NO_ERROR(code)                       \
+  do {                                              \
+    std::error_code __ec;                           \
+    ASSERT_FALSE(__ec = (code)) << __ec.message();  \
+  } while (0)
+
+
+// TODO Move this into some kind of libtestSupport?
+// Cribbed from llvm, where it's been since removed.
+namespace {
+
+using namespace std;
+using namespace llvm::sys::fs;
+
+error_code _remove_all_r(StringRef path, file_type ft, uint32_t &count) {
+  if (ft == file_type::directory_file) {
+    error_code ec;
+    directory_iterator i(path, ec);
+    if (ec)
+      return ec;
+
+    for (directory_iterator e; i != e; i.increment(ec)) {
+      if (ec)
+        return ec;
+
+      file_status st;
+
+      if (error_code ec = i->status(st))
+        return ec;
+
+      if (error_code ec = _remove_all_r(i->path(), st.type(), count))
+        return ec;
+    }
+
+    if (error_code ec = remove(path, false))
+      return ec;
+
+    ++count; // Include the directory itself in the items removed.
+  } else {
+    if (error_code ec = remove(path, false))
+      return ec;
+
+    ++count;
+  }
+
+  return error_code();
+}
+
+error_code remove_all(const Twine &path, uint32_t &num_removed) {
+  SmallString<128> path_storage;
+  StringRef p = path.toStringRef(path_storage);
+
+  file_status fs;
+  if (error_code ec = status(path, fs))
+    return ec;
+  num_removed = 0;
+  return _remove_all_r(p, fs.type(), num_removed);
+}
+
+error_code remove_all(const Twine &path) {
+  uint32_t num_removed = 0;
+  return remove_all(path, num_removed);
+}
+
+}
+
+namespace {
+
+// TODO Move this into some kind of libtestSupport?
+/// Creates a temporary directory in its constructor and removes it in its
+/// destructor. Makes it available via str() and c_str().
+class TmpDir {
+private:
+  TmpDir(const TmpDir&) = delete;
+  TmpDir& operator=(const TmpDir&) = delete;
+
+  SmallString<256> tempDir;
+
+public:
+  TmpDir(StringRef namePrefix = "") {
+    SmallString<256> tempDirPrefix;
+    llvm::sys::path::system_temp_directory(true, tempDirPrefix);
+    llvm::sys::path::append(tempDirPrefix, namePrefix);
+
+    std::error_code ec = llvm::sys::fs::createUniqueDirectory
+      (Twine(tempDirPrefix),
+       tempDir);
+    assert(!ec);
+    (void)ec;
+  }
+
+  ~TmpDir() {
+    std::error_code ec = remove_all(Twine(tempDir));
+    assert(!ec);
+    (void)ec;
+  }
+
+  const char *c_str() { return tempDir.c_str(); }
+  std::string str() const { return tempDir.str(); }
+};
+
+
+/// Records delegate callbacks and makes them available via ``getTrace()``
+/// and ``checkTrace()``.
+///
+/// Allows for command skipping via ``commandsToSkip``.
+class TestBuildSystemFrontendDelegate : public BuildSystemFrontendDelegate {
+  using super = BuildSystemFrontendDelegate;
+  FileSystem& fs;
+  std::string traceData;
+  raw_string_ostream traceStream;
+
+public:
+  TestBuildSystemFrontendDelegate(SourceMgr& sourceMgr,
+                                  const BuildSystemInvocation& invocation,
+                                  FileSystem& fs):
+      BuildSystemFrontendDelegate(sourceMgr, invocation, "client", 0),
+      fs(fs),
+      traceStream(traceData)
+  {
+  }
+
+  std::unordered_set<std::string> commandsToSkip;
+
+  void clearTrace() {
+    traceStream.flush();
+    traceData.clear();
+  }
+
+  const std::string& getTrace() {
+    return traceStream.str();
+  }
+
+  bool checkTrace(StringRef expected) {
+    expected = expected.ltrim();
+
+    bool result = expected == getTrace();
+    if (!result) {
+      errs() << "error: failed to match expected trace.\n\n"
+             << "Actual:\n" << getTrace() << "\n"
+             << "Expected:\n" << expected << "\n";
+
+      TmpDir tmpDir;
+
+      std::string outputActual = tmpDir.str() + "/actual.log";
+      {
+        std::error_code ec;
+        llvm::raw_fd_ostream os(outputActual, ec, llvm::sys::fs::F_Text);
+        assert(!ec);
+        os << getTrace();
+        os.close();
+        assert(!os.has_error());
+      }
+
+      std::string outputExpected = tmpDir.str() + "/expected.log";
+      {
+        std::error_code ec;
+        llvm::raw_fd_ostream os(outputExpected, ec, llvm::sys::fs::F_Text);
+        assert(!ec);
+        os << expected;
+        os.close();
+        assert(!os.has_error());
+      }
+
+      errs() << "Diff:\n";
+      system(("diff '" + outputActual + "' '"+ outputExpected +"'").c_str());
+    }
+
+    return result;
+  }
+
+  virtual void hadCommandFailure() override {
+    traceStream << __FUNCTION__ << "\n";
+    super::hadCommandFailure();
+  }
+
+  virtual void commandPreparing(Command* command) override {
+    traceStream << __FUNCTION__ << ": " << command->getName() << "\n";
+    super::commandPreparing(command);
+  }
+
+  virtual bool shouldCommandStart(Command* command) override {
+    traceStream << __FUNCTION__ << ": " << command->getName() << "\n";
+
+    if (commandsToSkip.find(command->getName()) != commandsToSkip.end()) {
+      return false;
+    }
+
+    return super::shouldCommandStart(command);
+  }
+
+  virtual void commandStarted(Command* command) override {
+    traceStream << __FUNCTION__ << ": " << command->getName() << "\n";
+    super::commandStarted(command);
+  }
+
+  virtual void commandFinished(Command* command) override {
+    traceStream << __FUNCTION__ << ": " << command->getName() << "\n";
+    super::commandFinished(command);
+  }
+
+  virtual void commandProcessStarted(Command* command, ProcessHandle handle) override {
+    traceStream << __FUNCTION__ << ": " << command->getName() << "\n";
+    super::commandProcessStarted(command, handle);
+  }
+
+  virtual void commandProcessHadError(Command* command, ProcessHandle handle,
+                                      const Twine& message) override {
+    traceStream << __FUNCTION__ << ": " << command->getName() << ": " << message << "\n";
+    super::commandProcessHadError(command, handle, message);
+  }
+
+  virtual void commandProcessFinished(Command* command, ProcessHandle handle,
+                                      int exitStatus) override {
+    traceStream << __FUNCTION__ << ": " << command->getName() << ": " << exitStatus << "\n";
+    super::commandProcessFinished(command, handle, exitStatus);
+  }
+
+  virtual FileSystem& getFileSystem() override {
+    return fs;
+  }
+
+  virtual std::unique_ptr<Tool> lookupTool(StringRef name) override {
+    return nullptr;
+  }
+};
+
+
+/// Sets up state and provides utils for build system frontend tests.
+class BuildSystemFrontendTest : public ::testing::Test {
+protected:
+  TmpDir tempDir{"FrontendTest"};
+  std::unique_ptr<FileSystem> fs = createLocalFileSystem();
+  SourceMgr sourceMgr;
+  BuildSystemInvocation invocation;
+
+  virtual void SetUp() override {
+    invocation.chdirPath = tempDir.str();
+    invocation.traceFilePath = tempDir.str() + "/trace.log";
+  }
+
+  void writeBuildFile(StringRef s) {
+    std::error_code ec;
+    raw_fd_ostream os(std::string(tempDir.str()) + "/build.llbuild", ec,
+                      llvm::sys::fs::F_Text);
+    ASSERT_NO_ERROR(ec);
+
+    os << s;
+  }
+};
+
+
+// We have commands { 3 -> 2 -> 1 }. We'd like to skip 2, but we still
+// want 1 and 3 to run.
+TEST_F(BuildSystemFrontendTest, commandSkipping) {
+  writeBuildFile(R"END(
+client:
+    name: client
+
+targets:
+    "": ["3"]
+
+commands:
+    1:
+        tool: shell
+        outputs: ["1"]
+        args: touch 1
+
+    2:
+        tool: shell
+        inputs: ["1"]
+        outputs: ["2"]
+        args: touch 2
+
+    3:
+        tool: shell
+        inputs: ["2"]
+        outputs: ["3"]
+        args: touch 3
+)END");
+
+  {
+    TestBuildSystemFrontendDelegate delegate(sourceMgr, invocation, *fs);
+    delegate.commandsToSkip.insert("2");
+
+    BuildSystemFrontend frontend(delegate, invocation);
+    ASSERT_TRUE(frontend.build(""));
+
+    ASSERT_TRUE(delegate.checkTrace(R"END(
+commandPreparing: 3
+commandPreparing: 2
+commandPreparing: 1
+shouldCommandStart: 1
+commandStarted: 1
+commandProcessStarted: 1
+commandProcessFinished: 1: 0
+commandFinished: 1
+shouldCommandStart: 2
+commandFinished: 2
+shouldCommandStart: 3
+commandStarted: 3
+commandProcessStarted: 3
+commandProcessFinished: 3: 0
+commandFinished: 3
+)END"));
+
+    ASSERT_FALSE(fs->getFileInfo(tempDir.str() + "/1").isMissing());
+    ASSERT_TRUE(fs->getFileInfo(tempDir.str() + "/2").isMissing());
+    ASSERT_FALSE(fs->getFileInfo(tempDir.str() + "/3").isMissing());
+  }
+
+  // If we rebuild incrementally without skipping, we expect to run 2 and
+  // re-run 3. 1 doesn't have to run at all, so we don't expect to get asked
+  // if it should start.
+  {
+    TestBuildSystemFrontendDelegate delegate(sourceMgr, invocation, *fs);
+
+    BuildSystemFrontend frontend(delegate, invocation);
+    ASSERT_TRUE(frontend.build(""));
+
+    ASSERT_TRUE(delegate.checkTrace(R"END(
+commandPreparing: 2
+shouldCommandStart: 2
+commandStarted: 2
+commandProcessStarted: 2
+commandProcessFinished: 2: 0
+commandFinished: 2
+commandPreparing: 3
+shouldCommandStart: 3
+commandStarted: 3
+commandProcessStarted: 3
+commandProcessFinished: 3: 0
+commandFinished: 3
+)END"));
+
+    ASSERT_FALSE(fs->getFileInfo(tempDir.str() + "/2").isMissing());
+  }
+
+}
+
+// We have commands { 2 -> 1 }, where two requires 1's output. We'd like to
+// skip 1, we expect 2 to run and fail because 1 did not produce output.
+TEST_F(BuildSystemFrontendTest, commandSkippingFailure) {
+  writeBuildFile(R"END(
+client:
+    name: client
+
+targets:
+    "": ["2"]
+
+commands:
+    1:
+        tool: shell
+        outputs: ["1"]
+        args: touch 1
+
+    2:
+        tool: shell
+        inputs: ["1"]
+        outputs: ["2"]
+        args: cp 1 2
+)END");
+
+  {
+    TestBuildSystemFrontendDelegate delegate(sourceMgr, invocation, *fs);
+    delegate.commandsToSkip.insert("1");
+
+    BuildSystemFrontend frontend(delegate, invocation);
+    ASSERT_FALSE(frontend.build(""));
+    ASSERT_EQ(1u, delegate.getNumFailedCommands());
+
+    ASSERT_TRUE(delegate.checkTrace(R"END(
+commandPreparing: 2
+commandPreparing: 1
+shouldCommandStart: 1
+commandFinished: 1
+shouldCommandStart: 2
+commandStarted: 2
+commandProcessStarted: 2
+commandProcessFinished: 2: 256
+commandFinished: 2
+hadCommandFailure
+)END"));
+
+    ASSERT_TRUE(fs->getFileInfo(tempDir.str() + "/1").isMissing());
+    ASSERT_TRUE(fs->getFileInfo(tempDir.str() + "/2").isMissing());
+  }
+
+  // If we rebuild incrementally without skipping, we expect to run 1 and 2.
+  {
+    TestBuildSystemFrontendDelegate delegate(sourceMgr, invocation, *fs);
+
+    BuildSystemFrontend frontend(delegate, invocation);
+    ASSERT_TRUE(frontend.build(""));
+
+    ASSERT_TRUE(delegate.checkTrace(R"END(
+commandPreparing: 2
+commandPreparing: 1
+shouldCommandStart: 1
+commandStarted: 1
+commandProcessStarted: 1
+commandProcessFinished: 1: 0
+commandFinished: 1
+shouldCommandStart: 2
+commandStarted: 2
+commandProcessStarted: 2
+commandProcessFinished: 2: 0
+commandFinished: 2
+)END"));
+
+    ASSERT_FALSE(fs->getFileInfo(tempDir.str() + "/1").isMissing());
+    ASSERT_FALSE(fs->getFileInfo(tempDir.str() + "/2").isMissing());
+  }
+
+}
+
+}

--- a/unittests/BuildSystem/CMakeLists.txt
+++ b/unittests/BuildSystem/CMakeLists.txt
@@ -1,5 +1,13 @@
 add_llbuild_unittest(BuildSystemTests
   LaneBasedExecutionQueueTest
+  BuildSystemFrontendTest.cpp
   )
 
-target_link_libraries(BuildSystemTests curses llbuildBuildSystem llvmSupport)
+target_link_libraries(BuildSystemTests
+  llbuildBuildSystem
+  llbuildCore
+  llbuildBasic
+  llvmSupport
+  sqlite3
+  curses
+  )


### PR DESCRIPTION
This allows a build system delegate to run a subset of the build by explicitly skipping commands yet allowing dependent commands to run.

As a prerequisite, this includes a separate commit to disambiguate BuildValue::SkippedCommand into FailedDependencyCommand and CancelledCommand.
