### PR TITLE
[Core] Insert discovered deps at the appropriate point.

### DIFF
--- a/lib/Core/BuildEngine.cpp
+++ b/lib/Core/BuildEngine.cpp
@@ -800,7 +800,7 @@ private:
         // they are not keys for rules which have not been run, which would
         // indicate an underspecified build (e.g., a generated header).
         ruleInfo->result.dependencies.insert(
-          ruleInfo->result.dependencies.begin(),
+          ruleInfo->result.dependencies.end(),
           taskInfo->discoveredDependencies.begin(),
           taskInfo->discoveredDependencies.end());
 


### PR DESCRIPTION
 - This was just an inefficient oversigh, the discovered dependencies should
   always be appended to the result deps list.

 - <rdar://problem/31537299> Discovered dependencies aren't in the appropriate order