### PR TITLE
Fix format specifier warnings compiling NinjaBuildCommand.cpp

### DIFF
--- a/lib/Commands/NinjaBuildCommand.cpp
+++ b/lib/Commands/NinjaBuildCommand.cpp
@@ -1042,7 +1042,7 @@ buildCommand(BuildContext& context, ninja::Command* command) {
                         ("{ \"name\": \"%s\", \"ph\": \"B\", \"pid\": 0, "
                          "\"tid\": %d, \"ts\": %llu},\n"),
                         localCommand->getEffectiveDescription().c_str(), bucket,
-                        startTime);
+                        static_cast<unsigned long long>(startTime));
               });
           }
 
@@ -1056,7 +1056,7 @@ buildCommand(BuildContext& context, ninja::Command* command) {
                         ("{ \"name\": \"%s\", \"ph\": \"E\", \"pid\": 0, "
                          "\"tid\": %d, \"ts\": %llu},\n"),
                         localCommand->getEffectiveDescription().c_str(), bucket,
-                        endTime);
+                        static_cast<unsigned long long>(endTime));
               });
           }
 #endif


### PR DESCRIPTION
> [9/16] Building CXX object lib/Commands/CMakeFiles/llbuildCommands.dir/NinjaBuildCommand.cpp.o
> /mnt/c/Users/hughb/Documents/GitHub/swift-linux/swift-llbuild/lib/Commands/NinjaBuildCommand.cpp:979:25: warning: format specifies type 'unsigned long long' but the argument has type 'uint64_t' (aka 'unsigned long') [-Wformat]
>                        startTime);
 >                       ^~~~~~~~~
> /mnt/c/Users/hughb/Documents/GitHub/swift-linux/swift-llbuild/lib/Commands/NinjaBuildCommand.cpp:993:25: warning: format specifies type 'unsigned long long' but the argument has type 'uint64_t' (aka 'unsigned long') [-Wformat]
 >                       endTime);
 >                       ^~~~~~~
> 2 warnings generated.

This is because `startTime` and `endTime` are `uint64_t`. On Windows x64, it's already `unsigned long long`, but apparently not on my Linux VM