### PR TITLE
[BuildSystem] Add support for task-level build system tests.

### DIFF
--- a/include/llbuild/BuildSystem/BuildDescription.h
+++ b/include/llbuild/BuildSystem/BuildDescription.h
@@ -318,6 +318,34 @@ public:
   const tool_set& getTools() const { return tools; }
 
   /// @}
+  /// @name Construction Helpers.
+  /// @{
+
+  Node& addNode(std::unique_ptr<Node> value) {
+    auto& result = *value.get();
+    getNodes()[value->getName()] = std::move(value);
+    return result;
+  }
+
+  Target& addTarget(std::unique_ptr<Target> value) {
+    auto& result = *value.get();
+    getTargets()[value->getName()] = std::move(value);
+    return result;
+  }
+
+  Command& addCommand(std::unique_ptr<Command> value) {
+    auto& result = *value.get();
+    getCommands()[value->getName()] = std::move(value);
+    return result;
+  }
+
+  Tool& addTool(std::unique_ptr<Tool> value) {
+    auto& result = *value.get();
+    getTools()[value->getName()] = std::move(value);
+    return result;
+  }
+  
+  /// @}
 };
 
 }

--- a/include/llbuild/BuildSystem/BuildSystem.h
+++ b/include/llbuild/BuildSystem/BuildSystem.h
@@ -16,6 +16,7 @@
 #include "llbuild/Basic/Compiler.h"
 #include "llbuild/Basic/LLVM.h"
 
+#include "llvm/ADT/Optional.h"
 #include "llvm/ADT/StringRef.h"
 
 #include <cstdint>
@@ -33,6 +34,8 @@ namespace buildsystem {
 
 class BuildDescription;
 class BuildExecutionQueue;
+class BuildKey;
+class BuildValue;
 class Command;
 class Tool;
   
@@ -227,6 +230,13 @@ public:
   /// \returns True on success, or false if the build was aborted (for example,
   /// if a cycle was discovered).
   bool build(StringRef target);
+
+  /// Build a specific key directly.
+  ///
+  /// A build description *must* have been loaded before calling this method.
+  ///
+  /// \returns The result of computing the value, or nil if the build failed.
+  llvm::Optional<BuildValue> build(BuildKey target);
 
   /// Cancel the current build
   void cancel();

--- a/llbuild.xcodeproj/project.pbxproj
+++ b/llbuild.xcodeproj/project.pbxproj
@@ -83,6 +83,7 @@
 		E104FAFE1B655C5D005C68A0 /* libcurses.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = E15B6EC61B546A2C00643066 /* libcurses.dylib */; };
 		E104FB001B6568E0005C68A0 /* BuildSystem.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E104FAFF1B6568E0005C68A0 /* BuildSystem.cpp */; };
 		E1066C081BC5ACAB00B892CE /* LaneBasedExecutionQueue.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E1066C071BC5ACAB00B892CE /* LaneBasedExecutionQueue.cpp */; };
+		E1075ED71E4EA417007D52C6 /* BuildSystemTaskTests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E1075ED61E4EA417007D52C6 /* BuildSystemTaskTests.cpp */; };
 		E10D5CDF19FEBF6A00211ED4 /* LitTests.m in Sources */ = {isa = PBXBuildFile; fileRef = E10D5CDE19FEBF6A00211ED4 /* LitTests.m */; };
 		E10D5CE419FEF3BD00211ED4 /* Python.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E10D5CE319FEF3BD00211ED4 /* Python.framework */; };
 		E10D5CE619FEF40100211ED4 /* LitTests.py in Resources */ = {isa = PBXBuildFile; fileRef = E10D5CE519FEF40100211ED4 /* LitTests.py */; };
