### PR TITLE
Intern build description strings.

### DIFF
--- a/include/llbuild/BuildSystem/BuildFile.h
+++ b/include/llbuild/BuildSystem/BuildFile.h
@@ -65,6 +65,8 @@ struct ConfigureContext {
   BuildFileToken at;
 
 public:
+  BuildFileDelegate& getDelegate() const { return delegate; }
+
   void error(const Twine& message) const;
 };
 
@@ -72,6 +74,9 @@ class BuildFileDelegate {
 public:
   virtual ~BuildFileDelegate();
 
+  /// Get an interned string.
+  virtual StringRef getInternedString(StringRef value) = 0;
+  
   /// Get the file system to use for access.
   virtual basic::FileSystem& getFileSystem() = 0;
   

--- a/lib/Commands/BuildSystemCommand.cpp
+++ b/lib/Commands/BuildSystemCommand.cpp
@@ -23,6 +23,7 @@
 
 #include "llvm/ADT/SmallString.h"
 #include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/StringMap.h"
 #include "llvm/Support/SourceMgr.h"
 #include "llvm/Support/raw_ostream.h"
 
@@ -47,6 +48,7 @@ class ParseBuildFileDelegate : public BuildFileDelegate {
   bool showOutput;
   StringRef bufferBeingParsed;
   std::unique_ptr<basic::FileSystem> fileSystem;
+  llvm::StringMap<bool> internedStrings;
   
 public:
   ParseBuildFileDelegate(bool showOutput)
@@ -56,6 +58,11 @@ public:
 
   virtual bool shouldShowOutput() { return showOutput; }
 
+  virtual StringRef getInternedString(StringRef value) override {
+    auto entry = internedStrings.insert(std::make_pair(value, true));
+    return entry.first->getKey();
+  }
+  
   virtual basic::FileSystem& getFileSystem() override { return *fileSystem; }
   
   virtual void setFileContentsBeingParsed(StringRef buffer) override;


### PR DESCRIPTION
 - It is common to have many duplicated strings in a loaded build description
   file (typically from command line arguments), so this patch optimizes the
   memory use of the build description by interning these strings while loading.

 - While we pay some cost for the interning itself, on the other hand this
   allows avoiding what would otherwise be additional allocations in many cases,
   so the interning ends up paying for itself while reducing memory footprint &
   improving cache locality. On the balance my tests indicate this is a wash to
   small improvement in terms of CPU use.

 - <rdar://problem/32128433> Intern build description strings