### PR TITLE
[BuildSystem] Fix bug where directory contents were always recomputed.

### DIFF
--- a/lib/BuildSystem/BuildSystem.cpp
+++ b/lib/BuildSystem/BuildSystem.cpp
@@ -681,7 +681,7 @@ public:
     if (info.isMissing()) {
       return value.isMissingInput();
     } else {
-      return value.isExistingInput() && value.getOutputInfo() == info;
+      return value.isDirectoryContents() && value.getOutputInfo() == info;
     }
   }
 };

--- a/tests/BuildSystem/Build/directory-contents.llbuild
+++ b/tests/BuildSystem/Build/directory-contents.llbuild
@@ -1,0 +1,42 @@
+# Check that directory contents are rebuilt *only* when appropriate.
+#
+# RUN: rm -rf %t.build
+# RUN: mkdir -p %t.build
+# RUN: cp %s %t.build/build.llbuild
+# RUN: mkdir -p %t.build/dir
+# RUN: %{llbuild} buildsystem build --serial --trace %t.initial.trace --chdir %t.build
+# RUN: %{FileCheck} --check-prefix=CHECK-INITIAL --input-file=%t.initial.trace %s
+#
+# CHECK-INITIAL: { "new-rule", "[[RULE_NAME:R[0-9]+]]", "Ddir" },
+# CHECK-INITIAL: { "rule-needs-to-run", "[[RULE_NAME]]", "never-built" },
+
+
+# A null rebuild shouldn't rebuild the directory.
+#
+# RUN: %{llbuild} buildsystem build --serial --trace %t.rebuild.trace --chdir %t.build
+# RUN: %{FileCheck} --check-prefix=CHECK-REBUILD --input-file=%t.rebuild.trace %s
+#
+# CHECK-REBUILD: { "new-rule", "[[RULE_NAME:R[0-9]+]]", "Ddir" },
+# CHECK-REBUILD: { "rule-does-not-need-to-run", "[[RULE_NAME]]" },
+
+
+# A rebuild after adding a new file should rebuild the directory.
+#
+# RUN: touch %t.build/dir/file
+# RUN: %{llbuild} buildsystem build --serial --trace %t.modified.trace --chdir %t.build
+# RUN: %{FileCheck} --check-prefix=CHECK-MODIFIED --input-file=%t.modified.trace %s
+#
+# CHECK-MODIFIED: { "new-rule", "[[RULE_NAME:R[0-9]+]]", "Ddir" },
+# CHECK-MODIFIED: { "rule-needs-to-run", "[[RULE_NAME]]", "invalid-value" },
+
+client:
+  name: basic
+
+targets:
+  "": ["<all>"]
+
+commands:
+  C.all:
+    tool: phony
+    inputs: ["dir/"]
+    outputs: ["<all>"]


### PR DESCRIPTION
 - Reapplied with a fix for the directory signature test to esnure that the
   directory is actually modified (as reported by stat()) before the check which
   requires that.

 - This exposes some infragility in caching the directory contents, at least on
   some systems (this test failed regularly on Ubuntu 16.05), but at least for
   now we still rely on that ability for better or worse.

 - <rdar://problem/30640443> Directory contents nodes are always
   rebuilding