### PR TITLE
<rdar://problem/30961839> Implement support for stale file removal

### DIFF
--- a/docs/buildsystem.rst
+++ b/docs/buildsystem.rst
@@ -689,3 +689,25 @@ A typical use for this tool is creating static libraries.
    FIXME: currently the archive is always recreated entirely, it would be
    preferable in future to correctly update/delete/create the archive file
    as required.
+
+Stale File Removal Tool
+-----------------------
+
+**Identifier**: *stale-file-removal*
+
+A tool to remove stale files from previous builds.
+
+The build system records the last value of `expectedOutputs` and compares it
+to the current one. Any path that was previously present, but isn't in the
+current string list will be removed from the file system.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 80
+
+   * - Name
+     - Description
+
+   * - expectedOutputs
+     - A string list of paths that are expected to be produced by the given
+       manifest.

--- a/include/llbuild/Basic/FileSystem.h
+++ b/include/llbuild/Basic/FileSystem.h
@@ -59,6 +59,13 @@ public:
   /// \returns The file contents, on success, or null on error.
   virtual std::unique_ptr<llvm::MemoryBuffer>
   getFileContents(const std::string& path) = 0;
+
+  /// Remove the file or directory at the given path.
+  ///
+  /// Directory removal is non-recursive, so only empty directories will be removed.
+  ///
+  /// \returns True if the item was removed, false otherwise.
+  virtual bool remove(const std::string& path) = 0;
   
   /// Get the information to represent the state of the given path in the file
   /// system.

--- a/include/llbuild/Basic/PlatformUtility.h
+++ b/include/llbuild/Basic/PlatformUtility.h
@@ -38,6 +38,7 @@ int pclose(FILE *stream);
 int pipe(int ptHandles[2]);
 FILE *popen(const char *command, const char *mode);
 int read(int fileHandle, void *destinationBuffer, unsigned int maxCharCount);
+int rmdir(const char *path);
 int stat(const char *fileName, StatStruct *buf);
 int unlink(const char *fileName);
 int write(int fileHandle, void *destinationBuffer, unsigned int maxCharCount);

--- a/lib/Basic/PlatformUtility.cpp
+++ b/lib/Basic/PlatformUtility.cpp
@@ -88,6 +88,14 @@ int sys::read(int fileHandle, void *destinationBuffer,
 #endif
 }
 
+int sys::rmdir(const char *path) {
+#if defined(_WIN32)
+  return ::_rmdir(path);
+#else
+  return ::rmdir(path);
+#endif
+}
+
 int sys::stat(const char *fileName, StatStruct *buf) {
 #if defined(_WIN32)
   return ::_stat(fileName, buf);

--- a/lib/BuildSystem/BuildValue.cpp
+++ b/lib/BuildSystem/BuildValue.cpp
@@ -36,6 +36,7 @@ StringRef BuildValue::stringForKind(BuildValue::Kind kind) {
     CASE(CancelledCommand);
     CASE(SkippedCommand);
     CASE(Target);
+    CASE(StaleFileRemoval);
 #undef CASE
   }
   return "<unknown>";

--- a/products/libllbuild/BuildSystem-C-API.cpp
+++ b/products/libllbuild/BuildSystem-C-API.cpp
@@ -82,6 +82,14 @@ public:
     return result;
   }
 
