### PR TITLE
Refactor code for creating a process and redirecting input and output

### DIFF
--- a/include/llbuild/Basic/RedirectedProcess.h
+++ b/include/llbuild/Basic/RedirectedProcess.h
@@ -1,0 +1,68 @@
+//===- RedirectedProcess.h --------------------------------------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2015 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// This file contains abstractions for creating a process and redirecting
+// input and output of that process.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLBUILD_BASIC_REDIRECTEDPROCESS_H
+#define LLBUILD_BASIC_REDIRECTEDPROCESS_H
+
+#include "llvm/ADT/SmallString.h"
+
+#include <mutex>
+#include <vector>
+
+namespace llbuild {
+namespace basic {
+namespace sys {
+class RedirectedProcess {
+  bool shouldCaptureOutput;
+  struct ProcessInfo *innerProcessInfo;
+
+public:
+  RedirectedProcess(bool shouldCaptureOutput);
+
+  bool openPipe();
+
+  bool execute(const char *path, bool setGroupFlags, char *const *args,
+               char *const *envp, std::mutex &spawnedProcessMutex);
+
+  bool readPipe(llvm::SmallString<1024> &output);
+
+  bool waitForCompletion(int *exitStatus);
+
+  bool kill(int signal);
+
+  bool operator==(const RedirectedProcess &rhs) const;
+  size_t hash() const;
+
+  ~RedirectedProcess();
+  
+  static int sigkill();
+
+  static bool isProcessCancelledStatus(int status);
+};
+}
+}
+}
+
+namespace std {
+template <> struct hash<llbuild::basic::sys::RedirectedProcess> {
+  size_t operator()(const llbuild::basic::sys::RedirectedProcess &x) const {
+    return x.hash();
+  };
+};
+}
+
+#endif

