### PR TITLE
[BuildSystem] Add support for directory signatures.

### DIFF
--- a/include/llbuild/Basic/BinaryCoding.h
+++ b/include/llbuild/Basic/BinaryCoding.h
@@ -76,6 +76,11 @@ public:
     write(uint32_t(value >> 32));
   }
 
+  /// Encode a sequence of bytes to the stream.
+  void writeBytes(StringRef bytes) {
+    data.insert(data.end(), bytes.begin(), bytes.end());
+  }
+
   /// Encode a value to the stream.
   template<typename T>
   void write(T value) {
@@ -124,7 +129,10 @@ public:
   /// Construct a binary decoder. 
   BinaryDecoder(StringRef data) : data(data) {}
   
-  /// Construct a binary decoder. 
+  /// Construct a binary decoder.
+  ///
+  /// NOTE: The input data is supplied by reference, and its lifetime must
+  /// exceed that of the decoder.
   BinaryDecoder(const std::vector<uint8_t>& data) : BinaryDecoder(
       StringRef(reinterpret_cast<const char*>(data.data()), data.size())) {}
 
@@ -144,6 +152,16 @@ public:
 
   /// Decode a value from the stream.
   void read(uint64_t& value) { value = read64(); }
+
+  /// Decode a byte string from the stream.
+  ///
+  /// NOTE: The return value points into the decode stream, and must be copied
+  /// by clients if it is to last longer than the lifetime of the decoder.
+  void readBytes(size_t count, StringRef& value) {
+    assert(pos + count <= data.size());
+    value = StringRef(data.begin() + pos, count);
+    pos += count;
+  }
 
   /// Decode a value from the stream.
   template<typename T>

--- a/include/llbuild/BuildSystem/BuildKey.h
+++ b/include/llbuild/BuildSystem/BuildKey.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2015 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See http://swift.org/LICENSE.txt for license information
@@ -38,6 +38,9 @@ public:
 
     /// A key used to identify directory contents.
     DirectoryContents,
+
+    /// A key used to identify the signature of a complete directory tree.
+    DirectoryTreeSignature,
 
     /// A key used to identify a node.
     Node,
@@ -96,6 +99,11 @@ public:
     return BuildKey('D', path);
   }
 
+  /// Create a key for computing the contents of a directory.
+  static BuildKey makeDirectoryTreeSignature(StringRef path) {
+    return BuildKey('S', path);
+  }
+
   /// Create a key for computing a node result.
   static BuildKey makeNode(StringRef path) {
     return BuildKey('N', path);
@@ -122,6 +130,7 @@ public:
     case 'C': return Kind::Command;
     case 'D': return Kind::DirectoryContents;
     case 'N': return Kind::Node;
+    case 'S': return Kind::DirectoryTreeSignature;
     case 'T': return Kind::Target;
     case 'X': return Kind::CustomTask;
     default:
@@ -133,6 +142,9 @@ public:
   bool isCustomTask() const { return getKind() == Kind::CustomTask; }
   bool isDirectoryContents() const {
     return getKind() == Kind::DirectoryContents;
+  }
+  bool isDirectoryTreeSignature() const {
+    return getKind() == Kind::DirectoryTreeSignature;
   }
   bool isNode() const { return getKind() == Kind::Node; }
   bool isTarget() const { return getKind() == Kind::Target; }
@@ -159,6 +171,11 @@ public:
 
   StringRef getDirectoryContentsPath() const {
     assert(isDirectoryContents());
+    return StringRef(key.data()+1, key.size()-1);
+  }
+
+  StringRef getDirectoryTreeSignaturePath() const {
+    assert(isDirectoryTreeSignature());
     return StringRef(key.data()+1, key.size()-1);
   }
 

--- a/include/llbuild/BuildSystem/BuildKey.h
+++ b/include/llbuild/BuildSystem/BuildKey.h
@@ -36,6 +36,9 @@ public:
     /// A key used to identify a custom task.
     CustomTask,
 
+    /// A key used to identify directory contents.
+    DirectoryContents,
+
     /// A key used to identify a node.
     Node,
 
@@ -88,6 +91,11 @@ public:
     return BuildKey('X', name, taskData);
   }
 