+  virtual bool remove(const std::string& path) override {
+    if (!cAPIDelegate.fs_remove) {
+      return localFileSystem->remove(path);
+    }
+
+    return cAPIDelegate.fs_remove(cAPIDelegate.context, path.c_str());
+  }
+
   virtual basic::FileInfo getFileInfo(const std::string& path) override {
     if (!cAPIDelegate.fs_get_file_info) {
       return localFileSystem->getFileInfo(path);

--- a/products/libllbuild/public-api/llbuild/buildsystem.h
+++ b/products/libllbuild/public-api/llbuild/buildsystem.h
@@ -215,6 +215,13 @@ typedef struct llb_buildsystem_delegate_t_ {
   bool (*fs_get_file_contents)(void* context, const char* path,
                                llb_data_t* data_out);
 
+  /// Remove file or directory at given path.
+  ///
+  /// Xparam path The path to remove.
+  ///
+  /// \\returns True on success.
+  bool (*fs_remove)(void* context, const char* path);
+
   /// Get the file information for the given path.
   void (*fs_get_file_info)(void* context, const char* path,
                            llb_fs_file_info_t* data_out);

--- a/tests/BuildSystem/Build/stale-file-removal.llbuild
+++ b/tests/BuildSystem/Build/stale-file-removal.llbuild
@@ -1,0 +1,57 @@
+# Check the handling of stale file removal.
+#
+# We use 'grep' to slice out two different subfiles from the same file.
+#
+# RUN: rm -rf %t.build
+# RUN: mkdir -p %t.build
+#
+# RUN: grep -A1000 "VERSION-BEGIN-[1]" %s | grep -B10000 "VERSION-END-1" | grep -ve '^--$' > %t.build/build-1.llbuild
+# RUN: %{llbuild} buildsystem build --serial --chdir %t.build -f build-1.llbuild > %t.1.out
+# RUN: %{FileCheck} --check-prefix CHECK-VERSION-1 --input-file=%t.1.out %s
+#
+# CHECK-VERSION-1: STALE-FILE-REMOVAL
+#
+# RUN: grep -A1000 "VERSION-BEGIN-[2]" %s | grep -B10000 "VERSION-END-2" | grep -ve '^--$' > %t.build/build-2.llbuild
+# Create stale file
+# RUN: touch %t.build/a.out
+# RUN: %{llbuild} buildsystem build --serial --chdir %t.build -f build-2.llbuild > %t2.out
+# RUN: %{FileCheck} --check-prefix CHECK-VERSION-2 --input-file %t2.out %s
+# Check for absence of stale file
+# RUN: test ! -f %t.build/a.out
+#
+# CHECK-VERSION-2: STALE-FILE-REMOVAL-2
+#
+
+##### VERSION-BEGIN-1 #####
+
+client:
+  name: basic
+
+targets:
+  "": ["<all>"]
+
+commands:
+  C.1:
+    tool: stale-file-removal
+    description: STALE-FILE-REMOVAL
+    expectedOutputs: ["a.out"]
+    outputs: ["<all>"]
+
+##### VERSION-END-1 #####
+
+##### VERSION-BEGIN-2 #####
+
+client:
+  name: basic
+
+targets:
+  "": ["<all>"]
+
+commands:
+  C.1:
+    tool: stale-file-removal
+    description: STALE-FILE-REMOVAL-2
+    expectedOutputs: ["b.out"]
+    outputs: ["<all>"]
+
+##### VERSION-END-2 #####

--- a/unittests/BuildSystem/BuildValueTest.cpp
+++ b/unittests/BuildSystem/BuildValueTest.cpp
@@ -161,4 +161,25 @@ TEST(BuildValueTest, directoryListValues) {
   }
 }
 
+TEST(BuildValueTest, staleFileRemovalValues) {
+  std::vector<std::string> files { "a.out", "Info.plist" };
+
+  {
+    BuildValue a = BuildValue::makeStaleFileRemoval(ArrayRef<std::string>(files));
+    auto nodes = a.getStaleFileList();
+    EXPECT_EQ(2UL, nodes.size());
+    EXPECT_EQ(nodes[0], "a.out");
+    EXPECT_EQ(nodes[1], "Info.plist");
+  }
+
+  {
+    BuildValue a = BuildValue::makeStaleFileRemoval(ArrayRef<std::string>(files));
+    BuildValue b = BuildValue::fromData(a.toData());
+    auto nodes = b.getStaleFileList();
+    EXPECT_EQ(2UL, nodes.size());
+    EXPECT_EQ(nodes[0], "a.out");
+    EXPECT_EQ(nodes[1], "Info.plist");
+  }
+}
+
 }


### PR DESCRIPTION
Implement stale file removal and related tests.

Two things I'm not sure about:

- Should failures removing stale files actually fail the build or should they rather be warnings?
- Is it worth implementing a virtual `FileSystem` for the tests or is it good enough that we check for the error?