### PR TITLE
Use `set` instead of `unordered_set`

### DIFF
--- a/lib/BuildSystem/BuildSystem.cpp
+++ b/lib/BuildSystem/BuildSystem.cpp
@@ -46,7 +46,7 @@
 
 #include <memory>
 #include <mutex>
-#include <unordered_set>
+#include <set>
 
 #include <unistd.h>
 
@@ -2421,8 +2421,8 @@ class StaleFileRemovalCommand : public Command {
     }
 
     std::vector<StringRef> priorValueList = priorValue.getStaleFileList();
-    std::unordered_set<std::string> priorNodes(priorValueList.begin(), priorValueList.end());
-    std::unordered_set<std::string> expectedNodes(expectedOutputs.begin(), expectedOutputs.end());
+    std::set<std::string> priorNodes(priorValueList.begin(), priorValueList.end());
+    std::set<std::string> expectedNodes(expectedOutputs.begin(), expectedOutputs.end());
 
     std::set_difference(priorNodes.begin(), priorNodes.end(),
                         expectedNodes.begin(), expectedNodes.end(),


### PR DESCRIPTION
Turns out that `std::set_difference` does not work with unordered sets, but this didn't become apparent with the smaller sets we are using in the unit tests.

> The elements in the ranges shall already be ordered according to this same criterion