### PR TITLE
Add delegate support for command reporting

### DIFF
--- a/include/llbuild/BuildSystem/BuildSystem.h
+++ b/include/llbuild/BuildSystem/BuildSystem.h
@@ -176,6 +176,21 @@ public:
   /// commands).
   virtual void commandStarted(Command*) = 0;
 
+  /// Called to report an error during the execution of a command.
+  ///
+  /// \param data - The error message.
+  virtual void commandHadError(Command*, StringRef data) = 0;
+
+  /// Called to report a note during the execution of a command.
+  ///
+  /// \param data - The note message.
+  virtual void commandHadNote(Command*, StringRef data) = 0;
+
+  /// Called to report a warning during the execution of a command.
+  ///
+  /// \param data - The warning message.
+  virtual void commandHadWarning(Command*, StringRef data) = 0;
+
   /// Called by the build system to report a command has completed.
   ///
   /// \param result - The result of command (e.g. success, failure, etc).

--- a/include/llbuild/BuildSystem/BuildSystemFrontend.h
+++ b/include/llbuild/BuildSystem/BuildSystemFrontend.h
@@ -199,6 +199,21 @@ public:
   /// corresponding \see commandFinished() call.
   virtual void commandStarted(Command*) override;
 
+  /// Called to report an error during the execution of a command.
+  ///
+  /// \param data - The error message.
+  virtual void commandHadError(Command*, StringRef data) override;
+
+  /// Called to report a note during the execution of a command.
+  ///
+  /// \param data - The note message.
+  virtual void commandHadNote(Command*, StringRef data) override;
+
+  /// Called to report a warning during the execution of a command.
+  ///
+  /// \param data - The warning message.
+  virtual void commandHadWarning(Command*, StringRef data) override;
+
   /// Called by the build system to report a command has completed.
   ///
   /// \param result - The result of command (e.g. success, failure, etc).

--- a/lib/BuildSystem/BuildSystemFrontend.cpp
+++ b/lib/BuildSystem/BuildSystemFrontend.cpp
@@ -480,6 +480,21 @@ void BuildSystemFrontendDelegate::commandStarted(Command* command) {
   fflush(stdout);
 }
 
+void BuildSystemFrontendDelegate::commandHadError(Command* command, StringRef data) {
+  fwrite(data.data(), data.size(), 1, stderr);
+  fflush(stderr);
+}
+
+void BuildSystemFrontendDelegate::commandHadNote(Command* command, StringRef data) {
+  fwrite(data.data(), data.size(), 1, stdout);
+  fflush(stdout);
+}
+
+void BuildSystemFrontendDelegate::commandHadWarning(Command* command, StringRef data) {
+  fwrite(data.data(), data.size(), 1, stdout);
+  fflush(stdout);
+}
+
 void BuildSystemFrontendDelegate::commandFinished(Command*, CommandResult) {
 }
 

--- a/unittests/BuildSystem/MockBuildSystemDelegate.h
+++ b/unittests/BuildSystem/MockBuildSystemDelegate.h
@@ -123,6 +123,28 @@ public:
     }
   }
 
+  virtual void commandHadError(Command* command, StringRef data) {
+    llvm::errs() << "error: " << command->getName() << ": " << data.str() << "\n";
+    {
+      std::unique_lock<std::mutex> lock(messagesMutex);
+      messages.push_back(data.str());
+    }
+  }
+
+  virtual void commandHadNote(Command* command, StringRef data) {
+    if (trackAllMessages) {
+      std::unique_lock<std::mutex> lock(messagesMutex);
+      messages.push_back(("commandNote(" + command->getName() + ") " + data).str());
+    }
+  }
+
+  virtual void commandHadWarning(Command* command, StringRef data) {
+    if (trackAllMessages) {
+      std::unique_lock<std::mutex> lock(messagesMutex);
+      messages.push_back(("commandWarning(" + command->getName() + ") " + data).str());
+    }
+  }
+
   virtual void commandFinished(Command* command, CommandResult result) {
     if (trackAllMessages) {
       std::unique_lock<std::mutex> lock(messagesMutex);


### PR DESCRIPTION
Commands can now report additional errors, notes and warnings, not tied to a command process as before. This is used by the `StaleFileRemoval` command to report deleted files and demotes all its errors to warnings.

See <https://github.com/apple/swift-llbuild/pull/147#discussion_r116107807>