### PR TITLE
[libllbuild] Add support for build system reuse.

### DIFF
--- a/examples/c-api/buildsystem/main.c
+++ b/examples/c-api/buildsystem/main.c
@@ -213,9 +213,15 @@ int main(int argc, char **argv) {
     
   // Create a build system.
   llb_buildsystem_t* system = llb_buildsystem_create(delegate, invocation);
-    
-  // Build the default target.
+
+  // Initialize the system.
+  llb_buildsystem_initialize(system);
+  
+  // Build the default target, twice.
   llb_data_t key = { 0, NULL };
+  printf("initial build:\n");
+  llb_buildsystem_build(system, &key);
+  printf("second build:\n");
   llb_buildsystem_build(system, &key);
 
   // Destroy the build system.

--- a/products/libllbuild/BuildSystem-C-API.cpp
+++ b/products/libllbuild/BuildSystem-C-API.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2015 - 2016 Apple Inc. and the Swift project authors
+// Copyright (c) 2015 - 2017 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See http://swift.org/LICENSE.txt for license information
@@ -355,6 +355,10 @@ public:
     return *frontend;
   }
 
+  bool initialize() {
+    return getFrontend().initialize();
+  }
+
   bool build(const core::KeyType& key) {
     // Reset mutable build state.
     frontendDelegate->resetForBuild();
@@ -502,6 +506,11 @@ llb_buildsystem_tool_create(const llb_data_t* name,
   assert(delegate.create_command);
   return (llb_buildsystem_tool_t*) new CAPITool(
       StringRef((const char*)name->data, name->length), delegate);
+}
+
+bool llb_buildsystem_initialize(llb_buildsystem_t* system_p) {
+  CAPIBuildSystem* system = (CAPIBuildSystem*) system_p;
+  return system->initialize();
 }
 
 bool llb_buildsystem_build(llb_buildsystem_t* system_p, const llb_data_t* key) {

--- a/products/libllbuild/public-api/llbuild/buildsystem.h
+++ b/products/libllbuild/public-api/llbuild/buildsystem.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2015 - 2016 Apple Inc. and the Swift project authors
+// Copyright (c) 2015 - 2017 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See http://swift.org/LICENSE.txt for license information
@@ -330,10 +330,30 @@ llb_buildsystem_create(llb_buildsystem_delegate_t delegate,
 LLBUILD_EXPORT void
 llb_buildsystem_destroy(llb_buildsystem_t* system);
 
+/// Initialize the build system.
+///
+/// This will load the build manifest and apply any other options (for example,
+/// attaching the database).
+///
+/// Clients may use a single build system for many separate build
+/// invocations. When used this way, the underlying system will transparently
+/// cache the contents of the manifest as well as database results which can
+/// result in a significant performance improvement for builds in little
+/// substantive work is performed.
+///
+/// \returns True on success, or false if the system could not be
+/// initialized. It is a programmatic error to attempt to use the system after
+/// initialization has failed.
+LLBUILD_EXPORT bool
+llb_buildsystem_initialize(llb_buildsystem_t* system);
+
 /// Build the named target.
 ///
 /// It is an unchecked error for the client to request multiple builds
 /// concurrently.
+///
+/// This will automatically initialize the build system if it has not already
+/// been initialized.
 ///
 /// \param key The key to build.
 /// \returns True on success, or false if the build was aborted (for example, if

--- a/tests/Examples/buildsystem-capi.llbuild
+++ b/tests/Examples/buildsystem-capi.llbuild
@@ -6,6 +6,7 @@
 # RUN: %{FileCheck} %s --input-file %t.out
 #
 # CHECK: -- read file contents: {{.*}}/buildsystem-capi.llbuild
+# CHECK: initial build:
 # CHECK: -- stat: /
 # CHECK: command_started: <hello> -- HELLO
 # CHECK: command_finished: <hello>
@@ -14,6 +15,10 @@
 # CHECK: command_finished: <fancy-thing>
 # CHECK: command_started: <error> -- FAILING-COMMAND
 # CHECK: had_command_failure
+# CHECK: <unknown>:0: error: build had 1 command failure
+#
+# CHECK: second build:
+# CHECK: command_started: <error> -- FAILING-COMMAND
 # CHECK: <unknown>:0: error: build had 1 command failure
 
 client:


### PR DESCRIPTION
 - This adds llb_buildsystem_initialize() so that the initialize is clearly
   separated from the build and to make it explicit the system can be reused for
   multiple builds.