### PR TITLE
Allow stale file removal build values

### DIFF
--- a/lib/BuildSystem/ExternalCommand.cpp
+++ b/lib/BuildSystem/ExternalCommand.cpp
@@ -242,14 +242,14 @@ void ExternalCommand::provideValue(BuildSystemCommandInterface& bsci,
   assert(value.isExistingInput() || value.isMissingInput() ||
          value.isMissingOutput() || value.isFailedInput() ||
          value.isVirtualInput()  || value.isSkippedCommand() ||
-         value.isDirectoryTreeSignature());
+         value.isDirectoryTreeSignature() || value.isStaleFileRemoval());
 
   // If the input should cause this command to skip, how should it skip?
   auto getSkipValueForInput = [&]() -> llvm::Optional<BuildValue> {
     // If the value is an signature, existing, or virtual input, we are always
     // good.
     if (value.isDirectoryTreeSignature() | value.isExistingInput() ||
-        value.isVirtualInput())
+        value.isVirtualInput() || value.isStaleFileRemoval())
       return llvm::None;
 
     // We explicitly allow running the command against a missing output, under


### PR DESCRIPTION
I hit this when integrating with clients, not entirely sure why, but it seems correct, since directory tree signatures are also allowed here.