### PR TITLE
[BuildSystem] Add support for directory nodes.

### DIFF
--- a/include/llbuild/BuildSystem/BuildNode.h
+++ b/include/llbuild/BuildSystem/BuildNode.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2015 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See http://swift.org/LICENSE.txt for license information
@@ -32,6 +32,11 @@ namespace buildsystem {
   
 // FIXME: Figure out how this is going to be organized.
 class BuildNode : public Node {
+  /// Whether or not this node is a directory.
+  //
+  // FIXME: We need a type enumeration here.
+  bool directory;
+
   /// Whether or not this node is "virtual" (i.e., not a filesystem path).
   bool virtualNode;
 
@@ -48,12 +53,17 @@ class BuildNode : public Node {
   bool mutated;
 
 public:
-  explicit BuildNode(StringRef name, bool isVirtual, bool isCommandTimestamp,
-                     bool isMutated)
-      : Node(name), virtualNode(isVirtual),
+  explicit BuildNode(StringRef name, bool isDirectory, bool isVirtual,
+                     bool isCommandTimestamp, bool isMutated)
+      : Node(name), directory(isDirectory), virtualNode(isVirtual),
         commandTimestamp(isCommandTimestamp), mutated(isMutated) {}
 
+  /// Check whether this is a "virtual" (non-filesystem related) node.
   bool isVirtual() const { return virtualNode; }
+
+  /// Check whether this node is intended to represent a directory's contents
+  /// recursively.
+  bool isDirectory() const { return directory; }
 
   bool isCommandTimestamp() const { return commandTimestamp; }
 

--- a/lib/BuildSystem/BuildNode.cpp
+++ b/lib/BuildSystem/BuildNode.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2015 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See http://swift.org/LICENSE.txt for license information
@@ -25,9 +25,22 @@ using namespace llbuild::buildsystem;
 
 bool BuildNode::configureAttribute(const ConfigureContext& ctx, StringRef name,
                                    StringRef value) {
-  if (name == "is-virtual") {
+  if (name == "is-directory") {
+    if (value == "true") {
+      directory = true;
+      virtualNode = false;
+    } else if (value == "false") {
+      directory = false;
+    } else {
+      ctx.error("invalid value: '" + value + "' for attribute '"
+                + name + "'");
+      return false;
+    }
+    return true;
+  } else if (name == "is-virtual") {
     if (value == "true") {
       virtualNode = true;
+      directory = false;
     } else if (value == "false") {
       virtualNode = false;
       commandTimestamp = false;
@@ -41,6 +54,7 @@ bool BuildNode::configureAttribute(const ConfigureContext& ctx, StringRef name,
     if (value == "true") {
       commandTimestamp = true;
       virtualNode = true;
+      directory = false;
     } else if (value == "false") {
       commandTimestamp = false;
     } else {

--- a/lib/BuildSystem/ExternalCommand.cpp
+++ b/lib/BuildSystem/ExternalCommand.cpp
@@ -243,12 +243,15 @@ void ExternalCommand::provideValue(BuildSystemCommandInterface& bsci,
   assert(!value.hasMultipleOutputs());
   assert(value.isExistingInput() || value.isMissingInput() ||
          value.isMissingOutput() || value.isFailedInput() ||
-         value.isVirtualInput()  || value.isSkippedCommand());
+         value.isVirtualInput()  || value.isSkippedCommand() ||
+         value.isDirectoryTreeSignature());
 
   // If the input should cause this command to skip, how should it skip?
   auto getSkipValueForInput = [&]() -> llvm::Optional<BuildValue> {
-    // If the value is an existing or virtual input, we are always good.
-    if (value.isExistingInput() || value.isVirtualInput())
+    // If the value is an signature, existing, or virtual input, we are always
+    // good.
+    if (value.isDirectoryTreeSignature() | value.isExistingInput() ||
+        value.isVirtualInput())
       return llvm::None;
 
     // We explicitly allow running the command against a missing output, under

--- a/tests/Examples/buildsystem-capi.llbuild
+++ b/tests/Examples/buildsystem-capi.llbuild
@@ -25,6 +25,9 @@ tools: { "fancy": {} }
 targets:
   "": ["<all>"]
 
+nodes:
+  "/": { "is-directory": false }
+
 commands:
   "<all>":
     tool: phony


### PR DESCRIPTION
 - This adapts the directory tree signature so that it can finally be used in a
   build file to express dependencies for commands which consider their input
   paths recursively.

 - <rdar://problem/22640399> [llbuild] Add support for dependencies on directory contents