### PR TITLE
Port lib/Core to Windows/MSVC

### DIFF
--- a/lib/Core/BuildEngine.cpp
+++ b/lib/Core/BuildEngine.cpp
@@ -972,6 +972,8 @@ private:
     
     // Find the cycle by searching from the entry node.
     struct WorkItem {
+      WorkItem(Rule * node) { this->node = node; }
+
       Rule* node;
       unsigned predecessorIndex = 0;
     };


### PR DESCRIPTION
> 1>C:\Users\hbellamy\Documents\GitHub\my-swift\llbuild\lib\Core\BuildEngine.cpp(974): error C2440: 'initializing': cannot convert from 'initializer list' to '`anonymous-namespace'::BuildEngineImpl::reportCycle::WorkItem'
> 1>  C:\Users\hbellamy\Documents\GitHub\my-swift\llbuild\lib\Core\BuildEngine.cpp(974): note: No constructor could take the source type, or constructor overload resolution was ambiguous
> 1>C:\Users\hbellamy\Documents\GitHub\my-swift\llbuild\lib\Core\BuildEngine.cpp(995): error C2440: 'initializing': cannot convert from 'initializer list' to '`anonymous-namespace'::BuildEngineImpl::reportCycle::WorkItem'
> 1>  C:\Users\hbellamy\Documents\GitHub\my-swift\llbuild\lib\Core\BuildEngine.cpp(995): note: No constructor could take the source type, or constructor overload resolution was ambiguous
> 1>C:\Users\hbellamy\Documents\GitHub\my-swift\llbuild\lib\Core\BuildEngine.cpp(995): error C2672: 'std::vector<`anonymous-namespace'::BuildEngineImpl::reportCycle::WorkItem,std::allocator<_Ty>>::emplace_back': no matching overloaded function found
> 1>          with
> 1>          [
> 1>              _Ty=`anonymous-namespace'::BuildEngineImpl::reportCycle::WorkItem
> 1>          ]