### PR TITLE
Fix `BuildSystemTaskTests`

### DIFF
--- a/unittests/BuildSystem/BuildSystemTaskTests.cpp
+++ b/unittests/BuildSystem/BuildSystemTaskTests.cpp
@@ -728,7 +728,7 @@ commands:
     ASSERT_EQ(std::vector<std::string>({
       "commandPreparing(C.1)",
       "commandStarted(C.1)",
-      "commandFinished(C.1)",
+      "commandFinished(C.1: 0)",
     }), delegate.getMessages());
   }
 


### PR DESCRIPTION
This one needed to be updated after changes to `MockBuildSystemDelegate`.