### PR TITLE
Fix MSVC warnings for unknown escape character sequence

### DIFF
--- a/lib/Commands/BuildEngineCommand.cpp
+++ b/lib/Commands/BuildEngineCommand.cpp
@@ -283,21 +283,21 @@ static int executeAckermannCommand(std::vector<std::string> args) {
       ackermannUsage();
     } else if (option == "--recompute") {
       if (args.empty()) {
-        fprintf(stderr, "\error: %s: missing argument to '%s'\n\n",
+        fprintf(stderr, "error: %s: missing argument to '%s'\n\n",
                 getProgramName(), option.c_str());
         ackermannUsage();
       }
       char *end;
       recomputeCount = ::strtol(args[0].c_str(), &end, 10);
       if (*end != '\0') {
-        fprintf(stderr, "\error: %s: invalid argument to '%s'\n\n",
+        fprintf(stderr, "error: %s: invalid argument to '%s'\n\n",
                 getProgramName(), option.c_str());
         ackermannUsage();
       }
       args.erase(args.begin());
     } else if (option == "--dump-graph") {
       if (args.empty()) {
-        fprintf(stderr, "\error: %s: missing argument to '%s'\n\n",
+        fprintf(stderr, "error: %s: missing argument to '%s'\n\n",
                 getProgramName(), option.c_str());
         ackermannUsage();
       }
@@ -305,14 +305,14 @@ static int executeAckermannCommand(std::vector<std::string> args) {
       args.erase(args.begin());
     } else if (option == "--trace") {
       if (args.empty()) {
-        fprintf(stderr, "\error: %s: missing argument to '%s'\n\n",
+        fprintf(stderr, "error: %s: missing argument to '%s'\n\n",
                 getProgramName(), option.c_str());
         ackermannUsage();
       }
       traceFilename = args[0];
       args.erase(args.begin());
     } else {
-      fprintf(stderr, "\error: %s: invalid option: '%s'\n\n",
+      fprintf(stderr, "error: %s: invalid option: '%s'\n\n",
               getProgramName(), option.c_str());
       ackermannUsage();
     }


### PR DESCRIPTION
> warning C4129: 'e': unrecognized character escape sequence

I'm not sure what the intention here is:
- Accidental inclusion of `\error`: there are other cases in this file of `error` without `\error`
- Use of GCC extension escape sequence `\e`
- Wanting to print `\` to the stream, ie. `\\error`

I went with the first, but let me know