### PR TITLE
Add expected failures for mkdir.llbuild on WSL

### DIFF
--- a/tests/BuildSystem/Build/mkdir.llbuild
+++ b/tests/BuildSystem/Build/mkdir.llbuild
@@ -1,5 +1,9 @@
 # Check the 'mkdir' tool.
 #
+# mkdir on WSL gives the new folder 0777 permissions, which break this test. This is because
+# the WSL file system doesn't support permissions: https://github.com/Microsoft/BashOnWindows/issues/1801
+# See https://github.com/Microsoft/BashOnWindows/issues/1801
+# XFAIL: windows_subsystem_linux
 # RUN: rm -rf %t.build
 # RUN: mkdir -p %t.build
 # RUN: cp %s %t.build/build.llbuild

--- a/tests/lit.cfg
+++ b/tests/lit.cfg
@@ -57,7 +57,7 @@ config.test_exec_root = os.path.join(llbuild_obj_root, 'tests')
 #
 # FIXME: This is pretty compiler specific and probably should just be ripped out
 # of lit.
-config.target_triple = None
+config.target_triple = ""
 
 ###
 

--- a/tests/lit.cfg
+++ b/tests/lit.cfg
@@ -64,6 +64,11 @@ config.target_triple = None
 # Add a platform feature.
 config.available_features.add("platform="+platform.system())
 
+if platform.system() == 'Linux':
+    with open('/proc/version') as version:
+        if 'Microsoft' in version.read():
+            config.available_features.add('windows_subsystem_linux')
+
 # Add swiftc feature.
 config.available_features.add("has-swift="+config.swiftc_found)
 


### PR DESCRIPTION
```
hughbe@DESKTOP-187M57Q:/mnt/c/Users/hughb/Documents/GitHub-WSL/build$ ninja test
[1/1] Running llbuild tests...
-- Testing: 146 tests, 4 threads --
Testing: 0 .. 10.. 20.. 30.. 40.. 50.. 60.. 70.. 80.. 90..
Testing Time: 21.24s
  Expected Passes    : 138
  Expected Failures  : 1
  Unsupported Tests  : 7
```

https://github.com/Microsoft/BashOnWindows/issues/1801