### PR TITLE
Make cycle information available to the client

### DIFF
--- a/include/llbuild/BuildSystem/BuildSystemFrontend.h
+++ b/include/llbuild/BuildSystem/BuildSystemFrontend.h
@@ -15,6 +15,7 @@
 
 #include "llbuild/Basic/LLVM.h"
 #include "llbuild/BuildSystem/BuildSystem.h"
+#include "llbuild/Core/BuildEngine.h"
 
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/StringRef.h"
@@ -258,6 +259,14 @@ public:
                                       CommandResult result,
                                       int exitStatus);
 
+  /// Called when a cycle is detected by the build engine and it cannot make
+  /// forward progress.
+  ///
+  /// \param items The ordered list of items comprising the cycle, starting from
+  /// the node which was requested to build and ending with the first node in
+  /// the cycle (i.e., the node participating in the cycle will appear twice).
+  virtual void cycleDetected(const std::vector<core::Rule*>& items) = 0;
+
   /// @}
   
   /// @name Accessors
@@ -326,6 +335,9 @@ public:
   ///
   /// \param sourceMgr The source manager to use for diagnostics.
   void parse(ArrayRef<std::string> args, llvm::SourceMgr& sourceMgr);
+
+  /// Provides a default string representation for a cycle detected by the build engine.
+  static std::string formatDetectedCycle(const std::vector<core::Rule*>& cycle);
 };
 
 }

--- a/lib/Commands/BuildSystemCommand.cpp
+++ b/lib/Commands/BuildSystemCommand.cpp
@@ -21,6 +21,7 @@
 #include "llbuild/BuildSystem/BuildSystemFrontend.h"
 #include "llbuild/BuildSystem/BuildValue.h"
 
+#include "llvm/ADT/SmallString.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/Support/SourceMgr.h"
 #include "llvm/Support/raw_ostream.h"
@@ -509,6 +510,11 @@ public:
   virtual std::unique_ptr<Tool> lookupTool(StringRef name) override {
     // We do not support any non-built-in tools.
     return nullptr;
+  }
+
+  virtual void cycleDetected(const std::vector<Rule*>& cycle) override {
+    auto message = BuildSystemInvocation::formatDetectedCycle(cycle);
+    error(message);
   }
 };
 

--- a/products/libllbuild/public-api/llbuild/buildsystem.h
+++ b/products/libllbuild/public-api/llbuild/buildsystem.h
@@ -113,6 +113,39 @@ typedef enum {
   llb_buildsystem_command_status_kind_is_complete = 2,
 } llb_buildsystem_command_status_kind_t;
 
+typedef enum {
+  /// A key used to identify a command.
+  llb_build_key_kind_command = 0,
+
+  /// A key used to identify a custom task.
+  llb_build_key_kind_custom_task = 1,
+
+  /// A key used to identify directory contents.
+  llb_build_key_kind_directory_contents = 2,
+
+  /// A key used to identify the signature of a complete directory tree.
+  llb_build_key_kind_directory_tree_signature = 3,
+
+  /// A key used to identify a node.
+  llb_build_key_kind_node = 4,
+
+  /// A key used to identify a target.
+  llb_build_key_kind_target = 5,
+
+  /// An invalid key kind.
+  llb_build_key_kind_unknown = 6,
+} llb_build_key_kind_t;
+
+/// The BuildKey encodes the key space used by the BuildSystem when using the
+/// core BuildEngine.
+typedef struct llb_build_key_t_ llb_build_key_t;
+struct llb_build_key_t_ {
+  /// The kind of key
+  llb_build_key_kind_t kind;
+  /// The actual key data
+  const char* key;
+} ;
+
 /// Invocation parameters for a build system.
 typedef struct llb_buildsystem_invocation_t_ llb_buildsystem_invocation_t;
 struct llb_buildsystem_invocation_t_ {
@@ -319,6 +352,15 @@ typedef struct llb_buildsystem_delegate_t_ {
                                    llb_buildsystem_process_t* process,
                                    llb_buildsystem_command_result_t result,
                                    int exit_status);
+
+  /// Called when a cycle is detected by the build engine and it cannot make
+  /// forward progress.
+  ///
+  /// Xparam rules The ordered list of items comprising the cycle, starting from
+  /// the node which was requested to build and ending with the first node in
+  /// the cycle (i.e., the node participating in the cycle will appear twice).
+  /// Xparam rule_count The number of rules comprising the cycle.
+  void (*cycle_detected)(void* context, llb_build_key_t* rules, uint64_t rule_count);
   
   /// @}
 } llb_buildsystem_delegate_t;

--- a/products/swift-build-tool/swift-build-tool.cpp
+++ b/products/swift-build-tool/swift-build-tool.cpp
@@ -52,6 +52,11 @@ public:
 
     return nullptr;
   }
+
+  virtual void cycleDetected(const std::vector<core::Rule*>& items) override {
+    auto message = BuildSystemInvocation::formatDetectedCycle(items);
+    error(message);
+  }
 };
 
 static void usage(int exitCode) {

--- a/unittests/BuildSystem/BuildSystemFrontendTest.cpp
+++ b/unittests/BuildSystem/BuildSystemFrontendTest.cpp
@@ -195,6 +195,8 @@ public:
   virtual std::unique_ptr<Tool> lookupTool(StringRef name) override {
     return nullptr;
   }
+
+  virtual void cycleDetected(const std::vector<core::Rule*>& items) override { }
 };
 
 


### PR DESCRIPTION
This allows the clients of llbuild to decide how to present cycle diagnostics instead of doing this internally. When using the llbuild CLI, the previous way of reporting cycles is retained.