### PR TITLE
Shorten sigkill timeout to 0.1s when testing

### DIFF
--- a/lib/BuildSystem/LaneBasedExecutionQueue.cpp
+++ b/lib/BuildSystem/LaneBasedExecutionQueue.cpp
@@ -125,7 +125,13 @@ class LaneBasedExecutionQueue : public BuildExecutionQueue {
     std::unique_lock<std::mutex> lock(queueCompleteMutex);
 
     if (!queueComplete) {
-      queueCompleteCondition.wait_for(lock, std::chrono::seconds(10));
+      // Shorten timeout if in testing context
+      if (getenv("LLBUILD_TEST") != nullptr) {
+        queueCompleteCondition.wait_for(lock, std::chrono::milliseconds(1000));
+      } else {
+        queueCompleteCondition.wait_for(lock, std::chrono::seconds(10));
+      }
+
       sendSignalToProcesses(SIGKILL);
     }
   }

--- a/tests/BuildSystem/Build/sigkill-escalation.llbuild
+++ b/tests/BuildSystem/Build/sigkill-escalation.llbuild
@@ -6,7 +6,7 @@
 # RUN: cp %S/Inputs/wait-for-file %t.build
 # RUN: cp %S/Inputs/ignore-sigint %t.build
 # RUN: /bin/bash -x -c \
-# RUN:   "%{llbuild} buildsystem build --serial --chdir %t.build --no-db &> %t.out & \
+# RUN:   "LLBUILD_TEST=1 %{llbuild} buildsystem build --serial --chdir %t.build --no-db &> %t.out & \
 # RUN:    echo $! >%t.build/llbuild.pid; \
 # RUN:    wait $(cat %t.build/llbuild.pid)" || true
 # RUN: %{FileCheck} --input-file %t.out %s


### PR DESCRIPTION
If environment variable `LLBUILD_TEST` is present, the timeout will be shortened.

Fixes <rdar://problem/29678182> sigkill test is taking too long