### PR TITLE
[BuildSystem] Add support for a base environment.

### DIFF
--- a/docs/buildsystem.rst
+++ b/docs/buildsystem.rst
@@ -390,9 +390,13 @@ attributes on commands, and not at the tool level.
 
    * - env
      - A mapping of keys and values defining the environment to pass to the
-       launched process. If provided, **only** the entries in this mapping will
-       be exposed in the process environment. If not provided, the process will
-       inherit the environment from the client.
+       launched process. See also `inherit-env`.
+
+   * - inherit-env
+     - A boolean flag controlling whether this command should inherit the base
+       environment provided when executing the build system (either from the
+       command line, or via the internal C APIs), or whether it should only
+       include the entries explicitly provided in the `env` mapping above.
 
    * - allow-missing-inputs
      - A boolean value, indicating whether the commands should be allowed to run

--- a/include/llbuild/BuildSystem/BuildExecutionQueue.h
+++ b/include/llbuild/BuildSystem/BuildExecutionQueue.h
@@ -108,8 +108,11 @@ public:
   ///
   /// \param commandLine The command line to execute.
   ///
-  /// \param environment The environment to launch with. If empty, the process
-  /// environment will be inherited.
+  /// \param environment The environment to launch with.
+  ///
+  /// \param inheritEnvironment If true, the supplied environment will be
+  /// overlayed on top base environment supplied when creating the queue. If
+  /// false, only the supplied environment will be passed to the subprocess.
   ///
   /// \returns True on success.
   //
@@ -118,7 +121,8 @@ public:
   virtual bool
   executeProcess(QueueJobContext* context,
                  ArrayRef<StringRef> commandLine,
-                 ArrayRef<std::pair<StringRef, StringRef>> environment) = 0;
+                 ArrayRef<std::pair<StringRef, StringRef>> environment,
+                 bool inheritEnvironment = true) = 0;
 
   /// @}
 
@@ -223,8 +227,8 @@ public:
   /// become invalid as soon as the client returns from this API call.
   ///
   /// \param result - Whether the process suceeded, failed or was cancelled.
-  /// \param exitStatus - The raw exit status of the process, or -1 if an error was
-  /// encountered.
+  /// \param exitStatus - The raw exit status of the process, or -1 if an error
+  /// was encountered.
   //
   // FIXME: Need to include additional information on the status here, e.g., the
   // signal status, and the process output (if buffering).
@@ -236,7 +240,8 @@ public:
 /// Create an execution queue that schedules jobs to individual lanes with a
 /// capped limit on the number of concurrent lanes.
 BuildExecutionQueue *createLaneBasedExecutionQueue(
-    BuildExecutionQueueDelegate& delegate, int numLanes);
+    BuildExecutionQueueDelegate& delegate, int numLanes,
+    const char* const* environment);
 
 }
 }

--- a/include/llbuild/BuildSystem/BuildSystemFrontend.h
+++ b/include/llbuild/BuildSystem/BuildSystemFrontend.h
@@ -295,6 +295,14 @@ public:
   /// The path of the build trace output file to use, if any.
   std::string traceFilePath = "";
 
+  /// The base environment to use when executing subprocesses.
+  ///
+  /// The format is expected to match that of `::main()`, i.e. a null-terminated
+  /// array of pointers to null terminated C strings.
+  ///
+  /// If empty, the environment of the calling process will be used.
+  const char* const* environment = nullptr;
+
   /// The positional arguments.
   std::vector<std::string> positionalArgs;
 

--- a/lib/BuildSystem/BuildSystemFrontend.cpp
+++ b/lib/BuildSystem/BuildSystemFrontend.cpp
@@ -313,7 +313,8 @@ BuildSystemFrontendDelegate::createExecutionQueue() {
   
   if (impl->invocation.useSerialBuild) {
     return std::unique_ptr<BuildExecutionQueue>(
-        createLaneBasedExecutionQueue(impl->executionQueueDelegate, 1));
+        createLaneBasedExecutionQueue(impl->executionQueueDelegate, 1,
+                                      impl->invocation.environment));
   }
     
   // Get the number of CPUs to use.
