### PR TITLE
Fix mkdir usage on Windows

### DIFF
--- a/include/llbuild/Basic/PlatformUtility.h
+++ b/include/llbuild/Basic/PlatformUtility.h
@@ -33,6 +33,7 @@ using StatStruct = struct ::stat;
 bool chdir(const char *fileName);
 int close(int fileHandle);
 int lstat(const char *fileName, StatStruct *buf);
+bool mkdir(const char *fileName);
 int pclose(FILE *stream);
 int pipe(int ptHandles[2]);
 FILE *popen(const char *command, const char *mode);

--- a/lib/Basic/FileSystem.cpp
+++ b/lib/Basic/FileSystem.cpp
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "llbuild/Basic/FileSystem.h"
+#include "llbuild/Basic/PlatformUtility.h"
 
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/Support/Path.h"
@@ -18,7 +19,6 @@
 
 #include <cassert>
 #include <cstring>
-#include <sys/stat.h>
 
 using namespace llbuild;
 using namespace llbuild::basic;
@@ -46,7 +46,7 @@ public:
 
   virtual bool
   createDirectory(const std::string& path) override {
-    if (::mkdir(path.c_str(), S_IRWXU | S_IRWXG |  S_IRWXO) == -1) {
+    if (!sys::mkdir(path.c_str())) {
       if (errno != EEXIST) {
         return false;
       }

--- a/lib/Basic/PlatformUtility.cpp
+++ b/lib/Basic/PlatformUtility.cpp
@@ -11,6 +11,7 @@
 
 #if defined(_WIN32)
 #include "LeanWindows.h"
+#include <direct.h>
 #include <io.h>
 #else
 #include <stdio.h>
@@ -43,6 +44,14 @@ int sys::lstat(const char *fileName, sys::StatStruct *buf) {
   return ::_stat(fileName, buf);
 #else
   return ::lstat(fileName, buf);
+#endif
+}
+
+bool sys::mkdir(const char* fileName) {
+#if defined(_WIN32)
+  return _mkdir(fileName) == 0;
+#else
+  return ::mkdir(fileName, S_IRWXU | S_IRWXG |  S_IRWXO) == 0;
 #endif
 }
 


### PR DESCRIPTION
Windows has no equivilent of `S_IRWXU | S_IRWXG |  S_IRWXO`

However, it exposes `_mkdir(1)` in` <direct.h>`: https://msdn.microsoft.com/en-us/library/2fkk4dzw.aspx