### PR TITLE
[Core] Ensure database maintains the relative order of dependencies.

### DIFF
--- a/include/llbuild/Core/BuildDB.h
+++ b/include/llbuild/Core/BuildDB.h
@@ -61,6 +61,9 @@ public:
   /// unique. However, duplicate dependencies have no semantic meaning for the
   /// engine, and the database may elect to discard them from storage.
   ///
+  /// The database *MUST*, however, correctly maintain the order of the
+  /// dependencies.
+  ///
   /// \param error_out [out] Error string if return value is false.
   virtual bool setRuleResult(const Rule& rule, const Result& result, std::string* error_out) = 0;
 

--- a/tests/BuildSystem/Build/dep-scan-order.llbuild
+++ b/tests/BuildSystem/Build/dep-scan-order.llbuild
@@ -1,0 +1,87 @@
+# Check that dependency scanning order is respected.
+#
+# RUN: rm -rf %t.build
+# RUN: mkdir -p %t.build
+# RUN: echo "input" > %t.build/input
+# RUN: cp %s %t.build/build.llbuild
+
+
+# Run an initial build forces "generated-input" to be one of the first declared
+# keys. This is explicitly checking against an implementation detail that, when
+# written, the dependency scanning order could be tied to the database key
+# identifier index.
+#
+# RUN: %{llbuild} buildsystem build --serial --chdir %t.build PREPARE > %t.prepare.out 2> %t.prepare.err || true
+
+
+# Run the actual initial build.
+#
+# RUN: %{llbuild} buildsystem build --serial --chdir %t.build > %t.out
+# RUN: %{FileCheck} --input-file=%t.out %s --check-prefix=CHECK-INITIAL
+# RUN: diff %t.build/input %t.build/generated-input
+# RUN: diff %t.build/input %t.build/output
+#
+# CHECK-INITIAL: CONSUMER
+
+
+# Check that a null build does nothing.
+#
+# RUN: %{llbuild} buildsystem build --serial --chdir %t.build > %t2.out
+# RUN: echo "END-OF-FILE" >> %t2.out
+# RUN: %{FileCheck} --input-file=%t2.out %s --check-prefix=CHECK-REBUILD
+#
+# CHECK-REBUILD-NOT: GENERATOR
+# CHECK-REBUILD-NOT: CONSUMER
+
+
+# Check that a modification triggers both uses.
+#
+# RUN: echo "MOD" >> %t.build/input
+# RUN: %{llbuild} buildsystem build --serial --chdir %t.build --trace /tmp/x.trace > %t3.out
+# RUN: %{FileCheck} --input-file=%t3.out %s --check-prefix=CHECK-AFTER-MOD
+# RUN: diff %t.build/input %t.build/generated-input
+# RUN: diff %t.build/input %t.build/output
+#
+# CHECK-AFTER-MOD: GENERATOR
+# CHECK-AFTER-MOD: CONSUMER
+
+
+# Check that another null build does nothing.
+#
+# RUN: %{llbuild} buildsystem build --serial --chdir %t.build > %t4.out
+# RUN: echo "END-OF-FILE" >> %t4.out
+# RUN: %{FileCheck} --input-file=%t4.out %s --check-prefix=CHECK-REBUILD
+
+client:
+  name: basic
+
+targets:
+  "": ["output"]
+  PREPARE: ["generated-input"]
+  
+commands:
+  # A command which consumes a generated input and reports it as a discovered dep.
+  C.consumer:
+    tool: shell
+    description: CONSUMER
+    inputs: ["<GENERATOR>"]
+    outputs: ["output"]
+    # We report the dependency twice just to cover the duplicate dependency scenario.
+    args:
+      "echo \"output: generated-input generated-input\" > output.d &&
+       cp generated-input output"
+    deps: output.d
+    deps-style: makefile
+
+  # A command which generates the discovered input.
+  #
+  # NOTE: The generated-input itself is intentionally never declared as an
+  # output here; this test is intentionally checking that we support a situation
+  # where the dependency edge is only valid due to some other explicit ordering
+  # in the build system, in this case the edge "C.consumer -> <GENERATOR>".
+  C.generator:
+    tool: shell
+    description: GENERATOR
+    inputs: ["input"]
+    outputs: ["<GENERATOR>"]
+    args: cp input generated-input

--- a/tests/Ninja/Build/tracing-scanning.ninja
+++ b/tests/Ninja/Build/tracing-scanning.ninja
@@ -5,7 +5,7 @@
 # RUN: cp %s %t.build/build.ninja
 # RUN: touch %t.build/input-1
 # RUN: touch %t.build/input-2
-# RUN: %{llbuild} ninja build --jobs 1 --chdir %t.build --trace %t.trace-out
+# RUN: %{llbuild} ninja build --jobs 1 --chdir %t.build
 
 # Check dependency scanning on rebuild.
 #
@@ -38,6 +38,6 @@
 rule CAT
      command = cat ${in} > $out
 
-build output: CAT input-2 input-1
+build output: CAT input-1 input-2
 
 default output


### PR DESCRIPTION
 - As currently modeled, the engine only scans dependencies in serial order
   because we cannot yet handle the situation where a dependency has been
   inferred to be out-of-date, but it isn't yet at the head of the queue of
   things to actually begin to run in order to bring another node up-to-date.

 - Given that, it is very important that we do the scanning of dependencies in
   the order that they were declared, since there may be an implicit ordering
   relationship between the impact of evaluating those nodes. See the test case
   for an example (which also serves as a test case for the previous commit).

 - <rdar://problem/31490515> Serial dependency scanning is out-of-order