### PR TITLE
[BuildSystem] Switch BuildValue to use BinaryCoding.

### DIFF
--- a/include/llbuild/Basic/FileInfo.h
+++ b/include/llbuild/Basic/FileInfo.h
@@ -25,6 +25,8 @@
 #ifndef LLBUILD_BASIC_FILEINFO_H
 #define LLBUILD_BASIC_FILEINFO_H
 
+#include "BinaryCoding.h"
+
 #include <cstdint>
 #include <string>
 
@@ -104,6 +106,36 @@ struct FileInfo {
   /// \returns The FileInfo for the given path, which will be missing if the
   /// path does not exist (or any error was encountered).
   static FileInfo getInfoForPath(const std::string& path, bool asLink = false);
+};
+
+template<>
+struct BinaryCodingTraits<FileTimestamp> {
+  static inline void encode(const FileTimestamp& value, BinaryEncoder& coder) {
+    coder.write(value.seconds);
+    coder.write(value.nanoseconds);
+  }
+  static inline void decode(FileTimestamp& value, BinaryDecoder& coder) {
+    coder.read(value.seconds);
+    coder.read(value.nanoseconds);
+  }
+};
+
+template<>
+struct BinaryCodingTraits<FileInfo> {
+  static inline void encode(const FileInfo& value, BinaryEncoder& coder) {
+    coder.write(value.device);
+    coder.write(value.inode);
+    coder.write(value.mode);
+    coder.write(value.size);
+    coder.write(value.modTime);
+  }
+  static inline void decode(FileInfo& value, BinaryDecoder& coder) {
+    coder.read(value.device);
+    coder.read(value.inode);
+    coder.read(value.mode);
+    coder.read(value.size);
+    coder.read(value.modTime);
+  }
 };
 
 }

--- a/lib/BuildSystem/BuildSystem.cpp
+++ b/lib/BuildSystem/BuildSystem.cpp
@@ -130,7 +130,11 @@ public:
 
 class BuildSystemImpl : public BuildSystemCommandInterface {
   /// The internal schema version.
-  static const uint32_t internalSchemaVersion = 4;
+  ///
+  /// Version History:
+  /// * 5: Switch BuildValue to be BinaryCoding based
+  /// * 4: Pre-history
+  static const uint32_t internalSchemaVersion = 5;
   
   BuildSystem& buildSystem;
 

--- a/unittests/BuildSystem/BuildValueTest.cpp
+++ b/unittests/BuildSystem/BuildValueTest.cpp
@@ -40,6 +40,11 @@ TEST(BuildValueTest, virtualValueSerialization) {
     BuildValue a{ std::move(tmp) };
     EXPECT_EQ(a.toData(), BuildValue::makeVirtualInput().toData());
   }
+
+  // Check that a round-tripped value is equivalent.
+  EXPECT_EQ(BuildValue::makeVirtualInput().toData(),
+            BuildValue::fromData(
+                BuildValue::makeVirtualInput().toData()).toData());
 }
 
 TEST(BuildValueTest, commandValueSingleOutputSerialization) {
@@ -69,6 +74,12 @@ TEST(BuildValueTest, commandValueSingleOutputSerialization) {
     EXPECT_EQ(a.toData(),
               BuildValue::makeSuccessfulCommand(infos, signature).toData());
   }
+
+  // Check that a round-tripped value is equivalent.
+  EXPECT_EQ(BuildValue::makeSuccessfulCommand(infos, signature).toData(),
+            BuildValue::fromData(
+                BuildValue::makeSuccessfulCommand(
+                    infos, signature).toData()).toData());
 }
 
 TEST(BuildValueTest, commandValueMultipleOutputsSerialization) {
@@ -99,6 +110,12 @@ TEST(BuildValueTest, commandValueMultipleOutputsSerialization) {
     EXPECT_EQ(a.toData(),
               BuildValue::makeSuccessfulCommand(infos, signature).toData());
   }
+
+  // Check that a round-tripped value is equivalent.
+  EXPECT_EQ(BuildValue::makeSuccessfulCommand(infos, signature).toData(),
+            BuildValue::fromData(
+                BuildValue::makeSuccessfulCommand(
+                    infos, signature).toData()).toData());
 }
 
 }


### PR DESCRIPTION
 - This cleans up some gross code which was trying to use type punning but then
   having to mask off the non-deterministic values

 - Instead, now we just properly encode only the data we wish to, which reduces
   the encoded size of BuildValues significantly in some cases.

 - On average, this reduces the encoded BuildValue size by 50% for all encodings
   done on our test suite.