### PR TITLE
Add support for passing sqlite3 library and include directory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -119,6 +119,14 @@ if(${CMAKE_SYSTEM_NAME} MATCHES "(FreeBSD|DragonFly)")
   link_directories("/usr/local/lib")
 endif(${CMAKE_SYSTEM_NAME} MATCHES "(FreeBSD|DragonFly)")
 
+if(NOT ${LLBUILD_PATH_TO_SQLITE_SOURCE} STREQUAL "")
+  include_directories("${LLBUILD_PATH_TO_SQLITE_SOURCE}")
+endif()
+
+if(NOT "${LLBUILD_PATH_TO_SQLITE_BUILD}" STREQUAL "")
+  link_directories("${LLBUILD_PATH_TO_SQLITE_BUILD}")
+endif()
+
 # Xcode: Use libc++ and c++14 using proper build settings.
 if (XCODE)
   # Force usage of Clang.


### PR DESCRIPTION
This lets us support platforms that don't natively have sqlite3.lib, such as Windows. The naming convention and structure matches the way LLVM /LLDB/Clang allows you to configure external dependencies
```
mkdir "%swift_source_dir%/build-msvc/Ninja-DebugAssert/llbuild-windows-x86_64/vs"
pushd "%swift_source_dir%/build-msvc/Ninja-DebugAssert/llbuild-windows-x86_64/vs"
cmake -G "Visual Studio 14 2015"^
 -DCMAKE_GENERATOR_PLATFORM="x64"^
 -DCMAKE_BUILD_TYPE=Debug^
 -DLIT_EXECUTABLE="%swift_source_dir%/build-msvc/llvm-windows-x86_64/bin/llvm-lit.py"^
 -DFILECHECK_EXECUTABLE="%swift_source_dir%/build-msvc/llvm-windows-x86_64/bin/FileCheck.exe"^
 -DLLDB_PATH_TO_SQLITE_SOURCE="%swift_source_dir%/sql"^
 -DLLDB_PATH_TO_SQLITE_BUILD="%swift_source_dir%/sqlite3-windows-x86_64"^
 "%swift_source_dir%/llbuild"
popd
cmake --build "%swift_source_dir%/build-msvc/Ninja-DebugAssert/llbuild-windows-amd64/vs"
```