### PR TITLE
Only expect one dependency file when using WMO

### DIFF
--- a/lib/BuildSystem/BuildSystem.cpp
+++ b/lib/BuildSystem/BuildSystem.cpp
@@ -1381,6 +1381,11 @@ class ShellCommand : public ExternalCommand {
       return false;
     }
 
+    // Dependency information is only emitted for the first file when using WMO
+    if (isSwiftC() && usesWMO()) {
+      depsPaths.resize(1);
+    }
+
     for (const auto& depsPath: depsPaths) {
       // Read the dependencies file.
       auto input = bsci.getDelegate().getFileSystem().getFileContents(depsPath);
@@ -1498,6 +1503,24 @@ class ShellCommand : public ExternalCommand {
     DepsActions actions(bsci, task, this, depsPath);
     core::DependencyInfoParser(input->getBuffer(), actions).parse();
     return actions.numErrors == 0;
+  }
+
+  bool isSwiftC() {
+    for (const auto& arg: args) {
+      if (StringRef(arg).endswith("swiftc")) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  bool usesWMO() {
+    for (const auto& arg: args) {
+      if (arg == "-whole-module-optimization") {
+        return true;
+      }
+    }
+    return false;
   }
 
 public:


### PR DESCRIPTION
When using WMO, swiftc will only emit one dependency file for the whole build. This will be the one for the first file passed on the commandline.

This is pretty gross, though, since `ShellCommand` now contains Swift specific code and we are hard-coding assumptions about `swiftc` behaviour. I think eventually the output-file-map should give us the necessary information.

Fixes <rdar://problem/30927754>