### PR TITLE
Fix LLBUILD_EXPORT for Windows

### DIFF
--- a/products/libllbuild/public-api/llbuild/llbuild.h
+++ b/products/libllbuild/public-api/llbuild/llbuild.h
@@ -18,9 +18,15 @@
 #define LLBUILD_PUBLIC_LLBUILD_H
 
 #if defined(__cplusplus)
+#if defined(_WIN32)
+#define LLBUILD_EXPORT extern "C" __declspec(dllexport)
+#else
 #define LLBUILD_EXPORT extern "C" __attribute__((visibility("default")))
+#endif
 #elif __GNUC__
 #define LLBUILD_EXPORT extern __attribute__((visibility("default")))
+#elif defined(_WIN32)
+#define LLBUILD_EXPORT extern __declspec(dllexport)
 #else
 #define LLBUILD_EXPORT extern
 #endif


### PR DESCRIPTION
Windows requires the use of `__declspec(dllexport)`. This works with MSVC, Clang and GCC. This fixes the exported API on Windows.

However, MSVC doesn't understand `__attribute()` syntax, so this also fixes many build errors.