### PR TITLE
Change DB API to find constant key IDs.

### DIFF
--- a/include/llbuild/Core/BuildDB.h
+++ b/include/llbuild/Core/BuildDB.h
@@ -16,6 +16,8 @@
 #include "llbuild/Basic/LLVM.h"
 #include "llvm/ADT/StringRef.h"
 
+#include "llbuild/Core/BuildEngine.h"
+
 #include <cstdint>
 #include <memory>
 #include <string>
@@ -30,6 +32,16 @@ class BuildDB {
 public:
   virtual ~BuildDB();
 
+  /// Get a unique ID for the given key.
+  ///
+  /// This method is thread safe, and cannot fail.
+  virtual KeyID getKeyID(const KeyType& key) = 0;
+
+  /// Get the key corresponding to a key ID.
+  ///
+  /// This method is thread safe, and cannot fail.
+  virtual KeyType getKeyForID(KeyID key) = 0;
+  
   /// Get the current build iteration.
   ///
   /// \param success_out [out] Whether or not the query succeeded.
@@ -43,6 +55,7 @@ public:
 
   /// Look up the result for a rule.
   ///
+  /// \param keyID The keyID for the rule.
   /// \param rule The rule to look up the result for.
   /// \param result_out [out] The result, if found.
   /// \param error_out [out] Error string if an error occurred.
@@ -53,7 +66,7 @@ public:
   // FIXME: Figure out if we want a more lazy approach where we make the
   // database cache result objects and we query them only when needed. This may
   // scale better to very large build graphs.
-  virtual bool lookupRuleResult(const Rule& rule, Result* result_out, std::string* error_out) = 0;
+  virtual bool lookupRuleResult(KeyID keyID, const Rule& rule, Result* result_out, std::string* error_out) = 0;
 
   /// Update the stored result for a rule.
   ///
@@ -64,8 +77,9 @@ public:
   /// The database *MUST*, however, correctly maintain the order of the
   /// dependencies.
   ///
+  /// \param keyID The keyID for the rule.
   /// \param error_out [out] Error string if return value is false.
-  virtual bool setRuleResult(const Rule& rule, const Result& result, std::string* error_out) = 0;
+  virtual bool setRuleResult(KeyID keyID, const Rule& rule, const Result& result, std::string* error_out) = 0;
 
   /// Called by the build engine to indicate that a build has started.
   ///

--- a/include/llbuild/Core/BuildEngine.h
+++ b/include/llbuild/Core/BuildEngine.h
@@ -20,6 +20,7 @@
 #include <utility>
 #include <vector>
 
+#include "llvm/ADT/StringRef.h"
 #include "llvm/ADT/Twine.h"
 
 namespace llbuild {
@@ -27,6 +28,7 @@ namespace core {
 
 // FIXME: Need to abstract KeyType;
 typedef std::string KeyType;
+typedef uint64_t KeyID;
 typedef std::vector<uint8_t> ValueType;
 
 class BuildDB;
@@ -61,7 +63,7 @@ struct Result {
   //
   // FIXME: At some point, figure out the optimal representation for this field,
   // which is likely to be a lot of the resident memory size.
-  std::vector<KeyType> dependencies;
+  std::vector<KeyID> dependencies;
 };
 
 /// A task object represents an abstract in-progress computation in the build
@@ -87,8 +89,6 @@ struct Result {
 /// complete its computation and provide the output. The Task is responsible for
 /// providing the engine with the computed value when ready using \see
 /// BuildEngine::taskIsComplete().
-//
-// FIXME: Define parallel execution semantics.
 class Task {
 public:
   Task() {}

--- a/lib/Core/SQLiteBuildDB.cpp
+++ b/lib/Core/SQLiteBuildDB.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2015 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See http://swift.org/LICENSE.txt for license information
@@ -20,6 +20,7 @@
 #include <cassert>
 #include <cerrno>
 #include <cstring>
+#include <mutex>
 #include <sstream>
 
 #include <sqlite3.h>
@@ -39,6 +40,9 @@ class SQLiteBuildDB : public BuildDB {
   static const int currentSchemaVersion = 6;
 
   sqlite3 *db = nullptr;
+
+  /// The mutex to protect all access to the database and statements.
+  std::mutex dbMutex;
 
   std::string getCurrentErrorMessage() {
     int err_code = sqlite3_errcode(db);
@@ -63,11 +67,28 @@ public:
 
   bool open(StringRef path, uint32_t clientSchemaVersion,
             std::string *error_out) {
+    std::lock_guard<std::mutex> guard(dbMutex);
     assert(!db);
+
+    // Configure SQLite3 on first use.
+    //
+    // We attempt to set multi-threading mode, but can settle for serialized if
+    // the library can't be reinitialized (there are only two modes).
+    static int sqliteConfigureResult = []() -> int {
+      // We access a single connection from multiple threads.
+      return sqlite3_config(SQLITE_CONFIG_MULTITHREAD);
+    }();
+    if (sqliteConfigureResult != SQLITE_OK) {
+        if (!sqlite3_threadsafe()) {
+            *error_out = "unable to configure database: not thread-safe";
+            return false;
+        }
+    }
+
     int result = sqlite3_open(path.str().c_str(), &db);
     if (result != SQLITE_OK) {
-      // FIXME: Provide better error messages.
-      *error_out = "unable to open database";
+      *error_out = "unable to open database: " + std::string(
+          sqlite3_errstr(result));
       return false;
     }
 
@@ -229,6 +250,11 @@ public:
       db, findKeyIDForKeyStmtSQL,
       -1, &findKeyIDForKeyStmt, nullptr);
     assert(result == SQLITE_OK);
+
+    result = sqlite3_prepare_v2(
+      db, findKeyNameForKeyIDStmtSQL,
+      -1, &findKeyNameForKeyIDStmt, nullptr);
+    assert(result == SQLITE_OK);
     
     result = sqlite3_prepare_v2(
       db, findIDForKeyInRuleResultsStmtSQL,
@@ -279,10 +305,12 @@ public:
   }
 
   void close() {
+    std::lock_guard<std::mutex> guard(dbMutex);
     assert(db);
 
     // Destroy prepared statements.
     sqlite3_finalize(findKeyIDForKeyStmt);
+    sqlite3_finalize(findKeyNameForKeyIDStmt);
     sqlite3_finalize(findRuleDependenciesStmt);
     sqlite3_finalize(findRuleResultStmt);
     sqlite3_finalize(deleteFromKeysStmt);
@@ -301,6 +329,7 @@ public:
   /// @{
 
   virtual uint64_t getCurrentIteration(bool* success_out, std::string *error_out) override {
+    std::lock_guard<std::mutex> guard(dbMutex);
     assert(db);
 
     // Fetch the iteration from the info table.
@@ -328,6 +357,7 @@ public:
   }
 
   virtual bool setCurrentIteration(uint64_t value, std::string *error_out) override {
+    std::lock_guard<std::mutex> guard(dbMutex);
     sqlite3_stmt* stmt;
     int result;
     result = sqlite3_prepare_v2(
@@ -347,22 +377,24 @@ public:
     return true;
   }
 
-  static constexpr const char *deleteFromKeysStmtSQL =
-  "DELETE FROM key_names WHERE key == ?;";
+  static constexpr const char *deleteFromKeysStmtSQL = (
+      "DELETE FROM key_names WHERE key == ?;");
   sqlite3_stmt* deleteFromKeysStmt = nullptr;
   
-  static constexpr const char *findRuleResultStmtSQL =
-  "SELECT rule_results.id, value, built_at, computed_at FROM rule_results "
-  "INNER JOIN key_names ON key_names.id = rule_results.key_id WHERE key == ?;";
+  static constexpr const char *findRuleResultStmtSQL = (
+      "SELECT id, value, built_at, computed_at FROM rule_results "
+      "WHERE key_id == ?;");
   sqlite3_stmt* findRuleResultStmt = nullptr;
 
-  static constexpr const char *findRuleDependenciesStmtSQL =
-  "SELECT key FROM key_names INNER JOIN rule_dependencies "
-  "ON key_names.id = rule_dependencies.key_id WHERE rule_id == ?"
-  "ORDER BY rule_dependencies.ordinal;";
+  static constexpr const char *findRuleDependenciesStmtSQL = (
+      "SELECT key_id FROM rule_dependencies WHERE rule_id == ?"
+      "ORDER BY rule_dependencies.ordinal;");
   sqlite3_stmt* findRuleDependenciesStmt = nullptr;
 
-  virtual bool lookupRuleResult(const Rule& rule, Result* result_out, std::string *error_out) override {
+  virtual bool lookupRuleResult(KeyID keyID, const Rule& rule,
+                                Result* result_out,
+                                std::string *error_out) override {
+    std::lock_guard<std::mutex> guard(dbMutex);
     assert(result_out->builtAt == 0);
 
     // Fetch the basic rule information.
@@ -372,9 +404,7 @@ public:
     assert(result == SQLITE_OK);
     result = sqlite3_clear_bindings(findRuleResultStmt);
     assert(result == SQLITE_OK);
-    result = sqlite3_bind_text(findRuleResultStmt, /*index=*/1,
-                               rule.key.data(), rule.key.size(),
-                               SQLITE_STATIC);
+    result = sqlite3_bind_int64(findRuleResultStmt, /*index=*/1, keyID);
     assert(result == SQLITE_OK);
 
     // If the rule wasn't found, we are done.
@@ -417,9 +447,8 @@ public:
         return false;
       }
       assert(sqlite3_column_count(findRuleDependenciesStmt) == 1);
-      result_out->dependencies.push_back(std::string(
-                (const char*)sqlite3_column_text(findRuleDependenciesStmt, 0),
-                sqlite3_column_bytes(findRuleDependenciesStmt, 0)));
+      auto dependencyID = sqlite3_column_int64(findRuleDependenciesStmt, 0);
+      result_out->dependencies.push_back(dependencyID);
     }
 
     return true;
@@ -452,10 +481,15 @@ public:
     "DELETE FROM rule_dependencies WHERE rule_id == ?;";
   sqlite3_stmt* deleteFromRuleDependenciesStmt = nullptr;
 
-  static constexpr const char *findKeyIDForKeyStmtSQL =
-  "SELECT id FROM key_names "
-  "WHERE key == ? LIMIT 1;";
+  static constexpr const char *findKeyIDForKeyStmtSQL = (
+      "SELECT id FROM key_names "
+      "WHERE key == ? LIMIT 1;");
   sqlite3_stmt* findKeyIDForKeyStmt = nullptr;
+
+  static constexpr const char *findKeyNameForKeyIDStmtSQL = (
+      "SELECT key FROM key_names "
+      "WHERE id == ? LIMIT 1;");
+  sqlite3_stmt* findKeyNameForKeyIDStmt = nullptr;
 
   static constexpr const char *insertIntoKeysStmtSQL =
   "INSERT OR IGNORE INTO key_names(key) VALUES (?);";
@@ -464,7 +498,8 @@ public:
   /// Inserts a key if not present and always returns keyID
   /// Sometimes key will be inserted for a lookup operation
   /// but that is okay because it'll be added at somepoint anyway
-  uint64_t getOrInsertKey(const KeyType& key, std::string *error_out) {
+  virtual KeyID getKeyID(const KeyType& key) override {
+    std::lock_guard<std::mutex> guard(dbMutex);
     int result;
 
     // Seach for the key.
@@ -495,23 +530,43 @@ public:
     assert(result == SQLITE_OK);
     result = sqlite3_step(insertIntoKeysStmt);
     if (result != SQLITE_DONE) {
-      *error_out = getCurrentErrorMessage();
-      return UINT64_MAX;
+      // FIXME: We need to support error reporting here, but the engine cannot
+      // handle it currently.
+      abort();
     }
 
     return sqlite3_last_insert_rowid(db);
   }
-  
-  virtual bool setRuleResult(const Rule& rule,
+
+  virtual KeyType getKeyForID(KeyID keyID) override {
+    std::lock_guard<std::mutex> guard(dbMutex);
+    int result;
+
+    // Seach for the key.
+    result = sqlite3_reset(findKeyNameForKeyIDStmt);
+    assert(result == SQLITE_OK);
+    result = sqlite3_clear_bindings(findKeyNameForKeyIDStmt);
+    assert(result == SQLITE_OK);
+    result = sqlite3_bind_int64(findKeyNameForKeyIDStmt, /*index=*/1, keyID);
+    assert(result == SQLITE_OK);
+
+    result = sqlite3_step(findKeyNameForKeyIDStmt);
+    assert(result == SQLITE_ROW);
+    assert(sqlite3_column_count(findKeyNameForKeyIDStmt) == 1);
+
+    // Found a keyID, return.
+    auto size = sqlite3_column_bytes(findKeyNameForKeyIDStmt, 0);
+    auto text = (const char*) sqlite3_column_text(findKeyNameForKeyIDStmt, 0);
+    return KeyType(text, size);
+  }
+
+  virtual bool setRuleResult(KeyID keyID,
+                             const Rule& rule,
                              const Result& ruleResult,
                              std::string *error_out) override {
+    std::lock_guard<std::mutex> guard(dbMutex);
     int result;
     uint64_t ruleID = 0;
-
-    uint64_t keyID = getOrInsertKey(rule.key, error_out);
-    if (keyID == UINT64_MAX) {
-      return false;
-    }
 
     // Find the existing rule id, if present.
     //
@@ -598,7 +653,7 @@ public:
 
     // Insert all the dependencies.
     for (unsigned i = 0; i != ruleResult.dependencies.size(); ++i) {
-      const auto& dependency = ruleResult.dependencies[i];
+      KeyID dependencyKeyID = ruleResult.dependencies[i];
 
       // Reset the insert statement.
       result = sqlite3_reset(insertIntoRuleDependenciesStmt);
@@ -612,12 +667,8 @@ public:
       assert(result == SQLITE_OK);
 
       // Bind the dependency key ID.
-      uint64_t dependencyKeyID = getOrInsertKey(dependency, error_out);
-      if (dependencyKeyID == UINT64_MAX) {
-        return false;
-      }
       result = sqlite3_bind_int64(insertIntoRuleDependenciesStmt, /*index=*/2,
-                                 dependencyKeyID);
+                                  dependencyKeyID);
       assert(result == SQLITE_OK);
 
       // Bind the index of the dependency.
@@ -636,6 +687,8 @@ public:
   }
 
   virtual bool buildStarted(std::string *error_out) override {
+    std::lock_guard<std::mutex> guard(dbMutex);
+
     // Execute the entire build inside a single transaction.
     //
     // FIXME: We should revist this, as we probably wouldn't want a crash in the
@@ -651,6 +704,8 @@ public:
   }
 
   virtual void buildComplete() override {
+    std::lock_guard<std::mutex> guard(dbMutex);
+
     // Sync changes to disk.
     int result = sqlite3_exec(db, "END;", nullptr, nullptr, nullptr);
     assert(result == SQLITE_OK);

--- a/unittests/Core/DepsBuildEngineTest.cpp
+++ b/unittests/Core/DepsBuildEngineTest.cpp
@@ -249,9 +249,18 @@ TEST(DepsBuildEngineTest, KeysWithNull) {
     fprintf(stderr, "iteration: %d\n", iteration);
     
     core::BuildEngine engine(delegate);
-    // FIXME: Don't put database in temp.
-    std::string error;
-    engine.attachDB(createSQLiteBuildDB(dbPath, 1, &error), &error);
+
+    // Attach the database.
+    {
+      std::string error;
+      auto db = createSQLiteBuildDB(dbPath, 1, &error);
+      EXPECT_EQ(bool(db), true);
+      if (!db) {
+        fprintf(stderr, "unable to open database: %s\n", error.c_str());
+        return;
+      }
+      engine.attachDB(std::move(db), &error);
+    }
 
     std::string inputA{"i\0A", 3};
     std::string inputB{"i\0B", 3};


### PR DESCRIPTION
 - This changes the BuildEngine <-> DB interaction to rely on first getting a
   unique (interned, effectively) ID for all keys.

 - That change allows us to then change the BuildEngine-level result to store
   dependencies in terms of key IDs, instead of expanded rules. This results in
   dramatically reduced memory usage, but also since this matches the underlying
   database schema it allows for much more efficient loading of the result
   dependencies.

 - In particular, this eliminates several joins from the database
   implementation.

 - There is potentially more we could do here to eliminate the ancillary key
   table entirely and simply make the results themselves serve as the canonical
   identifier for a rule, but that requires a little more work.

 - This is good for a 35% speedup on null builds of large build graphs.

 - This is a reapplication of 27a4a5d9 with a change to fix the concurrent
   access to the SQLite database (https://bugs.swift.org/browse/SR-4876)

 - <rdar://problem/32139612> Change RuleResult to store key IDs