### PR TITLE
Increase cancellation robustness

### DIFF
--- a/lib/BuildSystem/BuildSystemFrontend.cpp
+++ b/lib/BuildSystem/BuildSystemFrontend.cpp
@@ -340,10 +340,16 @@ bool BuildSystemFrontendDelegate::isCancelled() {
 
 void BuildSystemFrontendDelegate::cancel() {
   // FIXME: We should audit that a build is happening.
+  if (isCancelled_) {
+    return;
+  }
   isCancelled_ = true;
 
   auto delegateImpl = static_cast<BuildSystemFrontendDelegateImpl*>(impl);
-  delegateImpl->system->cancel();
+  auto system = delegateImpl->system;
+  if (system) {
+    system->cancel();
+  }
 }
 
 void BuildSystemFrontendDelegate::resetForBuild() {


### PR DESCRIPTION
Calling `cancel()` on already cancelled builds should be a nop. Also guard against the underlying `system` being deallocated.