### PR TITLE
[BuildSystem] Ensure unproducable nodes cause the build to halt.

### DIFF
--- a/lib/BuildSystem/BuildSystem.cpp
+++ b/lib/BuildSystem/BuildSystem.cpp
@@ -585,6 +585,7 @@ class ProducedNodeTask : public Task {
 
   virtual void inputsAvailable(BuildEngine& engine) override {
     if (isInvalid) {
+      getBuildSystem(engine).getDelegate().hadCommandFailure();
       engine.taskIsComplete(this, BuildValue::makeFailedInput().toData());
       return;
     }

--- a/tests/BuildSystem/Build/multiple-outputs-error.llbuild
+++ b/tests/BuildSystem/Build/multiple-outputs-error.llbuild
@@ -1,0 +1,37 @@
+# Check the diagnosing of multiple producers for a node.
+#
+# We shouldn't try to run `C.b` by default.
+
+# RUN: rm -rf %t.build
+# RUN: mkdir -p %t.build
+# RUN: cp %s %t.build/build.llbuild
+# RUN: %{llbuild} buildsystem build --serial --chdir %t.build &> %t.out || true
+# RUN: %{FileCheck} %s --input-file %t.out
+#
+# CHECK: unable to build node: '<a>'
+# CHECK-NOT: B
+# CHECK: build had 1 command failure
+
+client:
+  name: basic
+
+targets:
+  "": ["<a>", "<b>"]
+
+commands:
+  C.a1:
+    tool: shell
+    outputs: ["<a>"]
+    description: A1
+    args: true
+  C.a2:
+    tool: shell
+    outputs: ["<a>"]
+    description: A2
+    args: true
+  C.b:
+    tool: shell
+    outputs: ["<b>"]
+    description: B
+    args: true
+


### PR DESCRIPTION
 - <rdar://problem/31629500> Build doesn't abort after "unable to build node" error