### PR TITLE
[BuildSystem] Error if there is no root document.

### DIFF
--- a/lib/BuildSystem/BuildFile.cpp
+++ b/lib/BuildSystem/BuildFile.cpp
@@ -853,7 +853,13 @@ public:
     }
 
     auto& document = *it;
-    if (!parseRootNode(document.getRoot())) {
+    auto root = document.getRoot();
+    if (!root) {
+      error("missing document in stream");
+      return nullptr;
+    }
+
+    if (!parseRootNode(root)) {
       return nullptr;
     }
 


### PR DESCRIPTION
 - <rdar://problem/32179388> Crash with no root document