### PR TITLE
Introduce and use a basic wrapper around a process

### DIFF
--- a/include/llbuild/Basic/RedirectedProcess.h
+++ b/include/llbuild/Basic/RedirectedProcess.h
@@ -1,0 +1,45 @@
+//===- RedirectedProcess.h --------------------------------------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2015 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLBUILD_BASIC_REDIRECTEDPROCESS_H
+#define LLBUILD_BASIC_REDIRECTEDPROCESS_H
+
+#include <signal.h>
+
+namespace llbuild {
+namespace basic {
+/// This is an abstraction that spawns, reads, waits and kills a process.
+/// The implementation is platform specific.
+class RedirectedProcess {
+ public:
+  using ProcessId = pid_t;
+  ProcessId processId;
+
+  RedirectedProcess(ProcessId processId) { this->processId = processId; }
+
+  /// Sends the specified signal to the process.
+  void sendSignal(int signal) const;
+
+  struct Hash {
+    size_t operator()(const llbuild::basic::RedirectedProcess& x) const {
+      return x.processId;
+    }
+  };
+
+  bool operator==(const RedirectedProcess& rhs) const {
+    return processId == rhs.processId;
+  }
+};
+}
+}
+
+#endif

--- a/lib/Basic/CMakeLists.txt
+++ b/lib/Basic/CMakeLists.txt
@@ -3,9 +3,10 @@ add_llbuild_library(llbuildBasic
   FileSystem.cpp
   Hashing.cpp
   PlatformUtility.cpp
+  RedirectedProcess.cpp
   SerialQueue.cpp
-  Version.cpp
   ShellUtility.cpp
+  Version.cpp
   )
 
 if(${CMAKE_SYSTEM_NAME} MATCHES ".*BSD" OR ${CMAKE_SYSTEM_NAME} MATCHES "Linux")

--- a/lib/Basic/RedirectedProcess.cpp
+++ b/lib/Basic/RedirectedProcess.cpp
@@ -1,0 +1,20 @@
+//===-- RedirectedProcess.cpp ---------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2015 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#include "llbuild/Basic/RedirectedProcess.h"
+
+using namespace llbuild;
+using namespace llbuild::basic;
+
+void RedirectedProcess::sendSignal(int signal) const {
+  ::kill(-processId, signal);
+}

--- a/lib/BuildSystem/LaneBasedExecutionQueue.cpp
+++ b/lib/BuildSystem/LaneBasedExecutionQueue.cpp
@@ -15,6 +15,7 @@
 
 #include "llbuild/Basic/LLVM.h"
 #include "llbuild/Basic/PlatformUtility.h"
+#include "llbuild/Basic/RedirectedProcess.h"
 
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/Hashing.h"
@@ -42,6 +43,7 @@
 #include <sys/wait.h>
 
 using namespace llbuild;
+using namespace llbuild::basic;
 using namespace llbuild::buildsystem;
 
 namespace std {
@@ -76,7 +78,7 @@ class LaneBasedExecutionQueue : public BuildExecutionQueue {
   bool shutdown { false };
   
   /// The set of spawned processes to terminate if we get cancelled.
-  std::unordered_set<pid_t> spawnedProcesses;
+  std::unordered_set<RedirectedProcess, RedirectedProcess::Hash> spawnedProcesses;
   std::mutex spawnedProcessesMutex;
 
   /// Management of cancellation and SIGKILL escalation
@@ -150,10 +152,10 @@ class LaneBasedExecutionQueue : public BuildExecutionQueue {
   void sendSignalToProcesses(int signal) {
     std::unique_lock<std::mutex> lock(spawnedProcessesMutex);
 
-    for (pid_t pid: spawnedProcesses) {
+    for (auto&& process: spawnedProcesses) {
       // We are killing the whole process group here, this depends on us
       // spawning each process in its own group earlier.
-      ::kill(-pid, signal);
+      process.sendSignal(signal);
     }
   }
 
@@ -403,7 +405,7 @@ public:
         return CommandResult::Failed;
       }
 
-      spawnedProcesses.insert(pid);
+      spawnedProcesses.insert(RedirectedProcess(pid));
     }
 
     posix_spawn_file_actions_destroy(&fileActions);


### PR DESCRIPTION
Functionality limited to killing the process - part of refactoring away
platform specific behaviour from NinjaBuildCommand.cpp and
LaneBasedExecutionQueue.cpp

This is also the start of refactoring away the duplicate code in the two files.

I've decided to go at this incrementally. This code has been extracted from and improved from #98

This may seem overkill (78 additions vs 9 deletions) on it's own but is part of something larger, and also has a lot of license header and namespace/class boilterplate.

Depends on #133