### PR TITLE
Define a platform independent abstraction for handling program signals

### DIFF
--- a/include/llbuild/Basic/SignalHandlerWrapper.h
+++ b/include/llbuild/Basic/SignalHandlerWrapper.h
@@ -1,0 +1,38 @@
+//===- SignalHandlerWrappper.h ----------------------------------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2015 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// This file implements a wrapper for handling signals.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLBUILD_BASIC_SIGNALHANDLERWRAPPER_H
+#define LLBUILD_BASIC_SIGNALHANDLERWRAPPER_H
+
+namespace llbuild {
+namespace basic {
+namespace sys {
+struct SignalHandlerWrapper {
+  void *innerAction;
+
+public:
+  using Handler = void (*)(int);
+
+  SignalHandlerWrapper() {}
+  SignalHandlerWrapper(Handler handler);
+
+  void registerAction(int sig, SignalHandlerWrapper *previous);
+};
+}
+}
+}
+
+#endif

--- a/lib/Basic/CMakeLists.txt
+++ b/lib/Basic/CMakeLists.txt
@@ -6,6 +6,7 @@ add_llbuild_library(llbuildBasic
   SerialQueue.cpp
   Version.cpp
   ShellUtility.cpp
+  SignalHandlerWrapper
   )
 
 if(${CMAKE_SYSTEM_NAME} MATCHES ".*BSD" OR ${CMAKE_SYSTEM_NAME} MATCHES "Linux")

--- a/lib/Basic/SignalHandlerWrapper.cpp
+++ b/lib/Basic/SignalHandlerWrapper.cpp
@@ -1,0 +1,44 @@
+//===- Support/SignalHandlerWrapper.cpp - Signal handling -----------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#include "llbuild/Basic/SignalHandlerWrapper.h"
+
+#include <signal.h>
+
+using namespace llbuild;
+using namespace llbuild::basic;
+using namespace llbuild::basic::sys;
+
+SignalHandlerWrapper::SignalHandlerWrapper(Handler handler) {
+#if defined(_WIN32)
+  innerAction = handler;
+#else
+  struct sigaction action{};
+  action.sa_handler = handler;
+  innerAction = handler;
+#endif
+}
+
+void SignalHandlerWrapper::registerAction(int sig,
+                                          SignalHandlerWrapper *previous) {
+#if defined(_WIN32)
+  Handler handler = ::signal(sig, static_cast<Handler>(innerAction));
+  if (previous) {
+    previous->innerAction = handler;
+  }
+#else
+  struct sigaction action = static_cast<struct sigaction>(innerAction);
+
+  struct sigaction previousHandler;
+  ::sigaction(sig, &action, &previousHandler);
+  if (previous) {
+    previous->innerAction = previousHandler;
+  }
+#endif
+}


### PR DESCRIPTION
Windows doesn't support `::sigaction`, as `::sigaction` is really complicated and Unix specific.
Fortunately, this isn't the end of the world, as Windows supplies `::signal` which can do the same behaviour we need.

However, the semantics of the two methods are different - `sigaction` is more powerful than `signal`, so has a more convoluted API.

This means that we need to introduce a wrapper for platform independent signalling operations.