### PR TITLE
Invoke llvm-lit.py with Python

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,6 +73,7 @@ set(LLBUILD_LIBRARY_OUTPUT_INTDIR ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_CFG_INTDIR
 
 find_package(Lit REQUIRED)
 find_package(FileCheck REQUIRED)
+find_package(PythonInterp)
 
 # Check if we should build the Swift bindings.
 if (";${LLBUILD_SUPPORT_BINDINGS};" MATCHES ";Swift;")

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -28,6 +28,7 @@ if(PYTHONINTERP_FOUND)
   endif()
 
   set(lit_command
+    ${PYTHON_EXECUTABLE}
     ${LIT_EXECUTABLE}
     ${LIT_ARGS}
     --param build_mode=${build_mode})


### PR DESCRIPTION
Python executables have to be executed via `python x.py` on Windows. Keep this on all platforms, to avoid platform specific code.