### PR TITLE
Disable signal handling tests on Linux

### DIFF
--- a/tests/BuildSystem/Build/sigkill-escalation.llbuild
+++ b/tests/BuildSystem/Build/sigkill-escalation.llbuild
@@ -13,6 +13,9 @@
 #
 # CHECK: SIGNAL
 # CHECK: cancelling build.
+#
+# FIXME: Disabled on Linux for the time being, it doesn't always pass. See https://bugs.swift.org/browse/SR-3427
+# REQUIRES: platform=Darwin
 
 client:
   name: basic

--- a/tests/BuildSystem/Build/signal-handling.llbuild
+++ b/tests/BuildSystem/Build/signal-handling.llbuild
@@ -12,6 +12,9 @@
 #
 # CHECK: SIGNAL
 # CHECK: cancelling build.
+#
+# FIXME: Disabled on Linux for the time being, it doesn't always pass. See https://bugs.swift.org/browse/SR-3427
+# REQUIRES: platform=Darwin
 
 client:
   name: basic

--- a/tests/Ninja/Build/signal-handling.ninja
+++ b/tests/Ninja/Build/signal-handling.ninja
@@ -12,6 +12,9 @@
 #
 # CHECK: [1/{{.*}}] SIGNAL PARENT LLBUILD PROCESS
 # CHECK: cancelling build.
+#
+# FIXME: Disabled on Linux for the time being, it doesn't always pass. See https://bugs.swift.org/browse/SR-3427
+# REQUIRES: platform=Darwin
 
 rule CAT
   command = cat ${in} > ${out}


### PR DESCRIPTION
Unfortunately, we are still seeing some occassional flakiness of these on CI, so we will disable them for now.