### PR TITLE
<rdar://problem/25014088> [XCBuild] Cross process locking for shared build state files

### DIFF
--- a/include/llbuild/Core/BuildDB.h
+++ b/include/llbuild/Core/BuildDB.h
@@ -69,7 +69,9 @@ public:
   /// The engine guarantees that all mutation operations (e.g., \see
   /// setCurrentIteration() and \see setRuleResult()) are only called between
   /// build paired \see buildStarted() and \see buildComplete() calls.
-  virtual void buildStarted() = 0;
+  ///
+  /// \param error_out [out] Error string if return value is false.
+  virtual bool buildStarted(std::string* error_out) = 0;
 
   /// Called by the build engine to indicate a build has finished, and results
   /// should be written.

--- a/lib/Core/BuildEngine.cpp
+++ b/lib/Core/BuildEngine.cpp
@@ -1112,8 +1112,15 @@ public:
   /// @{
 
   const ValueType& build(const KeyType& key) {
-    if (db)
-      db->buildStarted();
+    if (db) {
+      std::string error;
+      bool result = db->buildStarted(&error);
+      if (!result) {
+        delegate.error(error);
+        static ValueType emptyValue{};
+        return emptyValue;
+      }
+    }
 
     // Increment our running iteration count.
     //

--- a/unittests/Core/BuildEngineTest.cpp
+++ b/unittests/Core/BuildEngineTest.cpp
@@ -436,7 +436,7 @@ TEST(BuildEngineTest, incrementalDependency) {
       ruleResults[rule.key] = result;
       return true;
     }
-    virtual void buildStarted() override {}
+    virtual bool buildStarted(std::string* error_out) override { return true; }
     virtual void buildComplete() override {}
   };
   CustomDB *db = new CustomDB();

--- a/unittests/Core/SQLiteBuildDBTest.cpp
+++ b/unittests/Core/SQLiteBuildDBTest.cpp
@@ -50,3 +50,40 @@ TEST(SQLiteBuildDBTest, ErrorHandling) {
     ec = llvm::sys::fs::remove(dbPath.str());
     EXPECT_EQ(bool(ec), false);
 }
+
+TEST(SQLiteBuildDBTest, LockedWhileBuilding) {
+  // Create a temporary file.
+  llvm::SmallString<256> dbPath;
+  auto ec = llvm::sys::fs::createTemporaryFile("build", "db", dbPath);
+  EXPECT_EQ(bool(ec), false);
+  const char* path = dbPath.c_str();
+  fprintf(stderr, "using db: %s\n", path);
+
+  std::string error;
+  std::unique_ptr<BuildDB> buildDB = createSQLiteBuildDB(dbPath, 1, &error);
+  EXPECT_TRUE(buildDB != nullptr);
+  EXPECT_EQ(error, "");
+
+  std::unique_ptr<BuildDB> secondBuildDB = createSQLiteBuildDB(dbPath, 1, &error);
+  EXPECT_TRUE(buildDB != nullptr);
+  EXPECT_EQ(error, "");
+
+  bool result = buildDB->buildStarted(&error);
+  EXPECT_TRUE(result);
+  EXPECT_EQ(error, "");
+
+  // Tests that we cannot start a second build with an existing connection
+  result = secondBuildDB->buildStarted(&error);
+  EXPECT_FALSE(result);
+  std::stringstream out;
+  out << "error: accessing build database \"" << path << "\": database is locked Possibly there are two concurrent builds running in the same filesystem location.";
+  EXPECT_EQ(error, out.str());
+
+  // Tests that we cannot create new connections while a build is running
+  std::unique_ptr<BuildDB> otherBuildDB = createSQLiteBuildDB(dbPath, 1, &error);
+  EXPECT_TRUE(otherBuildDB == nullptr);
+  EXPECT_EQ(error, out.str());
+
+  ec = llvm::sys::fs::remove(dbPath.str());
+  EXPECT_EQ(bool(ec), false);
+}


### PR DESCRIPTION
Use exclusive locking for transactions when writing to the build database. Since we use a single transaction for the build, this effectively prohibits a second build from using the same database.