### PR TITLE
[BuildSystem] Add support for an 'is-mutated' node flag.

### DIFF
--- a/docs/buildsystem.rst
+++ b/docs/buildsystem.rst
@@ -288,6 +288,15 @@ The following attributes are currently supported:
 
        Such nodes are always virtual nodes.
 
+   * - is-mutated
+     - A boolean value, indicating whether the node is mutated by commands in
+       the build. When a command is mutated, it's file system information will
+       no longer be used in determining whether a detected change in the
+       *output* of a command should cause that command to rerun. Without this
+       check, the producer of the file would always rerun since the output
+       information captured at production time will always be out-of-date once
+       the mutating command runs.
+       
 .. note::
   FIXME: At some point, we probably want to support custom node types.
 

--- a/include/llbuild/BuildSystem/BuildNode.h
+++ b/include/llbuild/BuildSystem/BuildNode.h
@@ -38,14 +38,24 @@ class BuildNode : public Node {
   /// Such nodes should always also be virtual.
   bool commandTimestamp;
 
+  /// Whether this node is mutated by the build.
+  ///
+  /// This flag cannot currently be honored to provide a strongly consistent
+  /// build, but it is used to detect when the file system information on a node
+  /// cannot be safely used to track *output* file state.
+  bool mutated;
+
 public:
-  explicit BuildNode(StringRef name, bool isVirtual, bool isCommandTimestamp)
+  explicit BuildNode(StringRef name, bool isVirtual, bool isCommandTimestamp,
+                     bool isMutated)
       : Node(name), virtualNode(isVirtual),
-        commandTimestamp(isCommandTimestamp) {}
+        commandTimestamp(isCommandTimestamp), mutated(isMutated) {}
 
   bool isVirtual() const { return virtualNode; }
 
   bool isCommandTimestamp() const { return commandTimestamp; }
+
+  bool isMutated() const { return mutated; }
 
   virtual bool configureAttribute(const ConfigureContext& ctx, StringRef name,
                                   StringRef value) override;

--- a/lib/BuildSystem/BuildNode.cpp
+++ b/lib/BuildSystem/BuildNode.cpp
@@ -49,6 +49,17 @@ bool BuildNode::configureAttribute(const ConfigureContext& ctx, StringRef name,
       return false;
     }
     return true;
+  } else if (name == "is-mutated") {
+    if (value == "true") {
+      mutated = true;
+    } else if (value == "false") {
+      mutated = false;
+    } else {
+      ctx.error("invalid value: '" + value + "' for attribute '"
+                + name + "'");
+      return false;
+    }
+    return true;
   }
     
   // We don't support any other custom attributes.

