### PR TITLE
[BuildSystem] Ensure we create directories recursively.

### DIFF
--- a/include/llbuild/Basic/FileSystem.h
+++ b/include/llbuild/Basic/FileSystem.h
@@ -48,6 +48,12 @@ public:
   virtual bool
   createDirectory(const std::string& path) = 0;
 
+  /// Create the given directory (recursively) if it does not exist.
+  ///
+  /// \returns True on success (the directory was created, or already exists).
+  virtual bool
+  createDirectories(const std::string& path);
+
   /// Get a memory buffer for a given file on the file system.
   ///
   /// \returns The file contents, on success, or null on error.

--- a/lib/Basic/FileSystem.cpp
+++ b/lib/Basic/FileSystem.cpp
@@ -13,6 +13,7 @@
 #include "llbuild/Basic/FileSystem.h"
 
 #include "llvm/ADT/STLExtras.h"
+#include "llvm/Support/Path.h"
 #include "llvm/Support/MemoryBuffer.h"
 
 #include <cassert>
@@ -23,6 +24,19 @@ using namespace llbuild;
 using namespace llbuild::basic;
 
 FileSystem::~FileSystem() {}
+
+bool FileSystem::createDirectories(const std::string& path) {
+  // Attempt to create the final directory first, to optimize for the common
+  // case where we don't need to recurse.
+  if (createDirectory(path))
+    return true;
+
+  // If that failed, attempt to create the parent.
+  StringRef parent = llvm::sys::path::parent_path(path);
+  if (parent.empty())
+    return false;
+  return createDirectories(parent) && createDirectory(path);
+}
 
 namespace {
 

--- a/lib/BuildSystem/BuildSystem.cpp
+++ b/lib/BuildSystem/BuildSystem.cpp
@@ -1871,7 +1871,7 @@ class MkdirCommand : public ExternalCommand {
                                                Task* task,
                                                QueueJobContext* context) override {
     auto output = getOutputs()[0];
-    if (!bsci.getDelegate().getFileSystem().createDirectory(
+    if (!bsci.getDelegate().getFileSystem().createDirectories(
             output->getName())) {
       getBuildSystem(bsci.getBuildEngine()).error(
           "", "unable to create directory '" + output->getName() + "'");
@@ -2075,12 +2075,10 @@ class SymlinkCommand : public Command {
       // Create the directory containing the symlink, if necessary.
       //
       // FIXME: Shared behavior with ExternalCommand.
-      //
-      // FIXME: Need to use the filesystem interfaces.
       {
         auto parent = llvm::sys::path::parent_path(output->getName());
         if (!parent.empty()) {
-          (void) bsci.getDelegate().getFileSystem().createDirectory(parent);
+          (void) bsci.getDelegate().getFileSystem().createDirectories(parent);
         }
       }
 

--- a/lib/BuildSystem/ExternalCommand.cpp
+++ b/lib/BuildSystem/ExternalCommand.cpp
@@ -13,6 +13,7 @@
 #include "llbuild/BuildSystem/ExternalCommand.h"
 
 #include "llbuild/Basic/Hashing.h"
+#include "llbuild/Basic/FileSystem.h"
 #include "llbuild/BuildSystem/BuildExecutionQueue.h"
 #include "llbuild/BuildSystem/BuildFile.h"
 #include "llbuild/BuildSystem/BuildKey.h"
@@ -398,7 +399,7 @@ void ExternalCommand::inputsAvailable(BuildSystemCommandInterface& bsci,
         // FIXME: Need to use the filesystem interfaces.
         auto parent = llvm::sys::path::parent_path(node->getName());
         if (!parent.empty()) {
-          (void) llvm::sys::fs::create_directories(parent);
+          (void) bsci.getDelegate().getFileSystem().createDirectories(parent);
         }
       }
     }

--- a/lib/BuildSystem/SwiftTools.cpp
+++ b/lib/BuildSystem/SwiftTools.cpp
@@ -566,8 +566,8 @@ public:
     //
     // FIXME: This should really be done using an additional implicit input, so
     // it only happens once per build.
-    (void)llvm::sys::fs::create_directories(tempsPath, /*ignoreExisting=*/true);
-
+    (void) bsci.getDelegate().getFileSystem().createDirectories(tempsPath);
+ 
     SmallString<64> outputFileMapPath;
     getOutputFileMapPath(outputFileMapPath);
     

--- a/tests/BuildSystem/Build/output-dir-creation.llbuild
+++ b/tests/BuildSystem/Build/output-dir-creation.llbuild
@@ -5,8 +5,8 @@
 # RUN: cp %s %t.build/build.llbuild
 # RUN: %{llbuild} buildsystem build --serial --chdir %t.build > %t.out
 # RUN: test -d %t.build/subdir
-# RUN: test -f %t.build/subdir/file
-# RUN: test -L %t.build/subdir-2/symlink
+# RUN: test -f %t.build/subdir/subsubdir/file
+# RUN: test -L %t.build/subdir-2/subsubdir/symlink
 # RUN: %{FileCheck} --input-file=%t.out %s
 #
 # CHECK: TOUCH
@@ -21,15 +21,15 @@ targets:
 commands:
   C.all:
     tool: phony
-    inputs: ["subdir/file", "subdir-2/symlink"]
+    inputs: ["subdir/subsubdir/file", "subdir-2/subsubdir/symlink"]
     outputs: ["<all>"]
   C.touch:
     tool: shell
     description: TOUCH
-    args: ["touch", "subdir/file"]
-    outputs: ["subdir/file"]
+    args: ["touch", "subdir/subsubdir/file"]
+    outputs: ["subdir/subsubdir/file"]
   C.symlink:
     tool: symlink
     description: SYMLINK
-    outputs: ["subdir-2/symlink"]
+    outputs: ["subdir-2/subsubdir/symlink"]
     contents: ignored


### PR DESCRIPTION
 - Several callsites were left out of previous refactor to use the new
   FileSystem interface, which meant we were only doing this sometimes. This
   fixes all callsites to use the new interface, and also adds test coverage of
   symlink needing to create directories recursively.