### PR TITLE
[libllbuild] Allow clients to supply custom command signatures.

### DIFF
--- a/examples/c-api/buildsystem/main.c
+++ b/examples/c-api/buildsystem/main.c
@@ -52,6 +52,7 @@ static llb_buildsystem_command_t*
 fancy_tool_create_command(void *context, const llb_data_t* name) {
   llb_buildsystem_external_command_delegate_t delegate;
   delegate.context = NULL;
+  delegate.get_signature = NULL;
   delegate.execute_command = fancy_command_execute_command;
   return llb_buildsystem_external_command_create(name, delegate);
 }

--- a/products/libllbuild/public-api/llbuild/buildsystem.h
+++ b/products/libllbuild/public-api/llbuild/buildsystem.h
@@ -371,6 +371,19 @@ typedef struct llb_buildsystem_external_command_delegate_t_ {
   /// User context pointer.
   void* context;
 
+  /// Called to get a signature which represents the internal state of the
+  /// command which is not tracked by any other attribute visible to the build
+  /// system (for example, a declared input or output). This signature is
+  /// compared with previous executions of the command when determining whether
+  /// or not it needs to rerun.
+  ///
+  /// The contents *MUST* be returned in a new buffer allocated with \see
+  /// malloc().
+  //
+  // FIXME: We need to use a better data type than a uint64_t here.
+  void (*get_signature)(void* context, llb_buildsystem_command_t* command,
+                        llb_data_t* data_out);
+
   /// Called by the build system's execution queue after the command's inputs
   /// are available and the execution queue is ready to schedule the command.
   ///


### PR DESCRIPTION
 - This is used by C API clients supplying custom tools to track when those
   tools (which may embed their own state) may need to be rerun, even if other
   aspects of the command haven't changed.