### PR TITLE
Update import-llvm to support Windows

### DIFF
--- a/lib/llvm/import-llvm
+++ b/lib/llvm/import-llvm
@@ -36,7 +36,8 @@ Support_imports = [
     'ManagedStatic', 'MathExtras', 'Mutex', 'MutexGuard', 'Memory',
     'MemoryBuffer', 'PointerLikeTypeTraits', 'Recycler', 'SwapByteOrder',
     'TimeValue', 'Threading', 'Unicode', 'UniqueLock', 'Unix', 'WindowsError',
-    'Valgrind', 'circular_raw_ostream', 'raw_ostream', 'type_traits']
+    'Valgrind', 'circular_raw_ostream', 'raw_ostream', 'type_traits', 
+    'WindowsSupport']
 
 # Stuff we don't want, but have to pull in.
 Support_imports += [
@@ -110,6 +111,8 @@ def main():
             import_source('Support', name+'.cpp')
             import_source('Support', os.path.join('Unix', name+'.h'))
             import_source('Support', os.path.join('Unix', name+'.inc'))
+            import_source('Support', os.path.join('Windows', name+'.h'))
+            import_source('Support', os.path.join('Windows', name+'.inc'))
         
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
Windows requires certain files from LLVM that are unimported. Add them.

This meant updating the import-llvm python script to support the new inclusions and changes in the LLVM project layout.

I'm gonna start submitting some PRs soon that improve Windows support - e.g. fix uses of POSIX apis, fix the build system to support MSVC, and general porting goodness.

@ddunbar