@@ -165,6 +166,7 @@
 		E1AAD2921BC65B5000F54680 /* SwiftTools.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E1AAD2911BC65B5000F54680 /* SwiftTools.cpp */; };
 		E1ADC23E1A85938C00D5387C /* C-API.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E1ADC2311A85922F00D5387C /* C-API.cpp */; };
 		E1ADC23F1A8593AD00D5387C /* llbuild.h in Headers */ = {isa = PBXBuildFile; fileRef = E1ADC2351A8592AA00D5387C /* llbuild.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		E1B3B9DC1E4D5A7A00DF1FBC /* MockBuildSystemDelegate.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E1B3B9DA1E4D5A7A00DF1FBC /* MockBuildSystemDelegate.cpp */; };
 		E1B838D21B52E86E00DB876B /* Allocator.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E1B838A71B52E85400DB876B /* Allocator.cpp */; };
 		E1B838D31B52E86E00DB876B /* Atomic.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E1B838A81B52E85400DB876B /* Atomic.cpp */; };
 		E1B838D41B52E86E00DB876B /* Debug.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E1B838AA1B52E85400DB876B /* Debug.cpp */; };
@@ -712,6 +714,7 @@
 		E104FAFF1B6568E0005C68A0 /* BuildSystem.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = BuildSystem.cpp; sourceTree = "<group>"; };
 		E1066C071BC5ACAB00B892CE /* LaneBasedExecutionQueue.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = LaneBasedExecutionQueue.cpp; sourceTree = "<group>"; };
 		E1066C091BC5BCE700B892CE /* LLVM.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = LLVM.h; sourceTree = "<group>"; };
+		E1075ED61E4EA417007D52C6 /* BuildSystemTaskTests.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = BuildSystemTaskTests.cpp; sourceTree = "<group>"; };
 		E10D5CDA19FEBF6A00211ED4 /* LitXCTestAdaptor.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = LitXCTestAdaptor.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		E10D5CDD19FEBF6A00211ED4 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		E10D5CDE19FEBF6A00211ED4 /* LitTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = LitTests.m; sourceTree = "<group>"; };
@@ -857,6 +860,8 @@
 		E1ADC2341A85928100D5387C /* README.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
 		E1ADC2351A8592AA00D5387C /* llbuild.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = llbuild.h; sourceTree = "<group>"; };
 		E1ADC23A1A85936400D5387C /* libllbuild.dylib */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.dylib"; includeInIndex = 0; path = libllbuild.dylib; sourceTree = BUILT_PRODUCTS_DIR; };
+		E1B3B9DA1E4D5A7A00DF1FBC /* MockBuildSystemDelegate.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = MockBuildSystemDelegate.cpp; sourceTree = "<group>"; };
+		E1B3B9DB1E4D5A7A00DF1FBC /* MockBuildSystemDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MockBuildSystemDelegate.h; sourceTree = "<group>"; };
 		E1B49EF91B6BD45D0031AFC2 /* BuildSystemCommandInterface.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BuildSystemCommandInterface.h; sourceTree = "<group>"; };
 		E1B49EFA1B6BD45D0031AFC2 /* BuildSystem.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BuildSystem.h; sourceTree = "<group>"; };
 		E1B838A21B52E7DE00DB876B /* libllvmSupport.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libllvmSupport.a; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -1191,7 +1196,10 @@
 			children = (
 				C5740D0D1E0352D800567DD8 /* CMakeLists.txt */,
 				C5740D081E03523100567DD8 /* BuildSystemFrontendTest.cpp */,
+				E1075ED61E4EA417007D52C6 /* BuildSystemTaskTests.cpp */,
 				E192E92E1E30014E00122F17 /* BuildValueTest.cpp */,
+				E1B3B9DA1E4D5A7A00DF1FBC /* MockBuildSystemDelegate.cpp */,
+				E1B3B9DB1E4D5A7A00DF1FBC /* MockBuildSystemDelegate.h */,
 				9DB0478B1DF9D3E2006CDF52 /* LaneBasedExecutionQueueTest.cpp */,
 				9D0A6D7F1E1FFEA800BE636F /* TempDir.cpp */,
 				9D0A6D801E1FFEA800BE636F /* TempDir.h */,