@@ -327,7 +328,8 @@ BuildSystemFrontendDelegate::createExecutionQueue() {
   }
     
   return std::unique_ptr<BuildExecutionQueue>(
-      createLaneBasedExecutionQueue(impl->executionQueueDelegate, numLanes));
+      createLaneBasedExecutionQueue(impl->executionQueueDelegate, numLanes,
+                                    impl->invocation.environment));
 }
 
 bool BuildSystemFrontendDelegate::isCancelled() {

--- a/products/libllbuild/BuildSystem-C-API.cpp
+++ b/products/libllbuild/BuildSystem-C-API.cpp
@@ -328,7 +328,9 @@ public:
     invocation.buildFilePath =
       cAPIInvocation.buildFilePath ? cAPIInvocation.buildFilePath : "";
     invocation.dbPath = cAPIInvocation.dbPath ? cAPIInvocation.dbPath : "";
-    invocation.traceFilePath = cAPIInvocation.traceFilePath ? cAPIInvocation.traceFilePath : "";
+    invocation.traceFilePath = (
+        cAPIInvocation.traceFilePath ? cAPIInvocation.traceFilePath : "");
+    invocation.environment = cAPIInvocation.environment;
     invocation.useSerialBuild = cAPIInvocation.useSerialBuild;
     invocation.showVerboseStatus = cAPIInvocation.showVerboseStatus;
 

--- a/products/libllbuild/public-api/llbuild/buildsystem.h
+++ b/products/libllbuild/public-api/llbuild/buildsystem.h
@@ -124,7 +124,18 @@ struct llb_buildsystem_invocation_t_ {
 
   /// The path of the build trace output file to use, if any.
   const char* traceFilePath;
-    
+
+  /// The base environment to use when executing subprocesses.
+  ///
+  /// The format is expected to match that of `::main()`, i.e. a null-terminated
+  /// array of pointers to null terminated C strings.
+  ///
+  /// If empty, the environment of the calling process will be used.
+  ///
+  /// The environment is *not* copied by the build invocation, and must remain
+  /// alive for the lifetime of any build using this invocation.
+  const char* const* environment;
+  
   /// Whether to show verbose output.
   //
   // FIXME: This doesn't belong here, move once the status is fully delegated.
@@ -247,7 +258,8 @@ typedef struct llb_buildsystem_delegate_t_ {
   ///
   /// The system guarantees that all such calls will be paired with a
   /// corresponding \see commandFinished() call.
-  bool (*should_command_start)(void* context, llb_buildsystem_command_t* command);
+  bool (*should_command_start)(void* context,
+                               llb_buildsystem_command_t* command);
 
   /// Called when a command has been started.
   ///
@@ -323,6 +335,7 @@ llb_buildsystem_destroy(llb_buildsystem_t* system);
 /// It is an unchecked error for the client to request multiple builds
 /// concurrently.
 ///
+/// \param key The key to build.
 /// \returns True on success, or false if the build was aborted (for example, if
 /// a cycle was discovered).
 LLBUILD_EXPORT bool
@@ -403,8 +416,6 @@ typedef struct llb_buildsystem_external_command_delegate_t_ {
   ///
   /// The contents *MUST* be returned in a new buffer allocated with \see
   /// malloc().
-  //
-  // FIXME: We need to use a better data type than a uint64_t here.
   void (*get_signature)(void* context, llb_buildsystem_command_t* command,
                         llb_data_t* data_out);
 

--- a/products/libllbuild/public-api/llbuild/llbuild.h
+++ b/products/libllbuild/public-api/llbuild/llbuild.h
@@ -31,6 +31,18 @@
 #define LLBUILD_EXPORT extern
 #endif
 
+/// A monotonically increasing indicator of the llbuild API version.
+///
+/// The llbuild API is *not* stable. This value allows clients to conditionally
+/// compile for multiple versions of the API.
+///
+/// Version History:
+///
+/// 1: Added `environment` parameter to llb_buildsystem_invocation_t.
+///
+/// 0: Pre-history
+#define LLBUILD_API_VERSION 1
+
 /// Get the full version of the llbuild library.
 LLBUILD_EXPORT const char* llb_get_full_version_string(void);
 

--- a/tests/BuildSystem/Build/basic.llbuild
+++ b/tests/BuildSystem/Build/basic.llbuild
@@ -9,8 +9,11 @@
 # RUN: diff "%t.build/input A" %t.build/output
 #
 # CHECK: /usr/bin/env
+# CHECK: ENV_KEY=ENV_VALUE_1
 # CHECK-NOT: PATH=
-# CHECK: ENV_KEY=ENV_VALUE
+# CHECK-NEXT: /usr/bin/env
+# CHECK: ENV_KEY=ENV_VALUE_2
+# CHECK: PATH=random-overridden-path
 # CHECK: cp 'input A' output
 
 # Check the engine trace.
@@ -21,7 +24,7 @@
 # CHECK-TRACE: "new-rule", "R1", "Tbasic"
 # CHECK-TRACE: "new-rule", "R2", "Noutput"
 # CHECK-TRACE: "new-rule", "R3", "Ccp-output"
-# CHECK-TRACE: "new-rule", "R4", "N<env>"
+# CHECK-TRACE: "new-rule", "R4", "N<env-2>"
 # CHECK-TRACE: "build-ended"
 
 # Check that a null build does nothing.
@@ -59,16 +62,26 @@ targets:
 default: basic
 
 commands:
-  "<env>":
+  "<env-1>":
     tool: shell
-    outputs: ["<env>"]
+    outputs: ["<env-1>"]
     args: ["/usr/bin/env"]
     env:
-      ENV_KEY: ENV_VALUE
-    
+      ENV_KEY: ENV_VALUE_1
+    inherit-env: false
+
+  "<env-2>":
+    tool: shell
+    inputs: ["<env-1>"]
+    outputs: ["<env-2>"]
+    args: /usr/bin/env | /usr/bin/sort
+    env:
+      ENV_KEY: ENV_VALUE_2
+      PATH: random-overridden-path
+
   cp-output:
     tool: shell
-    inputs: ["input A", "<env>"]
+    inputs: ["input A", "<env-1>", "<env-2>"]
     outputs: ["output"]
     # FIXME: Design a limited mechanism for substitution. Might be tool specific.
     args: ["cp", "input A", "output"]


### PR DESCRIPTION
 - This allows clients to have exact control over the environment used when
   launching subprocesses, as well as individual control on a per-task basis
   over whether or not that environment should be inherited or replaced by an
   individual task.