### PR TITLE
Fix unit tests build failures with MSVC

### DIFF
--- a/unittests/Core/DependencyInfoParserTest.cpp
+++ b/unittests/Core/DependencyInfoParserTest.cpp
@@ -50,8 +50,9 @@ TEST(DependencyInfoParserTest, basic) {
     }
   };
 
-#define INPUT(str) ({ \
-      assert(sizeof(str) != 0); StringRef(str, sizeof(str) - 1); })
+#define INPUT(str)                                                             \
+  StringRef(str, sizeof(str) - 1);                                             \
+  assert(sizeof(str) != 0);
 
   // Check missing terminator diagnose (on empty file).
   {


### PR DESCRIPTION
> 6>C:\Users\hughb\Documents\GitHub\swift\llbuild\unittests\Core\DependencyInfoParserTest.cpp(59): error C2143: syntax error: missing ';' before '{'
6>C:\Users\hughb\Documents\GitHub\swift\llbuild\unittests\Core\DependencyInfoParserTest.cpp(59): error C2059: syntax error: ')'

I also ran clang-format on the line
