### PR TITLE
<rdar://problem/30059364> BuildEngine shouldn't call exit for error handling that isn't necessarily a programmer error

### DIFF
--- a/include/llbuild/Core/BuildEngine.h
+++ b/include/llbuild/Core/BuildEngine.h
@@ -20,6 +20,8 @@
 #include <utility>
 #include <vector>
 
+#include "llvm/ADT/Twine.h"
+
 namespace llbuild {
 namespace core {
 
@@ -203,6 +205,11 @@ public:
   /// the node which was requested to build and ending with the first node in
   /// the cycle (i.e., the node participating in the cycle will appear twice).
   virtual void cycleDetected(const std::vector<Rule*>& items) = 0;
+
+  /// Called when a fatal error is encountered by the build engine.
+  ///
+  /// \param message The diagnostic message.
+  virtual void error(const llvm::Twine& message) = 0;
 
 };
 

--- a/lib/BuildSystem/BuildSystem.cpp
+++ b/lib/BuildSystem/BuildSystem.cpp
@@ -117,6 +117,7 @@ class BuildSystemEngineDelegate : public BuildEngineDelegate {
 
   virtual Rule lookupRule(const KeyType& keyData) override;
   virtual void cycleDetected(const std::vector<Rule*>& items) override;
+  virtual void error(const Twine& message) override;
 
 public:
   BuildSystemEngineDelegate(BuildSystemImpl& system) : system(system) {}
@@ -824,6 +825,10 @@ void BuildSystemEngineDelegate::cycleDetected(const std::vector<Rule*>& cycle) {
   }
   
   system.error(system.getMainFilename(), os.str());
+}
+
+void BuildSystemEngineDelegate::error(const Twine& message) {
+  system.error(system.getMainFilename(), message);
 }
 
 #pragma mark - BuildSystemImpl implementation

--- a/lib/Commands/BuildEngineCommand.cpp
+++ b/lib/Commands/BuildEngineCommand.cpp
@@ -214,6 +214,11 @@ static int runAckermannBuild(int m, int n, int recomputeCount,
     virtual void cycleDetected(const std::vector<core::Rule*>& items) override {
       assert(0 && "unexpected cycle!");
     }
+
+    /// Called when a fatal error is encountered by the build engine.
+    virtual void error(const Twine &message) override {
+      assert(0 && ("error:" + message.str()).c_str());
+    }
   };
   AckermannDelegate delegate;
   core::BuildEngine engine(delegate);

--- a/lib/Commands/NinjaBuildCommand.cpp
+++ b/lib/Commands/NinjaBuildCommand.cpp
@@ -400,6 +400,8 @@ struct NinjaBuildEngineDelegate : public core::BuildEngineDelegate {
   virtual core::Rule lookupRule(const core::KeyType& key) override;
 
   virtual void cycleDetected(const std::vector<core::Rule*>& items) override;
+
+  virtual void error(const Twine& message) override;
 };
 
 /// Wrapper for information used during a single build.
@@ -1677,6 +1679,14 @@ void NinjaBuildEngineDelegate::cycleDetected(
   }
 
   context->emitError(message.str());
+
+  // Cancel the build.
+  context->isCancelled = true;
+}
+
+void NinjaBuildEngineDelegate::error(const Twine& message) {
+  // Report the error.
+  context->emitError("error: " + message.str());
 
   // Cancel the build.
   context->isCancelled = true;

--- a/perftests/Xcode/PerfTests/CorePerfTests.mm
+++ b/perftests/Xcode/PerfTests/CorePerfTests.mm
@@ -141,6 +141,11 @@ static ActionFn simpleAction(const std::vector<KeyType>& Inputs,
       fprintf(stderr, "error: unexpected cycle\n");
       abort();
     }
+
+    virtual void error(const Twine& message) override {
+      fprintf(stderr, "error: %s\n", message.str().c_str());
+      abort();
+    }
   } Delegate;
   __block core::BuildEngine Engine(Delegate);
   int LastInputValue = 0;
@@ -214,6 +219,11 @@ static int64_t i64pow(int64_t Value, int64_t Exponent) {
     virtual void cycleDetected(const std::vector<core::Rule*>& Cycle) override {
       // We never expect to find a cycle.
       fprintf(stderr, "error: unexpected cycle\n");
+      abort();
+    }
+
+    virtual void error(const Twine& message) override {
+      fprintf(stderr, "error: %s\n", message.str().c_str());
       abort();
     }
   } Delegate;
@@ -293,6 +303,11 @@ static int64_t i64pow(int64_t Value, int64_t Exponent) {
     virtual void cycleDetected(const std::vector<core::Rule*>& Cycle) override {
       // We never expect to find a cycle.
       fprintf(stderr, "error: unexpected cycle\n");
+      abort();
+    }
+
+    virtual void error(const Twine& message) override {
+      fprintf(stderr, "error: %s\n", message.str().c_str());
       abort();
     }
   } Delegate;

--- a/products/libllbuild/Core-C-API.cpp
+++ b/products/libllbuild/Core-C-API.cpp
@@ -86,6 +86,10 @@ class CAPIBuildEngineDelegate : public BuildEngineDelegate {
     assert(0 && "unexpected cycle!");
   }
 
+  virtual void error(const Twine& message) override {
+    cAPIDelegate.error(cAPIDelegate.context, message.str().c_str());
+  }
+
 public:
   CAPIBuildEngineDelegate(llb_buildengine_delegate_t delegate)
     : cAPIDelegate(delegate)

--- a/products/libllbuild/public-api/llbuild/core.h
+++ b/products/libllbuild/public-api/llbuild/core.h
@@ -104,6 +104,12 @@ typedef struct llb_buildengine_delegate_t_ {
     void (*lookup_rule)(void* context,
                         const llb_data_t* key,
                         llb_rule_t* rule_out);
+
+    /// Callback for fatal errors the build engine encounters.
+    ///
+    /// Xparam context The user context pointer.
+    /// Xparam message Error message.
+    void (*error)(void* context, const char* message);
 } llb_buildengine_delegate_t;
 
 /// Create a new build engine object.

--- a/unittests/Core/BuildEngineTest.cpp
+++ b/unittests/Core/BuildEngineTest.cpp
@@ -45,6 +45,11 @@ private:
     std::transform(items.begin(), items.end(), std::back_inserter(cycle),
                    [](auto rule) { return std::string(rule->key); });
   }
+
+  virtual void error(const Twine& message) override {
+    fprintf(stderr, "error: %s\n", message.str().c_str());
+    abort();
+  }
 };
 
 static int32_t intFromValue(const core::ValueType& value) {

--- a/unittests/Core/DepsBuildEngineTest.cpp
+++ b/unittests/Core/DepsBuildEngineTest.cpp
@@ -43,6 +43,11 @@ class SimpleBuildEngineDelegate : public core::BuildEngineDelegate {
     fprintf(stderr, "error: cycle\n");
     abort();
   }
+
+  virtual void error(const Twine& message) override {
+    fprintf(stderr, "error: %s\n", message.str().c_str());
+    abort();
+  }
 };
 
 static int32_t intFromValue(const core::ValueType& value) {


### PR DESCRIPTION
- Added delegate method for error propagation to `BuildEngineDelegate`
- Added delegate function pointer for error propagation to `llb_buildengine_delegate_t_`
- Adopted delegate implementations and tests accordingly
- `BuildEngine` uses this to report errors instead of aborting