### PR TITLE
[BuildSystem] Directory tree signatures must include path value.

### DIFF
--- a/docs/buildsystem.rst
+++ b/docs/buildsystem.rst
@@ -59,11 +59,11 @@ These are the supported node types:
 * File Nodes: A node is by default assumed to represent a path in the filesystem
   with the same name as the node.
 
-* Directory Nodes: A node ending with "/" is assumed to represent a *directory tree*,
-  not an individual file. The node's value will be a signature of the recursive
-  contents of the entire directory tree at that path, and any changes to any
-  part of the directory structure will causes commands taking it as an input to
-  rerun.
+* Directory Tree Nodes: A node ending with "/" is assumed to represent a
+  *directory tree*, not an individual file. The node's value will be a signature
+  of the recursive contents of the entire directory tree at that path, and any
+  changes to any part of the directory structure will causes commands taking it
+  as an input to rerun.
 
   For example, in the following build file fragment ``C1`` uses a directory node
   because the task is doing a recursive copy of the input directory::
@@ -74,7 +74,14 @@ These are the supported node types:
           inputs: ["input/"]
           outputs: ["output/"]
           args: rm -rf output && cp -r input output
-    
+
+  .. note::
+    It is legal to use a directory tree node to refer to a path which is
+    *actually* just a file; the node will be considered as changed whenever the
+    file on disk is changed. This is useful when the client cannot easily know
+    in advance whether the node is expected to be a file or a directory, but
+    should be treated as a directory tree if it is one.
+  
 * Virtual Nodes: Nodes matching the name ``'<.*>'``, e.g. ``<gate-task>``, are
   *assumed* to be virtual nodes, and are used for adding arbitrary edges to the
   graph. Virtual nodes carry no value and only will only cause commands to

--- a/tests/BuildSystem/Build/directory-tree-signatures.llbuild
+++ b/tests/BuildSystem/Build/directory-tree-signatures.llbuild
@@ -1,0 +1,71 @@
+# Check the handling of directory tree signatures.
+#
+# We check the node used against three kinds of directories: missing, a file, an
+# actual directory.
+#
+# RUN: rm -rf %t.build
+# RUN: mkdir -p %t.build
+# RUN: cp %s %t.build/build.llbuild
+# RUN: mkdir -p %t.build/dir
+# RUN: echo "file" > %t.build/file
+# RUN: %{llbuild} buildsystem build --serial --chdir %t.build > %t.initial.out
+# RUN: %{FileCheck} --check-prefix=CHECK-INITIAL --input-file=%t.initial.out %s
+#
+# CHECK-INITIAL: DTS-MISSING-CHANGED
+# CHECK-INITIAL: DTS-FILE-CHANGED
+# CHECK-INITIAL: DTS-DIR-CHANGED
+
+
+# Check that a null build does nothing.
+#
+# RUN: echo "START." > %t.rebuild.out
+# RUN: %{llbuild} buildsystem build --serial --chdir %t.build >> %t.rebuild.out
+# RUN: echo "EOF" >> %t.rebuild.out
+# RUN: %{FileCheck} --check-prefix=CHECK-REBUILD --input-file=%t.rebuild.out %s
+#
+# CHECK-REBUILD: START
+# CHECK-REBUILD-NOT: DTS-
+# CHECK-REBUILD-NEXT: EOF
+
+
+# Check that modifications are detected.
+#
+# RUN: mkdir -p %t.build/missing-dir
+# RUN: mkdir -p %t.build/dir/subdir
+# RUN: echo "modified" > %t.build/file
+# RUN: %{llbuild} buildsystem build --serial --chdir %t.build > %t.modified.out
+# RUN: %{FileCheck} --check-prefix=CHECK-MODIFIED --input-file=%t.modified.out %s
+#
+# CHECK-MODIFIED: DTS-MISSING-CHANGED
+# CHECK-MODIFIED: DTS-FILE-CHANGED
+# CHECK-MODIFIED: DTS-DIR-CHANGED
+
+client:
+  name: basic
+
+targets:
+  "": ["<all>"]
+
+commands:
+  C.all:
+    tool: phony
+    inputs: ["<D-missing>", "<D-file>", "<D-dir>"]
+    outputs: ["<all>"]
+  C.D-missing:
+    tool: shell
+    description: DTS-MISSING-CHANGED
+    inputs: ["missing-dir/"]
+    outputs: ["<D-missing>"]
+    args: true
+  C.D-file:
+    tool: shell
+    description: DTS-FILE-CHANGED
+    inputs: ["file/", "<D-missing>"]
+    outputs: ["<D-file>"]
+    args: true
+  C.D-dir:
+    tool: shell
+    description: DTS-DIR-CHANGED
+    inputs: ["dir/", "<D-file>"]
+    outputs: ["<D-dir>"]
+    args: true


### PR DESCRIPTION
 - This was an oversight -- normally this isn't required because the values for
   each recursively requested node end up serving as a signature for the
   top-level directory. However, when the top-level item *isn't* a directory,
   but is a missing directory or a file, then this fails.

 - <rdar://problem/30638878> Directory based dependencies need to be behave properly when tracking non-directories