### PR TITLE
[BuildSystem] Symlink commands should expose target file information.

### DIFF
--- a/tests/BuildSystem/Build/changed-link-target.llbuild
+++ b/tests/BuildSystem/Build/changed-link-target.llbuild
@@ -4,14 +4,18 @@
 #
 # RUN: rm -rf %t.build
 # RUN: mkdir -p %t.build
+# RUN: echo "FOO-1" > %t.build/foo-1
+# RUN: echo "FOO-2" > %t.build/foo-2
 #
 # RUN: grep -A1000 "VERSION-BEGIN-[1]" %s | grep -B10000 "VERSION-END-1" | grep -ve '^--$' > %t.build/build-1.llbuild
 # RUN: %{llbuild} buildsystem build --serial --chdir %t.build -f build-1.llbuild > %t1.out
 # RUN: %{FileCheck} --check-prefix CHECK-VERSION-1 --input-file %t1.out %s
+# RUN: diff %t.build/foo %t.build/foo-1
 #
 # RUN: grep -A1000 "VERSION-BEGIN-[2]" %s | grep -B10000 "VERSION-END-2" | grep -ve '^--$' > %t.build/build-2.llbuild
 # RUN: %{llbuild} buildsystem build --serial --chdir %t.build -f build-2.llbuild > %t2.out 2> %t2.err
 # RUN: %{FileCheck} --check-prefix CHECK-VERSION-2 --input-file %t2.out %s
+# RUN: diff %t.build/foo %t.build/foo-2
 
 ##### VERSION-BEGIN-1 #####
 

--- a/tests/BuildSystem/Build/dep-on-link-target.llbuild
+++ b/tests/BuildSystem/Build/dep-on-link-target.llbuild
@@ -1,0 +1,67 @@
+# Check behavior when a command directly depends on a file seen through a
+# symbolic link.
+#
+# RUN: rm -rf %t.build
+# RUN: mkdir -p %t.build
+# RUN: echo "input" > %t.build/input
+# RUN: cp %s %t.build/build.llbuild
+# RUN: %{llbuild} buildsystem build --serial --chdir %t.build > %t.out
+# RUN: %{FileCheck} --input-file=%t.out %s --check-prefix=CHECK-INITIAL
+# RUN: diff %t.build/input %t.build/output
+#
+# CHECK-INITIAL: LINK
+# CHECK-INITIAL: CONSUMER
+
+
+# Check that a null build does nothing.
+#
+# RUN: %{llbuild} buildsystem build --serial --chdir %t.build > %t2.out
+# RUN: echo "END-OF-FILE" >> %t2.out
+# RUN: %{FileCheck} --input-file=%t2.out %s --check-prefix=CHECK-REBUILD
+#
+# CHECK-REBUILD-NOT: LINK
+# CHECK-REBUILD-NOT: CONSUMER
+
+
+# Check that a modification triggers both uses.
+#
+# RUN: echo "MOD" >> %t.build/input
+# RUN: %{llbuild} buildsystem build --serial --chdir %t.build > %t3.out
+# RUN: %{FileCheck} --input-file=%t3.out %s --check-prefix=CHECK-AFTER-MOD
+# RUN: diff %t.build/input %t.build/output
+#
+# CHECK-AFTER-MOD: CONSUMER
+
+
+# Check that another null build does nothing.
+#
+# RUN: %{llbuild} buildsystem build --serial --chdir %t.build > %t4.out
+# RUN: echo "END-OF-FILE" >> %t4.out
+# RUN: %{FileCheck} --input-file=%t4.out %s --check-prefix=CHECK-REBUILD
+
+client:
+  name: basic
+
+targets:
+  "": ["output"]
+  
+commands:
+  # A command which consumes a generated input and reports it as a discovered dep.
+  C.consumer:
+    tool: shell
+    description: CONSUMER
+    inputs: ["link"]
+    outputs: ["output"]
+    args: cp link output
+
+  # A command which generates the discovered input.
+  #
+  # NOTE: The generated-input itself is intentionally never declared as an
+  # output here; this test is intentionally checking that we support a situation
+  # where the dependency edge is only valid due to some other explicit ordering
+  # in the build system, in this case the edge "C.consumer -> <GENERATOR>".
+  C.generator:
+    tool: symlink
+    description: LINK
+    outputs: ["link"]
+    contents: input