+  /// Create a key for computing the contents of a directory.
+  static BuildKey makeDirectoryContents(StringRef path) {
+    return BuildKey('D', path);
+  }
+
   /// Create a key for computing a node result.
   static BuildKey makeNode(StringRef path) {
     return BuildKey('N', path);
@@ -112,6 +120,7 @@ public:
   Kind getKind() const {
     switch (key[0]) {
     case 'C': return Kind::Command;
+    case 'D': return Kind::DirectoryContents;
     case 'N': return Kind::Node;
     case 'T': return Kind::Target;
     case 'X': return Kind::CustomTask;
@@ -121,8 +130,11 @@ public:
   }
 
   bool isCommand() const { return getKind() == Kind::Command; }
-  bool isNode() const { return getKind() == Kind::Node; }
   bool isCustomTask() const { return getKind() == Kind::CustomTask; }
+  bool isDirectoryContents() const {
+    return getKind() == Kind::DirectoryContents;
+  }
+  bool isNode() const { return getKind() == Kind::Node; }
   bool isTarget() const { return getKind() == Kind::Target; }
 
   StringRef getCommandName() const {
@@ -143,6 +155,11 @@ public:
     memcpy(&nameSize, &key[1], sizeof(uint32_t));
     uint32_t dataSize = key.size() - 1 - sizeof(uint32_t) - nameSize;
     return StringRef(&key[1 + sizeof(uint32_t) + nameSize], dataSize);
+  }
+
+  StringRef getDirectoryContentsPath() const {
+    assert(isDirectoryContents());
+    return StringRef(key.data()+1, key.size()-1);
   }
 
   StringRef getNodeName() const {

--- a/include/llbuild/BuildSystem/BuildValue.h
+++ b/include/llbuild/BuildSystem/BuildValue.h
@@ -155,7 +155,7 @@ private:
   }
   
   /// Create a build value containing directory contents.
-  BuildValue(Kind kind, FileInfo directoryInfo, ArrayRef<StringRef> values)
+  BuildValue(Kind kind, FileInfo directoryInfo, ArrayRef<std::string> values)
       : BuildValue(kind, directoryInfo)
   {
     // Construct the concatenated data.
@@ -264,7 +264,7 @@ public:
     return BuildValue(Kind::MissingInput);
   }
   static BuildValue makeDirectoryContents(FileInfo directoryInfo,
-                                          ArrayRef<StringRef> values) {
+                                          ArrayRef<std::string> values) {
     return BuildValue(Kind::DirectoryContents, directoryInfo, values);
   }
   static BuildValue makeMissingOutput() {

--- a/include/llbuild/BuildSystem/BuildValue.h
+++ b/include/llbuild/BuildSystem/BuildValue.h
@@ -24,6 +24,8 @@
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/raw_ostream.h"
 
+#include <vector>
+
 namespace llvm {
 class raw_ostream;
 }
@@ -48,6 +50,9 @@ class BuildValue {
 
     /// A value produced by a missing input file.
     MissingInput,
+
+    /// The contents of a directory.
+    DirectoryContents,
 
     /// A value produced by a command which succeeded, but whose output was
     /// missing.
@@ -89,20 +94,37 @@ class BuildValue {
   uint64_t commandSignature = 0;
 
   union {
-    /// The file info for the rule output, for existing inputs and successful
-    /// commands with a single output.
+    /// The file info for the rule output, for existing inputs, successful
+    /// commands with a single output, and directory contents.
     FileInfo asOutputInfo;
 
     /// The file info for successful commands with multiple outputs.
     FileInfo* asOutputInfos;
   } valueData = { {} };
 
+  /// String list storage.
+  //
+  // FIXME: We are currently paying the cost for carrying this around on every
+  // value, which is very wasteful. We need to redesign this type to be
+  // customized to each exact value.
+  struct {
+    /// The values are packed as a sequence of C strings.
+    char* contents;
+
+    /// The total length of the contents.
+    uint64_t size;
+  } stringValues = {0, 0};
+
   bool kindHasCommandSignature() const {
     return isSuccessfulCommand();
   }
 
+  bool kindHasStringList() const {
+    return isDirectoryContents();
+  }
+
   bool kindHasOutputInfo() const {
-    return isExistingInput() || isSuccessfulCommand();
+    return isExistingInput() || isSuccessfulCommand() || isDirectoryContents();
   }
   
 private:
@@ -131,6 +153,39 @@ private:
       }
     }
   }
+  
+  /// Create a build value containing directory contents.
+  BuildValue(Kind kind, FileInfo directoryInfo, ArrayRef<StringRef> values)
+      : BuildValue(kind, directoryInfo)
+  {
+    // Construct the concatenated data.
+    uint64_t size = 0;
+    for (auto value: values) {
+      size += value.size() + 1;
+    }
+    char *p, *contents = p = new char[size];
+    for (auto value: values) {
+      assert(value.find('\0') == StringRef::npos);
+      memcpy(p, value.data(), value.size());
+      p += value.size();
+      *p++ = '\0';
+    }
+    stringValues.contents = contents;
+    stringValues.size = size;
+  }
+
+  
+  std::vector<StringRef> getStringListValues() const {
+    assert(kindHasStringList());
+    std::vector<StringRef> result;
+    for (uint64_t i = 0; i < stringValues.size;) {
+      auto value = StringRef(&stringValues.contents[i]);
+      assert(i + value.size() <= stringValues.size);
+      result.push_back(value);
+      i += value.size() + 1;
+    }
+    return result;
+  }
 
   FileInfo& getNthOutputInfo(unsigned n) {
     assert(kindHasOutputInfo() && "invalid call for value kind");
@@ -155,6 +210,10 @@ public:
     } else {
       valueData.asOutputInfo = rhs.valueData.asOutputInfo;
     }
+    if (rhs.kindHasStringList()) {
+      stringValues = rhs.stringValues;
+      rhs.stringValues.contents = nullptr;
+    }
   }
   BuildValue& operator=(BuildValue&& rhs) {
     if (this != &rhs) {
@@ -172,12 +231,19 @@ public:
       } else {
         valueData.asOutputInfo = rhs.valueData.asOutputInfo;
       }
+      if (rhs.kindHasStringList()) {
+        stringValues = rhs.stringValues;
+        rhs.stringValues.contents = nullptr;
+      }
     }
     return *this;
   }
   ~BuildValue() {
     if (hasMultipleOutputs()) {
       delete[] valueData.asOutputInfos;
+    }
+    if (kindHasStringList()) {
+      delete[] stringValues.contents;
     }
   }
 
