### PR TITLE
[BuildSystem] Add support for "command timestamp" nodes.

### DIFF
--- a/docs/buildsystem.rst
+++ b/docs/buildsystem.rst
@@ -275,6 +275,19 @@ The following attributes are currently supported:
        to files in the file system matching the name. This attribute can be used
        to override that default.
 
+   * - is-command-timestamp
+     - A boolean value, indicating whether the node should be used to represent
+       the "timestamp" at which a command was run. When set, the node should
+       also be the output of some command in the graph. Whenever that command is
+       run, the node will take on a value representing the timestamp at which
+       the command was run.
+
+       This node can then be used as a (virtual) input to another command in
+       order to cause the downstream command to rerun whenever the producing
+       command is run.
+
+       Such nodes are always virtual nodes.
+
 .. note::
   FIXME: At some point, we probably want to support custom node types.
 

--- a/include/llbuild/BuildSystem/BuildNode.h
+++ b/include/llbuild/BuildSystem/BuildNode.h
@@ -33,11 +33,19 @@ class BuildNode : public Node {
   /// Whether or not this node is "virtual" (i.e., not a filesystem path).
   bool virtualNode;
 
+  /// Whether this node represents a "command timestamp".
+  ///
+  /// Such nodes should always also be virtual.
+  bool commandTimestamp;
+
 public:
-  explicit BuildNode(StringRef name, bool isVirtual)
-      : Node(name), virtualNode(isVirtual) {}
+  explicit BuildNode(StringRef name, bool isVirtual, bool isCommandTimestamp)
+      : Node(name), virtualNode(isVirtual),
+        commandTimestamp(isCommandTimestamp) {}
 
   bool isVirtual() const { return virtualNode; }
+
+  bool isCommandTimestamp() const { return commandTimestamp; }
 
   virtual bool configureAttribute(const ConfigureContext& ctx, StringRef name,
                                   StringRef value) override;

--- a/include/llbuild/Core/BuildEngine.h
+++ b/include/llbuild/Core/BuildEngine.h
@@ -30,6 +30,10 @@ typedef std::vector<uint8_t> ValueType;
 class BuildDB;
 class BuildEngine;
 
+/// A monotonically increasing timestamp identifying which iteration of a build
+/// an event occurred during.
+typedef uint64_t Timestamp;
+
 /// This object contains the result of executing a task to produce the value for
 /// a key.
 struct Result {
@@ -233,6 +237,12 @@ public:
 
   /// Return the delegate the engine was configured with.
   BuildEngineDelegate* getDelegate();
+
+  /// Get the current build timestamp used by the engine.
+  ///
+  /// The timestamp is a monotonically increasing value which is incremented
+  /// with each requested build.
+  Timestamp getCurrentTimestamp();
 
   /// @name Rule Definition
   /// @{

--- a/lib/BuildSystem/BuildNode.cpp
+++ b/lib/BuildSystem/BuildNode.cpp
@@ -30,6 +30,19 @@ bool BuildNode::configureAttribute(const ConfigureContext& ctx, StringRef name,
       virtualNode = true;
     } else if (value == "false") {
       virtualNode = false;
+      commandTimestamp = false;
+    } else {
+      ctx.error("invalid value: '" + value + "' for attribute '"
+                + name + "'");
+      return false;
+    }
+    return true;
+  } else if (name == "is-command-timestamp") {
+    if (value == "true") {
+      commandTimestamp = true;
+      virtualNode = true;
+    } else if (value == "false") {
+      commandTimestamp = false;
     } else {
       ctx.error("invalid value: '" + value + "' for attribute '"
                 + name + "'");

--- a/lib/BuildSystem/BuildSystem.cpp
+++ b/lib/BuildSystem/BuildSystem.cpp
@@ -831,7 +831,8 @@ void BuildSystemEngineDelegate::cycleDetected(const std::vector<Rule*>& cycle) {
 std::unique_ptr<BuildNode>
 BuildSystemImpl::lookupNode(StringRef name, bool isImplicit) {
   bool isVirtual = !name.empty() && name[0] == '<' && name.back() == '>';
-  return llvm::make_unique<BuildNode>(name, isVirtual);
+  return llvm::make_unique<BuildNode>(name, isVirtual,
+                                      /*isCommandTimestamp=*/false);
 }
 
 bool BuildSystemImpl::build(StringRef target) {

--- a/lib/Core/BuildEngine.cpp
+++ b/lib/Core/BuildEngine.cpp
@@ -1049,6 +1049,10 @@ public:
     return &delegate;
   }
 
+  Timestamp getCurrentTimestamp() {
+    return currentTimestamp;
+  }
+
   RuleInfo& getRuleInfoForKey(const KeyType& key) {
     // Check if we have already found the rule.
     auto it = ruleInfos.find(key);
@@ -1342,6 +1346,10 @@ BuildEngine::~BuildEngine() {
 
 BuildEngineDelegate* BuildEngine::getDelegate() {
   return static_cast<BuildEngineImpl*>(impl)->getDelegate();
+}
+
+Timestamp BuildEngine::getCurrentTimestamp() {
+  return static_cast<BuildEngineImpl*>(impl)->getCurrentTimestamp();
 }
 
 void BuildEngine::addRule(Rule&& rule) {

--- a/tests/BuildSystem/Build/command-dependencies.llbuild
+++ b/tests/BuildSystem/Build/command-dependencies.llbuild
@@ -1,0 +1,59 @@
+# Check the behavior of command dependencies.
+#
+# RUN: rm -rf %t.build
+# RUN: mkdir -p %t.build
+# RUN: touch %t.build/input
+# RUN: cp %s %t.build/build.llbuild
+
+# Both commands should run on the initial build.
+#
+# RUN: %{llbuild} buildsystem build --serial --chdir %t.build > %t.initial.out
+# RUN: %{FileCheck} --check-prefix CHECK-INITIAL --input-file %t.initial.out %s
+# CHECK-INITIAL: C.output-2
+# CHECK-INITIAL: C.output-1
+# RUN: diff %t.build/output-1 %t.build/output-2
+
+# No commands should run on a null rebuild.
+#
+# RUN: %{llbuild} buildsystem build --serial --chdir %t.build > %t.null.out
+# RUN: echo EOF >> %t.null.out
+# RUN: %{FileCheck} --check-prefix CHECK-NULL --input-file %t.null.out %s
+# RUN: diff %t.build/output-1 %t.build/output-2
+# CHECK-NULL-NOT: C.output
+# CHECK-NULL: EOF
+
+# Forcing the initial command to run should cause them both to run again.
+#
+# RUN: echo modified >> %t.build/input
+# RUN: %{llbuild} buildsystem build --serial --chdir %t.build > %t.rebuild.out
+# RUN: cat %t.rebuild.out
+# RUN: %{FileCheck} --check-prefix CHECK-REBUILD --input-file %t.rebuild.out %s
+# RUN: diff %t.build/output-1 %t.build/output-2
+#
+# CHECK-REBUILD: C.output-2
+# CHECK-REBUILD: C.output-1
+
+client:
+  name: basic
+
+targets:
+  "": ["<output>"]
+
+nodes:
+  "<C.output-2.timestamp>":
+    is-command-timestamp: true
+
+commands:
+  C.output-1:
+    tool: shell
+    inputs: ["<C.output-2.timestamp>"]
+    outputs: ["<output>"]
+    description: C.output-1
+    args: cp output-2 output-1
+
+  C.output-2:
+    tool: shell
+    inputs: ["input"]
+    outputs: ["<C.output-2.timestamp>"]
+    description: C.output-2
+    args: cp input output-2


### PR DESCRIPTION
 - These nodes can be used to build relationships between commands which
   effectively cause one command to trigger another to build any time it
   updates.

 - This can be used as part of a primitive mechanism for supporting commands
   which need to mutate the outputs of other commands, by treating the output as
   effectively one of the mutating command, and using a trigger relationship
   between the producing & mutation commands to cause them to run in concert.