--- a/lib/Basic/CMakeLists.txt
+++ b/lib/Basic/CMakeLists.txt
@@ -3,6 +3,7 @@ add_llbuild_library(llbuildBasic
   FileSystem.cpp
   Hashing.cpp
   PlatformUtility.cpp
+  RedirectedProcess.cpp
   SerialQueue.cpp
   Version.cpp
   ShellUtility.cpp

--- a/lib/Basic/RedirectedProcess.cpp
+++ b/lib/Basic/RedirectedProcess.cpp
@@ -1,0 +1,217 @@
+//===-- RedirectedProcess.cpp ---------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2015 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#include "llbuild/Basic/RedirectedProcess.h"
+
+#include <signal.h>
+
+#include <fcntl.h>
+#include <unistd.h>
+#include <spawn.h>
+#include <string.h>
+#include <sys/wait.h>
+
+using namespace llbuild;
+using namespace llbuild::basic;
+using namespace llbuild::basic::sys;
+
+struct llbuild::basic::sys::ProcessInfo {
+  pid_t processId;
+  int readHandle;
+  int writeHandle;
+};
+
+RedirectedProcess::RedirectedProcess(bool shouldCaptureOutput) {
+  this->shouldCaptureOutput = shouldCaptureOutput;
+  this->innerProcessInfo = new ProcessInfo();
+}
+
+bool RedirectedProcess::openPipe() {
+  if (!shouldCaptureOutput) {
+    return true;
+  }
+
+  int pipeHandles[2] = {-1, -1};
+  if (::pipe(pipeHandles) < 0) {
+    return false;
+  }
+
+  innerProcessInfo->readHandle = pipeHandles[0];
+  innerProcessInfo->writeHandle = pipeHandles[1];
+
+  return true;
+}
+
+bool RedirectedProcess::execute(const char *path, bool setGroupFlags,
+                                char *const *args, char *const *envp,
+                                std::mutex &spawnedProcessesMutex) {
+  // Initialize the spawn attributes.
+  posix_spawnattr_t attributes;
+  posix_spawnattr_init(&attributes);
+
+  // Unmask all signals
+  sigset_t noSignals;
+  sigemptyset(&noSignals);
+  posix_spawnattr_setsigmask(&attributes, &noSignals);
+
+// Reset all signals to default behavior.
+//
+// On Linux, this can only be used to reset signals that are legal to
+// modify, so we have to take care about the set we use.
+#if defined(__linux__)
+  sigset_t mostSignals;
+  sigemptyset(&mostSignals);
+  for (int i = 1; i < SIGUNUSED; ++i) {
+    if (i == SIGKILL || i == SIGSTOP)
+      continue;
+    sigaddset(&mostSignals, i);
+  }
+  posix_spawnattr_setsigdefault(&attributes, &mostSignals);
+#else
+  sigset_t mostSignals;
+  sigfillset(&mostSignals);
+  sigdelset(&mostSignals, SIGKILL);
+  sigdelset(&mostSignals, SIGSTOP);
+  posix_spawnattr_setsigdefault(&attributes, &mostSignals);
+#endif
+
+  // Establish a separate process group.
+  posix_spawnattr_setpgroup(&attributes, 0);
+
+  // Set the attribute flags.
+  unsigned flags = POSIX_SPAWN_SETSIGMASK | POSIX_SPAWN_SETSIGDEF;
+  if (setGroupFlags)
+    flags |= POSIX_SPAWN_SETPGROUP;
+
+// Close all other files by default.
+//
+// FIXME: This is an Apple-specific extension, and we will have to do
+// something else on other platforms (and unfortunately, there isn't
+// really an easy answer other than using a stub executable).
+#ifdef __APPLE__
+  flags |= POSIX_SPAWN_CLOEXEC_DEFAULT;
+#endif
+
+  posix_spawnattr_setflags(&attributes, flags);
+
+  // Setup the file actions.
+  posix_spawn_file_actions_t fileActions;
+  posix_spawn_file_actions_init(&fileActions);
+
+  // Open /dev/null as stdin.
+  posix_spawn_file_actions_addopen(&fileActions, 0, "/dev/null", O_RDONLY, 0);
+
+  // Create a pipe to use to read the command output, if necessary.
+  if (shouldCaptureOutput) {
+    // Open the write end of the pipe as stdout and stderr.
+    posix_spawn_file_actions_adddup2(&fileActions, innerProcessInfo->writeHandle, 1);
+    posix_spawn_file_actions_adddup2(&fileActions, innerProcessInfo->writeHandle, 2);
+
+    // Close the read and write ends of the pipe.
+    posix_spawn_file_actions_addclose(&fileActions, innerProcessInfo->readHandle);
+    posix_spawn_file_actions_addclose(&fileActions, innerProcessInfo->writeHandle);
+  } else {
+    posix_spawn_file_actions_adddup2(&fileActions, 1, 1);
+    posix_spawn_file_actions_adddup2(&fileActions, 2, 2);
+  }
+
+  // Spawn the command.
+  pid_t pid;
+  {
+    // We need to hold the spawn processes lock when we spawn, to ensure that
+    // we don't create a process in between when we are cancelled.
+    std::lock_guard<std::mutex> guard(spawnedProcessesMutex);
+
+    if (posix_spawn(&pid, path, /*file_actions=*/&fileActions,
+                    /*attrp=*/&attributes, args, envp) != 0) {
+      return false;
+    }
+  }
+
+  posix_spawn_file_actions_destroy(&fileActions);
+  posix_spawnattr_destroy(&attributes);
+
+  innerProcessInfo->processId = pid;
+
+  return true;
+}
+
+bool RedirectedProcess::readPipe(llvm::SmallString<1024> &output) {
+  if (!shouldCaptureOutput) {
+    return true;
+  }
+
+  // Close the write end of the output pipe.
+  ::close(innerProcessInfo->writeHandle);
+
+  // Read all the data from the output pipe.
+  while (true) {
+    char buf[4096];
+    ssize_t numBytes = ::read(innerProcessInfo->readHandle, buf, sizeof(buf));
+    if (numBytes < 0) {
+      return false;
+    }
+
+    if (numBytes == 0)
+      break;
+
+    output.insert(output.end(), &buf[0], &buf[numBytes]);
+  }
+
+  // Close the read end of the pipe.
+  ::close(innerProcessInfo->readHandle);
+
+  return true;
+}
+
+bool RedirectedProcess::waitForCompletion(int *exitStatus) {
+  int result = waitpid(innerProcessInfo->processId, exitStatus, 0);
+  while (result == -1 && errno == EINTR)
+    result = waitpid(innerProcessInfo->processId, exitStatus, 0);
+
+  return result != -1;
+}
+
+bool RedirectedProcess::kill(int signal) {
+  int result = ::kill(-(innerProcessInfo->processId), signal);
+  return result == 0;
+}
+
+bool RedirectedProcess::operator==(const RedirectedProcess &rhs) const {
+  return innerProcessInfo->processId == rhs.innerProcessInfo->processId &&
+         innerProcessInfo->readHandle == rhs.innerProcessInfo->readHandle &&
+         innerProcessInfo->writeHandle == rhs.innerProcessInfo->writeHandle;
+}
+
+size_t RedirectedProcess::hash() const {
+  return innerProcessInfo->processId;
+}
+
+RedirectedProcess::~RedirectedProcess() {
+  // TODO: this causes tens of errors at runtime running the tests:
+  // "*** Error in `/mnt/c/Users/hughb/Documents/GitHub/swift-linux/build/bin/llbuild': double free or corruption (fasttop): 0x00007f1450000940 ***"
+  // Surely we allocated innerProcessInfo (this->innerProcessInfo = new ProcessInfo();), so have
+  // to delete it? This may need investigation to make sure we don't leak memory.
+  // Or I'm probably wrong, and should delete this destructor.
+
+  //delete innerProcessInfo;
+}
+
+
+int RedirectedProcess::sigkill() {
+  return SIGKILL;
+}
+
+bool RedirectedProcess::isProcessCancelledStatus(int status) {
+  return WIFSIGNALED(status) &&
+    (WTERMSIG(status) == SIGINT || WTERMSIG(status) == SIGKILL);
+}

--- a/lib/BuildSystem/LaneBasedExecutionQueue.cpp
+++ b/lib/BuildSystem/LaneBasedExecutionQueue.cpp
@@ -15,6 +15,7 @@
 
 #include "llbuild/Basic/LLVM.h"
 #include "llbuild/Basic/PlatformUtility.h"
+#include "llbuild/Basic/RedirectedProcess.h"
 
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/Hashing.h"
@@ -42,6 +43,7 @@
 #include <sys/wait.h>
 
 using namespace llbuild;
+using namespace llbuild::basic;
 using namespace llbuild::buildsystem;
 
 namespace std {
@@ -76,7 +78,7 @@ class LaneBasedExecutionQueue : public BuildExecutionQueue {
   bool shutdown { false };
   
   /// The set of spawned processes to terminate if we get cancelled.
-  std::unordered_set<pid_t> spawnedProcesses;
+  std::unordered_set<sys::RedirectedProcess> spawnedProcesses;
   std::mutex spawnedProcessesMutex;
 
   /// Management of cancellation and SIGKILL escalation
@@ -143,17 +145,17 @@ class LaneBasedExecutionQueue : public BuildExecutionQueue {
         queueCompleteCondition.wait_for(lock, std::chrono::seconds(10));
       }
 
-      sendSignalToProcesses(SIGKILL);
+      sendSignalToProcesses(sys::RedirectedProcess::sigkill());
     }
   }
 
   void sendSignalToProcesses(int signal) {
     std::unique_lock<std::mutex> lock(spawnedProcessesMutex);
 
-    for (pid_t pid: spawnedProcesses) {
+    for (sys::RedirectedProcess process: spawnedProcesses) {
       // We are killing the whole process group here, this depends on us
       // spawning each process in its own group earlier.
-      ::kill(-pid, signal);
+      process.kill(signal);
     }
   }
 
@@ -237,86 +239,6 @@ public:
     LaneBasedExecutionQueueJobContext& context =
       *reinterpret_cast<LaneBasedExecutionQueueJobContext*>(opaqueContext);
     getDelegate().commandProcessStarted(context.job.getForCommand(), handle);
-    
-    // Initialize the spawn attributes.
-    posix_spawnattr_t attributes;
-    posix_spawnattr_init(&attributes);
-
-    // Unmask all signals.
-    sigset_t noSignals;
-    sigemptyset(&noSignals);
-    posix_spawnattr_setsigmask(&attributes, &noSignals);
-
-    // Reset all signals to default behavior.
-    //
-    // On Linux, this can only be used to reset signals that are legal to
-    // modify, so we have to take care about the set we use.
-#if defined(__linux__)
-    sigset_t mostSignals;
-    sigemptyset(&mostSignals);
-    for (int i = 1; i < SIGUNUSED; ++i) {
-      if (i == SIGKILL || i == SIGSTOP) continue;
-      sigaddset(&mostSignals, i);
-    }
-    posix_spawnattr_setsigdefault(&attributes, &mostSignals);
-#else
-    sigset_t mostSignals;
-    sigfillset(&mostSignals);
-    sigdelset(&mostSignals, SIGKILL);
-    sigdelset(&mostSignals, SIGSTOP);
-    posix_spawnattr_setsigdefault(&attributes, &mostSignals);
-#endif
-
-    // Establish a separate process group.
-    posix_spawnattr_setpgroup(&attributes, 0);
-
-    // Set the attribute flags.
-    unsigned flags = POSIX_SPAWN_SETSIGMASK | POSIX_SPAWN_SETSIGDEF;
-    flags |= POSIX_SPAWN_SETPGROUP;
-
-    // Close all other files by default.
-    //
-    // FIXME: Note that this is an Apple-specific extension, and we will have to
-    // do something else on other platforms (and unfortunately, there isn't
-    // really an easy answer other than using a stub executable).
-#ifdef __APPLE__
-    flags |= POSIX_SPAWN_CLOEXEC_DEFAULT;
-#endif
-
-    posix_spawnattr_setflags(&attributes, flags);
-
-    // Setup the file actions.
-    posix_spawn_file_actions_t fileActions;
-    posix_spawn_file_actions_init(&fileActions);
-
-    // Open /dev/null as stdin.
-    posix_spawn_file_actions_addopen(
-        &fileActions, 0, "/dev/null", O_RDONLY, 0);
-
-    // If we are capturing output, create a pipe and appropriate spawn actions.
-    int outputPipe[2]{ -1, -1 };
-    if (shouldCaptureOutput) {
-      if (basic::sys::pipe(outputPipe) < 0) {
-        getDelegate().commandProcessHadError(
-            context.job.getForCommand(), handle,
-            Twine("unable to open output pipe (") + strerror(errno) + ")");
-        getDelegate().commandProcessFinished(context.job.getForCommand(),
-                                             handle, CommandResult::Failed, -1);
-        return CommandResult::Failed;
-      }
-
-      // Open the write end of the pipe as stdout and stderr.
-      posix_spawn_file_actions_adddup2(&fileActions, outputPipe[1], 1);
-      posix_spawn_file_actions_adddup2(&fileActions, outputPipe[1], 2);
-
-      // Close the read and write ends of the pipe.
-      posix_spawn_file_actions_addclose(&fileActions, outputPipe[0]);
-      posix_spawn_file_actions_addclose(&fileActions, outputPipe[1]);
-    } else {
-      // Otherwise, propagate the current stdout/stderr.
-      posix_spawn_file_actions_adddup2(&fileActions, 1, 1);
-      posix_spawn_file_actions_adddup2(&fileActions, 2, 2);
-    }
 
     // Form the complete C string command line.
     std::vector<std::string> argsStorage(
@@ -384,70 +306,55 @@ public:
         args[0] = argsStorage[0].c_str();
       }
     }
-      
-    // Spawn the command.
-    pid_t pid;
-    {
-      // We need to hold the spawn processes lock when we spawn, to ensure that
-      // we don't create a process in between when we are cancelled.
-      std::lock_guard<std::mutex> guard(spawnedProcessesMutex);
 
-      if (posix_spawn(&pid, args[0], /*file_actions=*/&fileActions,
-                      /*attrp=*/&attributes, const_cast<char**>(args.data()),
-                      const_cast<char* const*>(envp)) != 0) {
-        getDelegate().commandProcessHadError(
-            context.job.getForCommand(), handle,
-            Twine("unable to spawn process (") + strerror(errno) + ")");
-        getDelegate().commandProcessFinished(context.job.getForCommand(), handle,
-                                             CommandResult::Failed, -1);
-        return CommandResult::Failed;
-      }
-
-      spawnedProcesses.insert(pid);
+    sys::RedirectedProcess process = sys::RedirectedProcess(true);
+    bool pipeSuccess = process.openPipe();
+    if (!pipeSuccess) {
+      getDelegate().commandProcessHadError(
+          context.job.getForCommand(), handle,
+          Twine("unable to open output pipe (") + strerror(errno) + ")");
+      getDelegate().commandProcessFinished(context.job.getForCommand(), handle,
+                                           CommandResult::Failed, -1);
+      return CommandResult::Failed;
     }
 
-    posix_spawn_file_actions_destroy(&fileActions);
-    posix_spawnattr_destroy(&attributes);
+    bool processSuccess =
+        process.execute(args[0], true, const_cast<char *const *>(args.data()),
+                        const_cast<char **>(envp), spawnedProcessesMutex);
+    if (!processSuccess) {
+      getDelegate().commandProcessHadError(context.job.getForCommand(), handle,
+                                           Twine("unable to spawn process (") +
+                                               strerror(errno) + ")");
+      getDelegate().commandProcessFinished(context.job.getForCommand(), handle,
+                                           CommandResult::Failed, -1);
+      return CommandResult::Failed;
+    }
+
+    spawnedProcesses.insert(process);
 
     // Read the command output, if capturing.
     SmallString<1024> outputData;
-    if (shouldCaptureOutput) {
-      // Close the write end of the output pipe.
-      ::close(outputPipe[1]);
-
-      // Read all the data from the output pipe.
-      while (true) {
-        char buf[4096];
-        ssize_t numBytes = read(outputPipe[0], buf, sizeof(buf));
-        if (numBytes < 0) {
-          getDelegate().commandProcessHadError(
-              context.job.getForCommand(), handle,
-              Twine("unable to read process output (") + strerror(errno) + ")");
-          break;
-        }
-
-        if (numBytes == 0)
-          break;
-
-        outputData.insert(outputData.end(), &buf[0], &buf[numBytes]);
-      }
-
-      // Close the read end of the pipe.
-      ::close(outputPipe[0]);
+    bool readSuccess = process.readPipe(outputData);
+    if (!readSuccess) {
+      getDelegate().commandProcessHadError(context.job.getForCommand(), handle,
+                                           Twine("unable to spawn process (") +
+                                               strerror(errno) + ")");
+      getDelegate().commandProcessFinished(context.job.getForCommand(), handle,
+                                           CommandResult::Failed, -1);
+      return CommandResult::Failed;
     }
-    
+
     // Wait for the command to complete.
-    int status, result = waitpid(pid, &status, 0);
-    while (result == -1 && errno == EINTR)
-      result = waitpid(pid, &status, 0);
+    int status;
+    bool waitResult = process.waitForCompletion(&status);
 
     // Update the set of spawned processes.
     {
         std::lock_guard<std::mutex> guard(spawnedProcessesMutex);
-        spawnedProcesses.erase(pid);
+        spawnedProcesses.erase(process);
     }
 
-    if (result == -1) {
+    if (!waitResult) {
       getDelegate().commandProcessHadError(
           context.job.getForCommand(), handle,
           Twine("unable to wait for process (") + strerror(errno) + ")");
@@ -463,7 +370,7 @@ public:
     }
     
     // Notify of the process completion.
-    bool cancelled = WIFSIGNALED(status) && (WTERMSIG(status) == SIGINT || WTERMSIG(status) == SIGKILL);
+    bool cancelled = sys::RedirectedProcess::isProcessCancelledStatus(status);
     CommandResult commandResult = cancelled ? CommandResult::Cancelled : (status == 0) ? CommandResult::Succeeded : CommandResult::Failed;
     getDelegate().commandProcessFinished(context.job.getForCommand(), handle,
                                          commandResult, status);


### PR DESCRIPTION
The code in `NinjaBuildCommand.cpp` and `LaneBasedExecutionQueue.cpp` for creating processes is identical (with a few formatting and comment changes).

This means that we can refactor the code to avoid duplication.

However, refactoring is also necessary to make this more portable to Windows (which will be in a subsequent PR to simplify your work as reviewers).

The process of creating a process and reading input has been split up into multiple sections, based on functionality, and to make it simpler to identify which bits do what. This will also simplify large blocks of platform specific code in the future, and provide an abstraction of behaviour.

In each file, we:
- Open a pipe
- Create a process, and associate the process and the pipe
- Read from the pipe
- Wait until the process closes
- Assess the return result of the process

We also perform related changes such as killing a process. These require us to allow the `RedirectedProcess` abstraction to be hashable and equatable to be contained in `std::unordered_set`. Of course, the hash code and equality code with differ on Windows vs Unix platforms.

As part of aligning the code to be the same in `NinjaBuildCommand` and `LaneBasedExecutionQueue`, **`NinjaBuildCommand` reads into `llvm::SmallString<1024>` rather than `std::vector<char>`

This does incur one behaviour change - NinjaBuildCommand now considers SIGABRT to be a cancellation signal, aligning it with the behaviour of `LaneBasedExecutionQueue.cpp` introduced in #74

@neonichu FYI

Also, there's a TODO in `~RedirectedProcess` that I'd like to call out as I'm not sure what's the right thing to do