@@ -2631,6 +2639,8 @@
 				9DB047C01DF9F592006CDF52 /* LaneBasedExecutionQueueTest.cpp in Sources */,
 				C5740D091E03523100567DD8 /* BuildSystemFrontendTest.cpp in Sources */,
 				9D0A6D811E1FFEA800BE636F /* TempDir.cpp in Sources */,
+				E1075ED71E4EA417007D52C6 /* BuildSystemTaskTests.cpp in Sources */,
+				E1B3B9DC1E4D5A7A00DF1FBC /* MockBuildSystemDelegate.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/unittests/BuildSystem/BuildSystemTaskTests.cpp
+++ b/unittests/BuildSystem/BuildSystemTaskTests.cpp
@@ -1,0 +1,66 @@
+//===- BuildSystemTaskTests.cpp -------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#include "MockBuildSystemDelegate.h"
+#include "TempDir.h"
+
+#include "llbuild/Basic/LLVM.h"
+#include "llbuild/BuildSystem/BuildDescription.h"
+#include "llbuild/BuildSystem/BuildKey.h"
+#include "llbuild/BuildSystem/BuildValue.h"
+#include "llbuild/BuildSystem/BuildSystem.h"
+
+#include "llvm/ADT/STLExtras.h"
+#include "llvm/Support/FileSystem.h"
+#include "llvm/Support/Path.h"
+#include "llvm/Support/raw_ostream.h"
+
+#include "gtest/gtest.h"
+
+using namespace llvm;
+using namespace llbuild;
+using namespace llbuild::buildsystem;
+using namespace llbuild::unittests;
+
+namespace {
+
+/// Check that we evaluate a path key properly.
+TEST(BuildSystemTaskTests, basics) {
+  TmpDir tempDir{ __FUNCTION__ };
+
+  // Create a smaple file.
+  SmallString<256> path{ tempDir.str() };
+  sys::path::append(path, "a.txt");
+  auto testString = StringRef("Hello, world!\n");
+  {
+    std::error_code ec;
+    llvm::raw_fd_ostream os(path, ec, llvm::sys::fs::F_None);
+    assert(!ec);
+    os << testString;
+  }
+
+  // Create the build system.
+  auto description = llvm::make_unique<BuildDescription>();
+  MockBuildSystemDelegate delegate;
+  BuildSystem system(delegate);
+  system.enableTracing("/tmp/x.trace", nullptr);
+  system.loadDescription(std::move(description));
+
+  // Build a specific key.
+  auto key = BuildKey::makeNode(path);
+  auto result = system.build(key);
+  ASSERT_TRUE(result.hasValue());
+  ASSERT_TRUE(result.getValue().isExistingInput());
+  ASSERT_EQ(result.getValue().getOutputInfo().size, testString.size());
+}
+
+}

--- a/unittests/BuildSystem/CMakeLists.txt
+++ b/unittests/BuildSystem/CMakeLists.txt
@@ -1,6 +1,8 @@
 add_llbuild_unittest(BuildSystemTests
+  BuildSystemTaskTests.cpp
   BuildSystemFrontendTest.cpp
   BuildValueTest.cpp
+  MockBuildSystemDelegate.cpp
   LaneBasedExecutionQueueTest
   TempDir.cpp
   )

--- a/unittests/BuildSystem/MockBuildSystemDelegate.cpp
+++ b/unittests/BuildSystem/MockBuildSystemDelegate.cpp
@@ -1,0 +1,24 @@
+//===- MockBuildSystemDelegate.cpp ----------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#include "MockBuildSystemDelegate.h"
+
+using namespace llvm;
+using namespace llbuild;
+using namespace llbuild::buildsystem;
+using namespace llbuild::unittests;
+
+MockExecutionQueueDelegate::MockExecutionQueueDelegate() {}
+
+MockBuildSystemDelegate::MockBuildSystemDelegate()
+    : BuildSystemDelegate("mock", 0)
+{}

--- a/unittests/BuildSystem/MockBuildSystemDelegate.h
+++ b/unittests/BuildSystem/MockBuildSystemDelegate.h
@@ -1,0 +1,94 @@
+//===- MockBuildSystemDelegate.h --------------------------------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#include "llbuild/BuildSystem/BuildExecutionQueue.h"
+#include "llbuild/BuildSystem/BuildDescription.h"
+#include "llbuild/BuildSystem/BuildSystem.h"
+
+#include "llbuild/Basic/FileSystem.h"
+#include "llbuild/Basic/LLVM.h"
+
+#include <memory>
+
+using namespace llvm;
+using namespace llbuild;
+using namespace llbuild::buildsystem;
+
+namespace llbuild {
+namespace unittests {
+
+class MockExecutionQueueDelegate : public BuildExecutionQueueDelegate {
+public:
+  MockExecutionQueueDelegate();
+
+private:
+  virtual void commandJobStarted(Command*) {}
+
+  virtual void commandJobFinished(Command*) {}
+
+  virtual void commandProcessStarted(Command*, ProcessHandle handle) {}
+
+  virtual void commandProcessHadError(Command*, ProcessHandle handle,
+                                      const Twine& message) {}
+
+  virtual void commandProcessHadOutput(Command*, ProcessHandle handle,
+                                       StringRef data) {}
+  
+  virtual void commandProcessFinished(Command*, ProcessHandle handle,
+                                      CommandResult result,
+                                      int exitStatus) {}
+};
+  
+class MockBuildSystemDelegate : public BuildSystemDelegate {
+  std::unique_ptr<basic::FileSystem> fileSystem =
+    basic::createLocalFileSystem();
+  
+  MockExecutionQueueDelegate executionQueueDelegate;
+  
+public:
+  MockBuildSystemDelegate();
+  
+  virtual basic::FileSystem& getFileSystem() { return *fileSystem; }
+  
+  virtual void setFileContentsBeingParsed(StringRef buffer) {}
+
+  virtual void error(StringRef filename,
+                     const Token& at,
+                     const Twine& message) {}
+
+  virtual std::unique_ptr<Tool> lookupTool(StringRef name) {
+    return nullptr;
+  }
+
+  virtual std::unique_ptr<BuildExecutionQueue> createExecutionQueue() {
+    return std::unique_ptr<BuildExecutionQueue>(
+        createLaneBasedExecutionQueue(executionQueueDelegate, /*numLanes=*/1,
+                                      /*environment=*/nullptr));
+  }
+
+  virtual bool isCancelled() { return false; }
+  
+  virtual void hadCommandFailure() {}
+
+  virtual void commandStatusChanged(Command*, CommandStatusKind) {}
+
+  virtual void commandPreparing(Command*) {}
+
+  virtual bool shouldCommandStart(Command*) { return true; }
+
+  virtual void commandStarted(Command*) { }
+
+  virtual void commandFinished(Command*) {}
+};
+
+}
+}

--- a/unittests/BuildSystem/TempDir.cpp
+++ b/unittests/BuildSystem/TempDir.cpp
@@ -81,8 +81,8 @@ llbuild::TmpDir::TmpDir(llvm::StringRef namePrefix) {
     llvm::sys::path::system_temp_directory(true, tempDirPrefix);
     llvm::sys::path::append(tempDirPrefix, namePrefix);
 
-    std::error_code ec = llvm::sys::fs::createUniqueDirectory
-    (llvm::Twine(tempDirPrefix), tempDir);
+    std::error_code ec = llvm::sys::fs::createUniqueDirectory(
+        tempDirPrefix.str(), tempDir);
     assert(!ec);
     (void)ec;
 }


### PR DESCRIPTION
 - This exposes a new internal API from the BuildSystem which lets clients
   request the results for arbitrary BuildKeys, which in turn lets us unit test
   specific tasks much more effectively, when combined with the previous work to
   allow us to manually build up an in memory build description.