### PR TITLE
Fix races in `LaneBasedExecutionQueueTest`

### DIFF
--- a/llbuild.xcodeproj/project.pbxproj
+++ b/llbuild.xcodeproj/project.pbxproj
@@ -64,6 +64,7 @@
 /* End PBXAggregateTarget section */
 
 /* Begin PBXBuildFile section */
+		9D0A6D811E1FFEA800BE636F /* TempDir.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 9D0A6D7F1E1FFEA800BE636F /* TempDir.cpp */; };
 		9D2107C61DFADDFA00BE26FF /* libcurses.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = E15B6EC61B546A2C00643066 /* libcurses.dylib */; };
 		9DB047BA1DF9D4A4006CDF52 /* libgtest_main.a in Frameworks */ = {isa = PBXBuildFile; fileRef = E1A224E619F99C580059043E /* libgtest_main.a */; };
 		9DB047BB1DF9D4A4006CDF52 /* libgtest.a in Frameworks */ = {isa = PBXBuildFile; fileRef = E1A224DD19F99B0E0059043E /* libgtest.a */; };
@@ -690,6 +691,8 @@
 		54E187B61CD296EA00F7EC89 /* BuildNode.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BuildNode.h; sourceTree = "<group>"; };
 		54E187B71CD296EA00F7EC89 /* ExternalCommand.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ExternalCommand.h; sourceTree = "<group>"; };
 		54E187B81CD296EA00F7EC89 /* SwiftTools.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SwiftTools.h; sourceTree = "<group>"; };
+		9D0A6D7F1E1FFEA800BE636F /* TempDir.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = TempDir.cpp; sourceTree = "<group>"; };
+		9D0A6D801E1FFEA800BE636F /* TempDir.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = TempDir.hpp; sourceTree = "<group>"; };
 		9DB0478B1DF9D3E2006CDF52 /* LaneBasedExecutionQueueTest.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = LaneBasedExecutionQueueTest.cpp; sourceTree = "<group>"; };
 		9DB047A81DF9D43D006CDF52 /* BuildSystemTests */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = BuildSystemTests; sourceTree = BUILT_PRODUCTS_DIR; };
 		C5740D081E03523100567DD8 /* BuildSystemFrontendTest.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = BuildSystemFrontendTest.cpp; sourceTree = "<group>"; };
@@ -1171,6 +1174,8 @@
 				C5740D0D1E0352D800567DD8 /* CMakeLists.txt */,
 				C5740D081E03523100567DD8 /* BuildSystemFrontendTest.cpp */,
 				9DB0478B1DF9D3E2006CDF52 /* LaneBasedExecutionQueueTest.cpp */,
+				9D0A6D7F1E1FFEA800BE636F /* TempDir.cpp */,
+				9D0A6D801E1FFEA800BE636F /* TempDir.hpp */,
 			);
 			path = BuildSystem;
 			sourceTree = "<group>";
@@ -2595,6 +2600,7 @@
 			files = (
 				9DB047C01DF9F592006CDF52 /* LaneBasedExecutionQueueTest.cpp in Sources */,
 				C5740D091E03523100567DD8 /* BuildSystemFrontendTest.cpp in Sources */,
+				9D0A6D811E1FFEA800BE636F /* TempDir.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/unittests/BuildSystem/CMakeLists.txt
+++ b/unittests/BuildSystem/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_llbuild_unittest(BuildSystemTests
   LaneBasedExecutionQueueTest
   BuildSystemFrontendTest.cpp
+  TempDir.cpp
   )
 
 target_link_libraries(BuildSystemTests

--- a/unittests/BuildSystem/TempDir.cpp
+++ b/unittests/BuildSystem/TempDir.cpp
@@ -1,0 +1,97 @@
+//===- unittests/BuildSystem/TempDir.cpp --------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#include "TempDir.hpp"
+
+#include "llvm/Support/FileSystem.h"
+#include "llvm/Support/Path.h"
+#include "llvm/Support/SourceMgr.h"
+
+// TODO Move this into some kind of libtestSupport?
+// Cribbed from llvm, where it's been since removed.
+namespace {
+
+    using namespace std;
+    using namespace llvm;
+    using namespace llvm::sys::fs;
+
+    error_code _remove_all_r(StringRef path, file_type ft, uint32_t &count) {
+        if (ft == file_type::directory_file) {
+            error_code ec;
+            directory_iterator i(path, ec);
+            if (ec)
+                return ec;
+
+            for (directory_iterator e; i != e; i.increment(ec)) {
+                if (ec)
+                    return ec;
+
+                file_status st;
+
+                if (error_code ec = i->status(st))
+                    return ec;
+
+                if (error_code ec = _remove_all_r(i->path(), st.type(), count))
+                    return ec;
+            }
+
+            if (error_code ec = remove(path, false))
+                return ec;
+
+            ++count; // Include the directory itself in the items removed.
+        } else {
+            if (error_code ec = remove(path, false))
+                return ec;
+
+            ++count;
+        }
+
+        return error_code();
+    }
+
+    error_code remove_all(const Twine &path, uint32_t &num_removed) {
+        SmallString<128> path_storage;
+        StringRef p = path.toStringRef(path_storage);
+        
+        file_status fs;
+        if (error_code ec = status(path, fs))
+            return ec;
+        num_removed = 0;
+        return _remove_all_r(p, fs.type(), num_removed);
+    }
+    
+    error_code remove_all(const Twine &path) {
+        uint32_t num_removed = 0;
+        return remove_all(path, num_removed);
+    }
+    
+}
+
+llbuild::TmpDir::TmpDir(llvm::StringRef namePrefix) {
+    llvm::SmallString<256> tempDirPrefix;
+    llvm::sys::path::system_temp_directory(true, tempDirPrefix);
+    llvm::sys::path::append(tempDirPrefix, namePrefix);
+
+    std::error_code ec = llvm::sys::fs::createUniqueDirectory
+    (llvm::Twine(tempDirPrefix), tempDir);
+    assert(!ec);
+    (void)ec;
+}
+
+llbuild::TmpDir::~TmpDir() {
+    std::error_code ec = remove_all(llvm::Twine(tempDir));
+    assert(!ec);
+    (void)ec;
+}
+
+const char *llbuild::TmpDir::c_str() { return tempDir.c_str(); }
+std::string llbuild::TmpDir::str() const { return tempDir.str(); }

--- a/unittests/BuildSystem/TempDir.hpp
+++ b/unittests/BuildSystem/TempDir.hpp
@@ -1,0 +1,41 @@
+//===- unittests/BuildSystem/TempDir.hpp --------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLBUILD_TESTS_TEMPDIR
+#define LLBUILD_TESTS_TEMPDIR
+
+#include "llvm/ADT/SmallString.h"
+#include "llvm/ADT/StringRef.h"
+
+namespace llbuild {
+
+// TODO Move this into some kind of libtestSupport?
+/// Creates a temporary directory in its constructor and removes it in its
+/// destructor. Makes it available via str() and c_str().
+class TmpDir {
+private:
+    TmpDir(const TmpDir&) = delete;
+    TmpDir& operator=(const TmpDir&) = delete;
+
+    llvm::SmallString<256> tempDir;
+
+public:
+    TmpDir(llvm::StringRef namePrefix = "");
+    ~TmpDir();
+
+    const char *c_str();
+    std::string str() const;
+};
+
+}
+
+#endif /* LLBUILD_TESTS_TEMPDIR */


### PR DESCRIPTION
- Fix race between signaling the sigkill-escalation thread and actually starting it
- Fix `LaneBasedExecutionQueueTest` so that we wait until the `yes` process has started before trying to kill it