### PR TITLE
Define config.shlibdir in lit.cfg

### DIFF
--- a/tests/Unit/lit.cfg
+++ b/tests/Unit/lit.cfg
@@ -35,6 +35,9 @@ if 'TMP' in os.environ:
 if 'TEMP' in os.environ:
     config.environment['TEMP'] = os.environ['TEMP']
 
+# Define the folder that contains the dlls created during the build.
+config.shlibdir = llbuild_obj_root
+
 # Win32 seeks DLLs along %PATH%.
 if sys.platform in ['win32', 'cygwin'] and os.path.isdir(config.shlibdir):
     config.environment['PATH'] = os.path.pathsep.join((


### PR DESCRIPTION
This fixes lit configuration errors running the unit tests on Windows