--- a/tests/BuildSystem/Build/output-dir-creation.llbuild
+++ b/tests/BuildSystem/Build/output-dir-creation.llbuild
@@ -23,6 +23,7 @@ commands:
     tool: phony
     inputs: ["subdir/subsubdir/file", "subdir-2/subsubdir/symlink"]
     outputs: ["<all>"]
+    allow-missing-inputs: true
   C.touch:
     tool: shell
     description: TOUCH

--- a/tests/BuildSystem/Build/symlink.llbuild
+++ b/tests/BuildSystem/Build/symlink.llbuild
@@ -1,39 +1,43 @@
 # Check the 'symlink' tool.
 #
+# NOTE: We create contents in a subdirectory of the target to ensure that the
+# changes we make don't cause the stat information of the link itself to change.
+#
 # RUN: rm -rf %t.build
 # RUN: mkdir -p %t.build
 # RUN: cp %s %t.build/build.llbuild
-# RUN: mkdir -p %t.build/symlink-target
+# RUN: mkdir -p %t.build/symlink-target/subdir
 # RUN: %{llbuild} buildsystem build --serial --chdir %t.build > %t.out
 # RUN: test -L %t.build/symlink
-# RUN: test -f %t.build/symlink-target/file
+# RUN: test -f %t.build/symlink-target/subdir/file
 # RUN: %{FileCheck} --input-file=%t.out %s
 #
 # CHECK: SYMLINK
-# CHECK: MUTATE
-
+# CHECK: USE-SYMLINK
 
 # Check that a null build does nothing.
 #
 # RUN: echo "START." > %t2.out
-# RUN: %{llbuild} buildsystem build --serial --chdir %t.build >> %t2.out
+# RUN: %{llbuild} buildsystem build --serial --trace %t2.trace --chdir %t.build >> %t2.out
 # RUN: echo "EOF" >> %t2.out
+# RUN: cat %t2.out
 # RUN: %{FileCheck} --input-file=%t2.out %s --check-prefix=CHECK-REBUILD
 #
 # CHECK-REBUILD: START
 # CHECK-REBUILD-NOT: SYMLINK
-# CHECK-REBUILD-NOT: MUTATE
+# CHECK-REBUILD-NOT: USE-SYMLINK
 # CHECK-REBUILD-NEXT: EOF
-
 
 # Ensure the symlink is recreated if necessary.
 #
 # RUN: rm -rf %t.build/symlink
 # RUN: %{llbuild} buildsystem build --serial --chdir %t.build > %t3.out
+# RUN: test -L %t.build/symlink
+# RUN: test -f %t.build/symlink-target/subdir/file
 # RUN: %{FileCheck} --input-file=%t3.out %s --check-prefix=CHECK-RECREATE
 #
 # CHECK-RECREATE: SYMLINK
-# CHECK-RECREATE: MUTATE
+# CHECK-RECREATE: USE-SYMLINK
 
 client:
   name: basic
@@ -44,17 +48,16 @@ targets:
 commands:
   C.all:
     tool: phony
-    inputs: ["symlink-target/file"]
+    inputs: ["symlink/subdir/file"]
     outputs: ["<all>"]
   C.symlink:
     tool: symlink
     description: SYMLINK
     outputs: ["symlink"]
     contents: "symlink-target"
-  C.mutate:
+  C.USE-SYMLINK:
     tool: shell
-    description: MUTATE
+    description: USE-SYMLINK
     inputs: ["symlink"]
-    outputs: ["symlink-target/file"]
-    # We use touch -r here to ensure the file time is modified to something different than the symlink.
-    args: touch symlink-target/file && touch -r / symlink-target
+    outputs: ["symlink/subdir/file"]
+    args: touch symlink/subdir/file

--- a/unittests/BuildSystem/BuildSystemFrontendTest.cpp
+++ b/unittests/BuildSystem/BuildSystemFrontendTest.cpp
@@ -450,6 +450,7 @@ commands:
         inputs: ["2"]
         outputs: ["3"]
         args: rm 2
+        allow-missing-inputs: true
 )END");
   // We need to delete the symlink ourselves, because llvm's remove()
   // currently refuses to delete symlinks.


### PR DESCRIPTION
 - When a node was depending on a symlink, we were ending up depending on 
   the symlink command because it is the producer of that node. However, that
   is broken because the command is typically depending on the *contents* of
   the file, and the producer was only tracking the lstat() information as
   part of its build value.

 - Instead, change the symlink command to vend the target file information (i.e.
   stat()) as its build result, and only track the lstat() information internally
   for the purposes of knowing when the command needs to rerun.

 - <rdar://problem/31455060> Missing command execution when link target changes