--- a/lib/BuildSystem/BuildSystem.cpp
+++ b/lib/BuildSystem/BuildSystem.cpp
@@ -838,7 +838,8 @@ std::unique_ptr<BuildNode>
 BuildSystemImpl::lookupNode(StringRef name, bool isImplicit) {
   bool isVirtual = !name.empty() && name[0] == '<' && name.back() == '>';
   return llvm::make_unique<BuildNode>(name, isVirtual,
-                                      /*isCommandTimestamp=*/false);
+                                      /*isCommandTimestamp=*/false,
+                                      /*isMutable=*/false);
 }
 
 bool BuildSystemImpl::build(StringRef target) {

--- a/lib/BuildSystem/ExternalCommand.cpp
+++ b/lib/BuildSystem/ExternalCommand.cpp
@@ -175,7 +175,7 @@ bool ExternalCommand::isResultValid(BuildSystem& system,
     // Ignore virtual outputs.
     if (node->isVirtual())
       continue;
-      
+
     // Rebuild if the output information has changed.
     //
     // We intentionally allow missing outputs here, as long as they haven't
@@ -191,6 +191,15 @@ bool ExternalCommand::isResultValid(BuildSystem& system,
     // could enable behavior to remove such output files if annotated prior to
     // running the command.
     auto info = node->getFileInfo(system.getDelegate().getFileSystem());
+
+    // If this output is mutated by the build, we can't rely on equivalence,
+    // only existence.
+    if (node->isMutated()) {
+      if (value.getNthOutputInfo(i).isMissing() != info.isMissing())
+        return false;
+      continue;
+    }
+
     if (value.getNthOutputInfo(i) != info)
       return false;
   }

--- a/tests/BuildSystem/Build/mutable-outputs.llbuild
+++ b/tests/BuildSystem/Build/mutable-outputs.llbuild
@@ -1,0 +1,81 @@
+# Demonstrates the current "recommended" way of modeling mutable outputs. We do
+# not yet have the ability to offer strong support for these situations, but
+# this approach uses command dependencies and the node "is-mutable" flag to
+# emulate support as best as possible.
+
+# Check the behavior of command dependencies.
+#
+# RUN: rm -rf %t.build
+# RUN: mkdir -p %t.build
+# RUN: printf Hello > %t.build/input
+# RUN: cp %s %t.build/build.llbuild
+
+# Both commands should run on the initial build.
+#
+# RUN: %{llbuild} buildsystem build --serial --chdir %t.build > %t.initial.out
+# RUN: %{FileCheck} --check-prefix CHECK-INITIAL-LOG --input-file %t.initial.out %s
+# RUN: printf "Hello, world!\n" > %t.build/expected-output
+# RUNX: diff %t.build/output %t.build/expected-output
+#
+# CHECK-INITIAL-LOG: C.create
+# CHECK-INITIAL-LOG: C.mutate
+
+# No commands should run on a null rebuild.
+#
+# RUN: %{llbuild} buildsystem build --serial --chdir %t.build > %t.null.out
+# RUN: echo EOF >> %t.null.out
+# RUN: %{FileCheck} --check-prefix CHECK-NULL-LOG --input-file %t.null.out %s
+# RUN: printf "Hello, world!\n" > %t.build/expected-output
+# RUNX: diff %t.build/output %t.build/expected-output
+#
+# CHECK-NULL-LOG-NOT: C.
+# CHECK-NULL-LOG: EOF
+
+# Forcing the initial command to run should cause them both to run again.
+#
+# RUN: printf "Hello there" > %t.build/input
+# RUN: %{llbuild} buildsystem build --serial --chdir %t.build > %t.rebuild.out
+# RUN: %{FileCheck} --check-prefix CHECK-REBUILD-LOG --input-file %t.rebuild.out %s
+# RUN: printf "Hello there, world!\n" > %t.build/expected-output
+# RUNX: diff %t.build/output %t.build/expected-output
+#
+# CHECK-REBUILD-LOG: C.create
+# CHECK-REBUILD-LOG: C.mutate
+
+# If the output file was removed, they should both to run again.
+#
+# RUN: rm %t.build/output
+# RUN: %{llbuild} buildsystem build --serial --chdir %t.build > %t.rebuild.out
+# RUN: %{FileCheck} --check-prefix CHECK-REMOVAL-LOG --input-file %t.rebuild.out %s
+# RUN: printf "Hello there, world!\n" > %t.build/expected-output
+# RUNX: diff %t.build/output %t.build/expected-output
+#
+# CHECK-REMOVAL-LOG: C.create
+# CHECK-REMOVAL-LOG: C.mutate
+
+client:
+  name: basic
+
+targets:
+  "": ["<C.mutate>"]
+
+nodes:
+  "<C.create.timestamp>":
+    is-command-timestamp: true
+  "output":
+    is-mutated: true
+
+commands:
+  C.mutate:
+    tool: shell
+    inputs: ["<C.create.timestamp>"]
+    outputs: ["<C.mutate>"]
+    description: C.mutate
+    args: test -f output && echo ", world!" >> output
+
+  C.create:
+    tool: shell
+    inputs: ["input"]
+    outputs: ["output", "<C.create.timestamp>"]
+    description: C.create
+    args: cp input output


### PR DESCRIPTION
 - This can be used to indicate a file which is mutated by subsequent commands,
   and cannot have its stat information (other than existence) meaningfully
   checked. This can be used as with command timestamp nodes as part of a
   primitive mechanism for supporting commands which mutate their inputs.