### PR TITLE
[BuildSystem] Don't crash decoding empty values.

### DIFF
--- a/include/llbuild/Basic/BinaryCoding.h
+++ b/include/llbuild/Basic/BinaryCoding.h
@@ -128,6 +128,11 @@ public:
   BinaryDecoder(const std::vector<uint8_t>& data) : BinaryDecoder(
       StringRef(reinterpret_cast<const char*>(data.data()), data.size())) {}
 
+  /// Check if the decoder is at the end of the stream.
+  bool isEmpty() const {
+    return pos == data.size();
+  }
+  
   /// Decode a value from the stream.
   void read(uint8_t& value) { value = read8(); }
   
@@ -148,7 +153,7 @@ public:
 
   /// Finish decoding and clean up.
   void finish() {
-    assert(pos == data.size());
+    assert(isEmpty());
   }
 };
 

--- a/include/llbuild/BuildSystem/BuildValue.h
+++ b/include/llbuild/BuildSystem/BuildValue.h
@@ -316,6 +316,12 @@ struct basic::BinaryCodingTraits<buildsystem::BuildValue::Kind> {
 };
 
 inline buildsystem::BuildValue::BuildValue(basic::BinaryDecoder& decoder) {
+  // Handle empty decode requests.
+  if (decoder.isEmpty()) {
+    kind = BuildValue::Kind::Invalid;
+    return;
+  }
+  
   decoder.read(kind);
   if (kindHasCommandSignature())
     decoder.read(commandSignature);

--- a/unittests/BuildSystem/BuildValueTest.cpp
+++ b/unittests/BuildSystem/BuildValueTest.cpp
@@ -20,6 +20,12 @@ using namespace llvm;
 
 namespace {
 
+/// We should support decoding an empty value without crashing.
+TEST(BuildValueTest, emptyDecode) {
+  auto result = BuildValue::fromData(core::ValueType());
+  EXPECT_EQ(result.toData(), BuildValue::makeInvalid().toData());
+}
+
 TEST(BuildValueTest, virtualValueSerialization) {
   // Check that two identical values are equivalent.
   {


### PR DESCRIPTION
 - We don't generally use this, but it is convenient to support empty values as
   a valid sentinel.