@@ -196,6 +262,10 @@ public:
   }
   static BuildValue makeMissingInput() {
     return BuildValue(Kind::MissingInput);
+  }
+  static BuildValue makeDirectoryContents(FileInfo directoryInfo,
+                                          ArrayRef<StringRef> values) {
+    return BuildValue(Kind::DirectoryContents, directoryInfo, values);
   }
   static BuildValue makeMissingOutput() {
     return BuildValue(Kind::MissingOutput);
@@ -233,6 +303,8 @@ public:
   bool isExistingInput() const { return kind == Kind::ExistingInput; }
   bool isMissingInput() const { return kind == Kind::MissingInput; }
 
+  bool isDirectoryContents() const { return kind == Kind::DirectoryContents; }
+  
   bool isMissingOutput() const { return kind == Kind::MissingOutput; }
   bool isFailedInput() const { return kind == Kind::FailedInput; }
   bool isSuccessfulCommand() const {return kind == Kind::SuccessfulCommand; }
@@ -243,6 +315,11 @@ public:
   bool isCancelledCommand() const { return kind == Kind::CancelledCommand; }
   bool isSkippedCommand() const { return kind == Kind::SkippedCommand; }
   bool isTarget() const { return kind == Kind::Target; }
+
+  std::vector<StringRef> getDirectoryContents() const {
+    assert(isDirectoryContents() && "invalid call for value kind");
+    return getStringListValues();
+  }
 
   bool hasMultipleOutputs() const {
     return numOutputInfos > 1;
@@ -303,38 +380,45 @@ template<>
 struct basic::BinaryCodingTraits<buildsystem::BuildValue::Kind> {
   typedef buildsystem::BuildValue::Kind Kind;
   
-  static inline void encode(Kind& value, BinaryEncoder& encoder) {
+  static inline void encode(Kind& value, BinaryEncoder& coder) {
     uint8_t tmp = uint8_t(value);
     assert(value == Kind(tmp));
-    encoder.write(tmp);
+    coder.write(tmp);
   }
-  static inline void decode(Kind& value, BinaryDecoder& decoder) {
+  static inline void decode(Kind& value, BinaryDecoder& coder) {
     uint8_t tmp;
-    decoder.read(tmp);
+    coder.read(tmp);
     value = Kind(tmp);
   }
 };
 
-inline buildsystem::BuildValue::BuildValue(basic::BinaryDecoder& decoder) {
+inline buildsystem::BuildValue::BuildValue(basic::BinaryDecoder& coder) {
   // Handle empty decode requests.
-  if (decoder.isEmpty()) {
+  if (coder.isEmpty()) {
     kind = BuildValue::Kind::Invalid;
     return;
   }
   
-  decoder.read(kind);
+  coder.read(kind);
   if (kindHasCommandSignature())
-    decoder.read(commandSignature);
+    coder.read(commandSignature);
   if (kindHasOutputInfo()) {
-    decoder.read(numOutputInfos);
+    coder.read(numOutputInfos);
     if (numOutputInfos > 1) {
-        valueData.asOutputInfos = new FileInfo[numOutputInfos];
+      valueData.asOutputInfos = new FileInfo[numOutputInfos];
     }
     for (uint32_t i = 0; i != numOutputInfos; ++i) {
-      decoder.read(getNthOutputInfo(i));
+      coder.read(getNthOutputInfo(i));
     }
   }
-  decoder.finish();
+  if (kindHasStringList()) {
+    coder.read(stringValues.size);
+    StringRef contents;
+    coder.readBytes(stringValues.size, contents);
+    stringValues.contents = new char[stringValues.size];
+    memcpy(stringValues.contents, contents.data(), contents.size());
+  }
+  coder.finish();
 }
 
 inline core::ValueType buildsystem::BuildValue::toData() const {
@@ -347,6 +431,10 @@ inline core::ValueType buildsystem::BuildValue::toData() const {
     for (uint32_t i = 0; i != numOutputInfos; ++i) {
       coder.write(getNthOutputInfo(i));
     }
+  }
+  if (kindHasStringList()) {
+    coder.write(stringValues.size);
+    coder.writeBytes(StringRef(stringValues.contents, stringValues.size));
   }
   return coder.contents();
 }

--- a/lib/BuildSystem/BuildKey.cpp
+++ b/lib/BuildSystem/BuildKey.cpp
@@ -25,6 +25,7 @@ StringRef BuildKey::stringForKind(BuildKey::Kind kind) {
 #define CASE(kind) case Kind::kind: return #kind
     CASE(Command);
     CASE(CustomTask);
+    CASE(DirectoryContents);
     CASE(Node);
     CASE(Target);
     CASE(Unknown);
@@ -43,6 +44,10 @@ void BuildKey::dump(raw_ostream& os) const {
   case Kind::CustomTask: {
     os << ", name='" << getCustomTaskName() << "'";
     os << ", dataSize='" << getCustomTaskData().size() << "'";
+    break;
+  }
+  case Kind::DirectoryContents: {
+    os << ", name='" << getDirectoryContentsPath() << "'";
     break;
   }
   case Kind::Node: {

--- a/lib/BuildSystem/BuildKey.cpp
+++ b/lib/BuildSystem/BuildKey.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2015 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See http://swift.org/LICENSE.txt for license information
@@ -26,6 +26,7 @@ StringRef BuildKey::stringForKind(BuildKey::Kind kind) {
     CASE(Command);
     CASE(CustomTask);
     CASE(DirectoryContents);
+    CASE(DirectoryTreeSignature);
     CASE(Node);
     CASE(Target);
     CASE(Unknown);
@@ -47,7 +48,11 @@ void BuildKey::dump(raw_ostream& os) const {
     break;
   }
   case Kind::DirectoryContents: {
-    os << ", name='" << getDirectoryContentsPath() << "'";
+    os << ", path='" << getDirectoryContentsPath() << "'";
+    break;
+  }
+  case Kind::DirectoryTreeSignature: {
+    os << ", path='" << getDirectoryTreeSignaturePath() << "'";
     break;
   }
   case Kind::Node: {

--- a/lib/BuildSystem/BuildSystem.cpp
+++ b/lib/BuildSystem/BuildSystem.cpp
@@ -588,6 +588,7 @@ class DirectoryContentsTask : public Task {
     if (info.isMissing()) {
       engine.taskIsComplete(
           this, BuildValue::makeMissingInput().toData());
+      return;
     }
 
     // Get the list of files in the directory.

--- a/lib/BuildSystem/BuildValue.cpp
+++ b/lib/BuildSystem/BuildValue.cpp
@@ -26,6 +26,7 @@ StringRef BuildValue::stringForKind(BuildValue::Kind kind) {
     CASE(VirtualInput);
     CASE(ExistingInput);
     CASE(MissingInput);
+    CASE(DirectoryContents);
     CASE(MissingOutput);
     CASE(FailedInput);
     CASE(SuccessfulCommand);
@@ -41,7 +42,7 @@ StringRef BuildValue::stringForKind(BuildValue::Kind kind) {
   
 void BuildValue::dump(raw_ostream& os) const {
   os << "BuildValue(" << stringForKind(kind);
-  if (isExistingInput() || isSuccessfulCommand()) {
+  if (kindHasOutputInfo()) {
     os << ", outputInfos=[";
     for (unsigned i = 0; i != getNumOutputs(); ++i) {
       auto& info = getNthOutputInfo(i);
@@ -57,6 +58,17 @@ void BuildValue::dump(raw_ostream& os) const {
            << ", modTime=(" << info.modTime.seconds
            << ":" << info.modTime.nanoseconds << "}";
       }
+    }
+    os << "]";
+  }
+  if (kindHasStringList()) {
+    std::vector<StringRef> values = getStringListValues();
+    os << ", values=[";
+    for (unsigned i = 0; i != values.size(); ++i) {
+      if (i != 0) os << ", ";
+      os << '"';
+      os.write_escaped(values[i]);
+      os << '"';
     }
     os << "]";
   }

--- a/lib/BuildSystem/BuildValue.cpp
+++ b/lib/BuildSystem/BuildValue.cpp
@@ -27,6 +27,7 @@ StringRef BuildValue::stringForKind(BuildValue::Kind kind) {
     CASE(ExistingInput);
     CASE(MissingInput);
     CASE(DirectoryContents);
+    CASE(DirectoryTreeSignature);
     CASE(MissingOutput);
     CASE(FailedInput);
     CASE(SuccessfulCommand);
@@ -42,6 +43,9 @@ StringRef BuildValue::stringForKind(BuildValue::Kind kind) {
   
 void BuildValue::dump(raw_ostream& os) const {
   os << "BuildValue(" << stringForKind(kind);
+  if (kindHasCommandSignature()) {
+    os << ", signature=" << commandSignature;
+  }
   if (kindHasOutputInfo()) {
     os << ", outputInfos=[";
     for (unsigned i = 0; i != getNumOutputs(); ++i) {
@@ -67,7 +71,8 @@ void BuildValue::dump(raw_ostream& os) const {
     for (unsigned i = 0; i != values.size(); ++i) {
       if (i != 0) os << ", ";
       os << '"';
-      os.write_escaped(values[i]);
+      os << values[i];
+      //      os.write_escaped(values[i]);
       os << '"';
     }
     os << "]";

--- a/lib/Core/BuildEngine.cpp
+++ b/lib/Core/BuildEngine.cpp
@@ -382,6 +382,10 @@ private:
     }
 
     // If the rule indicates its computed value is out of date, it needs to run.
+    //
+    // FIXME: We should probably try and move this so that it can be done by
+    // clients in the background, either by us backgrounding it, or by using a
+    // completion model as we do for inputs.
     if (ruleInfo.rule.isResultValid &&
         !ruleInfo.rule.isResultValid(buildEngine, ruleInfo.rule,
                                      ruleInfo.result.value)) {

--- a/unittests/Basic/BinaryCodingTests.cpp
+++ b/unittests/Basic/BinaryCodingTests.cpp
@@ -83,6 +83,25 @@ TEST(BinaryCodingTests, basic) {
   checkRoundtrip(uint64_t(0xABCD01234567DCBAULL));
 }
 
+TEST(BinaryCodingTests, bytes) {
+  BinaryEncoder encoder;
+  encoder.writeBytes(StringRef("hello"));
+  encoder.writeBytes(StringRef("world"));
+  auto result = encoder.contents();
+
+  // Check the raw encoding.
+  EXPECT_EQ(StringRef((char*)result.data(), result.size()),
+            StringRef("helloworld"));
+
+  // Check the decode.
+  BinaryDecoder decoder(result);
+  StringRef s1, s2;
+  decoder.readBytes(5, s1);
+  decoder.readBytes(5, s2);
+  EXPECT_EQ(s1, StringRef("hello"));
+  EXPECT_EQ(s2, StringRef("world"));
+}
+
 TEST(BinaryCodingTests, customType) {
   // Check the coding of basic types.
   checkRoundtrip(CustomType{ 0xABCD, 0x1234 });

--- a/unittests/BuildSystem/BuildSystemTaskTests.cpp
+++ b/unittests/BuildSystem/BuildSystemTaskTests.cpp
@@ -94,9 +94,8 @@ TEST(BuildSystemTaskTests, directoryContents) {
   {
     auto result = system.build(BuildKey::makeDirectoryContents(tempDir.str()));
     ASSERT_TRUE(result.hasValue());
-    ASSERT_TRUE(result.getValue().isDirectoryContents());
-    ASSERT_EQ(result.getValue().getDirectoryContents(),
-              std::vector<StringRef>({
+    ASSERT_TRUE(result->isDirectoryContents());
+    ASSERT_EQ(result->getDirectoryContents(), std::vector<StringRef>({
                   StringRef("fileA"), StringRef("fileB") }));
   }
 
@@ -105,8 +104,81 @@ TEST(BuildSystemTaskTests, directoryContents) {
     auto result = system.build(BuildKey::makeDirectoryContents(
                                    tempDir.str() + "/missing-subpath"));
     ASSERT_TRUE(result.hasValue());
-    ASSERT_TRUE(result.getValue().isMissingInput());
+    ASSERT_TRUE(result->isMissingInput());
   }
+}
+
+
+/// Check the evaluation of directory signatures.
+TEST(BuildSystemTaskTests, directorySignature) {
+  TmpDir tempDir{ __FUNCTION__ };
+
+  // Create a directory with sample files.
+  SmallString<256> fileA{ tempDir.str() };
+  sys::path::append(fileA, "fileA");
+  SmallString<256> fileB{ tempDir.str() };
+  sys::path::append(fileB, "fileB");
+  {
+    std::error_code ec;
+    llvm::raw_fd_ostream os(fileA, ec, llvm::sys::fs::F_Text);
+    assert(!ec);
+    os << "fileA";
+  }
+  {
+    std::error_code ec;
+    llvm::raw_fd_ostream os(fileB, ec, llvm::sys::fs::F_Text);
+    assert(!ec);
+    os << "fileB";
+  } 
+  SmallString<256> subdirA{ tempDir.str() };
+  sys::path::append(subdirA, "subdirA");
+  (void) llvm::sys::fs::create_directories(subdirA.str());
+  SmallString<256> subdirFileA{ subdirA };
+  sys::path::append(subdirFileA, "subdirFileA");
+  {
+    std::error_code ec;
+    llvm::raw_fd_ostream os(subdirFileA, ec, llvm::sys::fs::F_Text);
+    assert(!ec);
+    os << "subdirFileA";
+  }
+  
+  // Create the build system.
+  auto keyToBuild = BuildKey::makeDirectoryTreeSignature(tempDir.str());
+  auto description = llvm::make_unique<BuildDescription>();
+  MockBuildSystemDelegate delegate;
+  BuildSystem system(delegate);
+  system.loadDescription(std::move(description));
+
+  // Build an initial value.
+  auto resultA = system.build(keyToBuild);
+  ASSERT_TRUE(resultA.hasValue() && resultA->isDirectoryTreeSignature());
+
+  // Modify the immediate directory and rebuild.
+  SmallString<256> fileC{ tempDir.str() };
+  sys::path::append(fileC, "fileC");
+  {
+    std::error_code ec;
+    llvm::raw_fd_ostream os(fileC, ec, llvm::sys::fs::F_Text);
+    assert(!ec);
+    os << "fileC";
+  }
+  auto resultB = system.build(keyToBuild);
+  ASSERT_TRUE(resultB.hasValue() && resultB->isDirectoryTreeSignature());
+  ASSERT_TRUE(resultA->toData() != resultB->toData());
+
+  // Modify the subdirectory and rebuild.
+  SmallString<256> subdirFileD{ subdirA };
+  sys::path::append(subdirFileD, "fileD");
+  {
+    std::error_code ec;
+    llvm::raw_fd_ostream os(subdirFileD, ec, llvm::sys::fs::F_Text);
+    assert(!ec);
+    os << "fileD";
+  }
+  auto resultC = system.build(keyToBuild);
+  ASSERT_TRUE(resultC.hasValue() && resultC->isDirectoryTreeSignature());
+  ASSERT_TRUE(resultA->toData() != resultB->toData());
+  ASSERT_TRUE(resultA->toData() != resultC->toData());
 }
 
 }

--- a/unittests/BuildSystem/BuildSystemTaskTests.cpp
+++ b/unittests/BuildSystem/BuildSystemTaskTests.cpp
@@ -91,11 +91,22 @@ TEST(BuildSystemTaskTests, directoryContents) {
   system.loadDescription(std::move(description));
 
   // Build a specific key.
-  auto result = system.build(BuildKey::makeDirectoryContents(tempDir.str()));
-  ASSERT_TRUE(result.hasValue());
-  ASSERT_TRUE(result.getValue().isDirectoryContents());
-  ASSERT_EQ(result.getValue().getDirectoryContents(),
-            std::vector<StringRef>({ StringRef("fileA"), StringRef("fileB") }));
+  {
+    auto result = system.build(BuildKey::makeDirectoryContents(tempDir.str()));
+    ASSERT_TRUE(result.hasValue());
+    ASSERT_TRUE(result.getValue().isDirectoryContents());
+    ASSERT_EQ(result.getValue().getDirectoryContents(),
+              std::vector<StringRef>({
+                  StringRef("fileA"), StringRef("fileB") }));
+  }
+
+  // Check that a missing directory behaves properly.
+  {
+    auto result = system.build(BuildKey::makeDirectoryContents(
+                                   tempDir.str() + "/missing-subpath"));
+    ASSERT_TRUE(result.hasValue());
+    ASSERT_TRUE(result.getValue().isMissingInput());
+  }
 }
 
 }

--- a/unittests/BuildSystem/BuildValueTest.cpp
+++ b/unittests/BuildSystem/BuildValueTest.cpp
@@ -126,7 +126,7 @@ TEST(BuildValueTest, commandValueMultipleOutputsSerialization) {
 
 TEST(BuildValueTest, directoryListValues) {
   basic::FileInfo mockInfo{};
-  std::vector<StringRef> strings{ "hello", "world" };
+  std::vector<std::string> strings{ "hello", "world" };
   
   // Check that two identical values are equivalent.
   {

--- a/unittests/BuildSystem/BuildValueTest.cpp
+++ b/unittests/BuildSystem/BuildValueTest.cpp
@@ -124,4 +124,41 @@ TEST(BuildValueTest, commandValueMultipleOutputsSerialization) {
                     infos, signature).toData()).toData());
 }
 
+TEST(BuildValueTest, directoryListValues) {
+  basic::FileInfo mockInfo{};
+  std::vector<StringRef> strings{ "hello", "world" };
+  
+  // Check that two identical values are equivalent.
+  {
+    BuildValue a = BuildValue::makeDirectoryContents(mockInfo, strings);
+    EXPECT_EQ(a.toData(),
+              BuildValue::makeDirectoryContents(mockInfo, strings).toData());
+  }
+
+  // Check that a moved complex value is equivalent.
+  {
+    BuildValue tmp = BuildValue::makeDirectoryContents(mockInfo, strings);
+    BuildValue a = std::move(tmp);
+    EXPECT_EQ(a.toData(),
+              BuildValue::makeDirectoryContents(mockInfo, strings).toData());
+  }
+
+  // Check that an rvalue initialized complex value is equivalent.
+  {
+    BuildValue tmp = BuildValue::makeDirectoryContents(mockInfo, strings);
+    BuildValue a{ std::move(tmp) };
+    EXPECT_EQ(a.toData(),
+              BuildValue::makeDirectoryContents(mockInfo, strings).toData());
+  }
+
+  // Check the contents are correct.
+  {
+    BuildValue tmp = BuildValue::makeDirectoryContents(mockInfo, strings);
+    auto result = tmp.getDirectoryContents();
+    EXPECT_EQ(result.size(), 2U);
+    EXPECT_EQ(result[0], "hello");
+    EXPECT_EQ(result[1], "world");
+  }
+}
+
 }


### PR DESCRIPTION
 - This is another new task type which computes a recursive signature of
   a complete directory tree.

 - This isn't yet as efficient as it absolutely could be, because it
   ends up using both a node and directory contents input which
   duplicate some data, but this is expected to be a fairly heavyweight
   task now anyway.

 - This does not yet properly handle symbolic links, and still isn't
   used by anything real yet...

 - The signature is intentionally constructed so that it will always end up
   accumulating dependency edges on any nodes in the graph which produce the
   contents of the directory, for files which exist. It does *not* attempt to
   scan the entire dependency graph to accumulate edges on nodes which are not
   produced, thus clients are currently required to explicitly ensure some other
   ordering exists between this task and any task which produces output in the
   directory.

If you are curious about the performance, here are some ad hoc
benchmarks taken on a large directory subtree with ~75k nodes in
it. Times are taken on a MacBook Pro with an SSD:

* Initial snapshot, w/o database: 2.2s
* Initial snapshot, w/  database: 4.0s
  * Incremental update          : 4.3s
  * Database size               : 57MB
* `find <path> | wc -l`         : 0.5s

We can do better by avoiding the redundant work and taking more care to
ensure all IO is async, but this seems like a reasonable start.