### PR TITLE
[BuildSystem] Check for SkippedCommand in MkdirCommand and SymlinkCommand.

### DIFF
--- a/lib/BuildSystem/BuildSystem.cpp
+++ b/lib/BuildSystem/BuildSystem.cpp
@@ -1499,6 +1499,8 @@ class MkdirCommand : public Command {
     if (value.isFailedCommand() || value.isPropagatedFailureCommand() ||
         value.isCancelledCommand())
       return BuildValue::makeFailedInput();
+    if (value.isSkippedCommand())
+      return BuildValue::makeSkippedCommand();
 
     // Otherwise, we should have a successful command -- return the actual
     // result for the output.
@@ -1738,6 +1740,8 @@ class SymlinkCommand : public Command {
     if (value.isFailedCommand() || value.isPropagatedFailureCommand() ||
         value.isCancelledCommand())
       return BuildValue::makeFailedInput();
+    if (value.isSkippedCommand())
+      return BuildValue::makeSkippedCommand();
 
     // Otherwise, we should have a successful command -- return the actual
     // result for the output.


### PR DESCRIPTION
We've discussed refactoring this common behavior in {Mkdir, Symlink, and
External}Command, but I'm not in a position to do that right now.