### PR TITLE
Fix environ uses on Windows/MSVC

### DIFF
--- a/lib/BuildSystem/LaneBasedExecutionQueue.cpp
+++ b/lib/BuildSystem/LaneBasedExecutionQueue.cpp
@@ -43,9 +43,11 @@
 using namespace llbuild;
 using namespace llbuild::buildsystem;
 
+#if !defined(_WIN32)
 extern "C" {
   extern char **environ;
 }
+#endif
 
 namespace {
 
@@ -324,7 +326,7 @@ public:
     std::vector<const char*> env(environment.size() + 1);
     char* const* envp = nullptr;
     if (environment.empty()) {
-      envp = ::environ;
+      envp = environ;
     } else {
       for (size_t i = 0; i != envStorage.size(); ++i) {
         env[i] = envStorage[i].c_str();

--- a/lib/Commands/NinjaBuildCommand.cpp
+++ b/lib/Commands/NinjaBuildCommand.cpp
@@ -52,9 +52,11 @@ using namespace llbuild;
 using namespace llbuild::basic;
 using namespace llbuild::commands;
 
+#if !defined(_WIN32)
 extern "C" {
   extern char **environ;
 }
+#endif
 
 static uint64_t getTimeInMicroseconds() {
   llvm::sys::TimeValue now = llvm::sys::TimeValue::now();
@@ -1251,7 +1253,7 @@ buildCommand(BuildContext& context, ninja::Command* command) {
 
         if (posix_spawn(&pid, args[0], /*file_actions=*/&fileActions,
                         /*attrp=*/&attributes, const_cast<char**>(args),
-                        ::environ) != 0) {
+                        environ) != 0) {
           context.emitError("unable to spawn process (%s)", strerror(errno));
           return false;
         }


### PR DESCRIPTION
On Windows/MSVC, environ is not an` extern "C"` field in the global namespace.
Instead, it's a macro that returns a pointer.

Therefore, we get errors trying to declare `extern char **environ`, and we also get errors trying to refer to `::environ`. The fix is to remove `::`, which we can also do on non-Windows/MSVC platforms.

> warning C4273: '__p__environ': inconsistent dll linkage
> error C2589: '(': illegal token on right side of '::'
> error C2059: syntax error: '::' 

I have introduced `#ifdefs` around the `extern "C"` declaration of `environ` to fix the first issue mentioned. Can move them to a platform specific file if you'd like.