### PR TITLE
Consolidate common code between NinjaBuildCommand.cpp and LaneBasedExecutionQueue.cpp

### DIFF
--- a/lib/Commands/NinjaBuildCommand.cpp
+++ b/lib/Commands/NinjaBuildCommand.cpp
@@ -24,6 +24,7 @@
 #include "llbuild/Core/MakefileDepsParser.h"
 #include "llbuild/Ninja/ManifestLoader.h"
 
+#include "llvm/ADT/SmallString.h"
 #include "llvm/Support/TimeValue.h"
 
 #include "CommandLineStatusOutput.h"
@@ -1267,7 +1268,7 @@ buildCommand(BuildContext& context, ninja::Command* command) {
       posix_spawnattr_destroy(&attributes);
 
       // Read the command output, if buffering.
-      std::vector<char> outputData;
+      SmallString<1024> outputData;
       if (!isConsole) {
         // Close the write end of the output pipe.
         ::close(pipe[1]);

--- a/lib/Commands/NinjaBuildCommand.cpp
+++ b/lib/Commands/NinjaBuildCommand.cpp
@@ -1320,7 +1320,8 @@ buildCommand(BuildContext& context, ninja::Command* command) {
       if (status != 0) {
         // If the process was killed by SIGINT, assume it is because we were
         // interrupted.
-        if (WIFSIGNALED(status) && WTERMSIG(status) == SIGINT)
+        bool cancelled = WIFSIGNALED(status) && (WTERMSIG(status) == SIGINT || WTERMSIG(status) == SIGKILL);
+        if (cancelled)
           return false;
 
         // Otherwise, report the failure.


### PR DESCRIPTION
#98 refactors the common code between `NinjaBuildCommand.cpp` and `LaneBasedExecutionQueue.cpp` for creating, piping, waiting and killing processes.

The code in LaneBasedExecutionQueue is a bit more clean, and the ordering is different. I've extracted these changes from #98 as it is independent from #89 so won't cause merge conflicts. #98 needs a rethink in approach so might take some time. This is not affected

LaneBasedExecutionQueue has subtle differences such as using `llvm::SmallString` and counting both `SIGKILL` and `SIGINT` as cancellation signals