### PR TITLE
[BuildSystem] Diagnose duplicate command names.

### DIFF
--- a/lib/BuildSystem/BuildFile.cpp
+++ b/lib/BuildSystem/BuildFile.cpp
@@ -622,6 +622,12 @@ class BuildFileImpl {
           static_cast<llvm::yaml::ScalarNode*>(entry.getKey()));
       llvm::yaml::MappingNode* attrs = static_cast<llvm::yaml::MappingNode*>(
           entry.getValue());
+
+      // Check that the command is not a duplicate.
+      if (commands.count(name) != 0) {
+        error(entry.getKey(), "duplicate command in 'commands' map");
+        continue;
+      }
       
       // Get the initial attribute, which must be the tool name.
       auto it = attrs->begin();

--- a/tests/BuildSystem/Parser/errors.llbuild
+++ b/tests/BuildSystem/Parser/errors.llbuild
@@ -81,8 +81,6 @@ commands:
         tool: ["bad", "key"]
   command3:
         tool: "good"
-  command3:
-        tool: "good"
         # CHECK-ERR-NOT: error:
         # CHECK-ERR: error: invalid value type for 'inputs' command key
         inputs: {}
@@ -111,3 +109,7 @@ commands:
         attribute7:
           ["bad", "key"]: value
           "ok": ["bad", "value"]
+
+        # CHECK-ERR: errors.llbuild:[[@LINE+1]]:2: error: duplicate command in 'commands' map
+  command7:
+        tool: "duplicate"


### PR DESCRIPTION
 - <rdar://problem/31215991> llbuild manifest containing two equal commands results in a crashes