### PR TITLE
[BuildSystem] Lift errors out of frontend API.

### DIFF
--- a/examples/c-api/buildsystem/main.c
+++ b/examples/c-api/buildsystem/main.c
@@ -220,9 +220,13 @@ int main(int argc, char **argv) {
   // Build the default target, twice.
   llb_data_t key = { 0, NULL };
   printf("initial build:\n");
-  llb_buildsystem_build(system, &key);
+  if (!llb_buildsystem_build(system, &key)) {
+    printf("build had command failures\n");
+  }
   printf("second build:\n");
-  llb_buildsystem_build(system, &key);
+  if (!llb_buildsystem_build(system, &key)) {
+    printf("build had command failures\n");
+  }    
 
   // Destroy the build system.
   llb_buildsystem_destroy(system);

--- a/lib/BuildSystem/BuildSystemFrontend.cpp
+++ b/lib/BuildSystem/BuildSystemFrontend.cpp
@@ -520,13 +520,9 @@ bool BuildSystemFrontend::build(StringRef targetToBuild) {
   if (!buildSystem->build(targetToBuild))
     return false;
 
-  // If there were failed commands, report the count and return an error.
-  if (delegate.getNumFailedCommands()) {
-    getDelegate().error("build had " + Twine(delegate.getNumFailedCommands()) +
-                        " command failures");
-    return false;
-  }
-
-  // Otherwise, return an error only if there were unspecified errors.
-  return delegate.getNumErrors() == 0;
+  // The build was successful if there were no failed commands or unspecified
+  // errors.
+  //
+  // It is the job of the client to report a summary, if desired.
+  return delegate.getNumFailedCommands() == 0 && delegate.getNumErrors() == 0;
 }

--- a/lib/Commands/BuildSystemCommand.cpp
+++ b/lib/Commands/BuildSystemCommand.cpp
@@ -546,6 +546,12 @@ static int executeBuildCommand(std::vector<std::string> args) {
   BasicBuildSystemFrontendDelegate delegate(sourceMgr, invocation);
   BuildSystemFrontend frontend(delegate, invocation);
   if (!frontend.build(targetToBuild)) {
+    // If there were failed commands, report the count and return an error.
+    if (delegate.getNumFailedCommands()) {
+      delegate.error("build had " + Twine(delegate.getNumFailedCommands()) +
+                     " command failures");
+    }
+
     return 1;
   }
 

--- a/tests/Examples/buildsystem-capi.llbuild
+++ b/tests/Examples/buildsystem-capi.llbuild
@@ -15,11 +15,11 @@
 # CHECK: command_finished: <fancy-thing>
 # CHECK: command_started: <error> -- FAILING-COMMAND
 # CHECK: had_command_failure
-# CHECK: <unknown>:0: error: build had 1 command failure
+# CHECK: build had command failures
 #
 # CHECK: second build:
 # CHECK: command_started: <error> -- FAILING-COMMAND
-# CHECK: <unknown>:0: error: build had 1 command failure
+# CHECK: build had command failures
 
 client:
   name: basic


### PR DESCRIPTION
 - This frontend API shouldn't be responsible for synthesizing summary error
   messages, individual clients can do that.

 - <rdar://problem/31633275> Eliminate "build had N command failures" log message