### PR TITLE
Stale file removal fixes for Swift 4.0

### DIFF
--- a/include/llbuild/BuildSystem/BuildSystem.h
+++ b/include/llbuild/BuildSystem/BuildSystem.h
@@ -176,6 +176,21 @@ public:
   /// commands).
   virtual void commandStarted(Command*) = 0;
 
+  /// Called to report an error during the execution of a command.
+  ///
+  /// \param data - The error message.
+  virtual void commandHadError(Command*, StringRef data) = 0;
+
+  /// Called to report a note during the execution of a command.
+  ///
+  /// \param data - The note message.
+  virtual void commandHadNote(Command*, StringRef data) = 0;
+
+  /// Called to report a warning during the execution of a command.
+  ///
+  /// \param data - The warning message.
+  virtual void commandHadWarning(Command*, StringRef data) = 0;
+
   /// Called by the build system to report a command has completed.
   ///
   /// \param result - The result of command (e.g. success, failure, etc).

--- a/include/llbuild/BuildSystem/BuildSystem.h
+++ b/include/llbuild/BuildSystem/BuildSystem.h
@@ -39,6 +39,8 @@ class BuildKey;
 class BuildValue;
 class Command;
 class Tool;
+
+bool pathIsPrefixedByPath(std::string path, std::string prefixPath);
   
 class BuildSystemDelegate {
   // DO NOT COPY

--- a/include/llbuild/BuildSystem/BuildSystemFrontend.h
+++ b/include/llbuild/BuildSystem/BuildSystemFrontend.h
@@ -199,6 +199,21 @@ public:
   /// corresponding \see commandFinished() call.
   virtual void commandStarted(Command*) override;
 
+  /// Called to report an error during the execution of a command.
+  ///
+  /// \param data - The error message.
+  virtual void commandHadError(Command*, StringRef data) override;
+
+  /// Called to report a note during the execution of a command.
+  ///
+  /// \param data - The note message.
+  virtual void commandHadNote(Command*, StringRef data) override;
+
+  /// Called to report a warning during the execution of a command.
+  ///
+  /// \param data - The warning message.
+  virtual void commandHadWarning(Command*, StringRef data) override;
+
   /// Called by the build system to report a command has completed.
   ///
   /// \param result - The result of command (e.g. success, failure, etc).

--- a/lib/BuildSystem/BuildSystem.cpp
+++ b/lib/BuildSystem/BuildSystem.cpp
@@ -46,7 +46,7 @@
 
 #include <memory>
 #include <mutex>
-#include <unordered_set>
+#include <set>
 
 #include <unistd.h>
 
@@ -2421,8 +2421,8 @@ class StaleFileRemovalCommand : public Command {
     }
 
     std::vector<StringRef> priorValueList = priorValue.getStaleFileList();
-    std::unordered_set<std::string> priorNodes(priorValueList.begin(), priorValueList.end());
-    std::unordered_set<std::string> expectedNodes(expectedOutputs.begin(), expectedOutputs.end());
+    std::set<std::string> priorNodes(priorValueList.begin(), priorValueList.end());
+    std::set<std::string> expectedNodes(expectedOutputs.begin(), expectedOutputs.end());
 
     std::set_difference(priorNodes.begin(), priorNodes.end(),
                         expectedNodes.begin(), expectedNodes.end(),

--- a/lib/BuildSystem/BuildSystem.cpp
+++ b/lib/BuildSystem/BuildSystem.cpp
@@ -2457,8 +2457,7 @@ class StaleFileRemovalCommand : public Command {
 
       // Check if the file is located under one of the allowed root paths.
       for (auto root : roots) {
-        auto res = std::mismatch(root.begin(), root.end(), fileToDelete.begin());
-        if (res.first == root.end() && ((*(res.second++) == '\0') || (*(res.second++) == path_separator))) {
+        if (pathIsPrefixedByPath(fileToDelete, root)) {
           isLocatedUnderRootPath = true;
         }
       }
@@ -2649,4 +2648,14 @@ void BuildSystem::cancel() {
 
 void BuildSystem::resetForBuild() {
   static_cast<BuildSystemImpl*>(impl)->resetForBuild();
+}
+
+// This function checks if the given path is prefixed by another path.
+bool llbuild::buildsystem::pathIsPrefixedByPath(std::string path, std::string prefixPath) {
+  static char path_separator = llvm::sys::path::get_separator()[0];
+  auto res = std::mismatch(prefixPath.begin(), prefixPath.end(), path.begin());
+  // Check if `prefixPath` has been exhausted or just a separator remains.
+  bool isPrefix = res.first == prefixPath.end() || (*(res.first++) == path_separator);
+  // Check if `path` has been exhausted or just a separator remains.
+  return isPrefix && (res.second == path.end() || (*(res.second++) == path_separator));
 }

--- a/lib/BuildSystem/BuildSystemFrontend.cpp
+++ b/lib/BuildSystem/BuildSystemFrontend.cpp
@@ -480,6 +480,21 @@ void BuildSystemFrontendDelegate::commandStarted(Command* command) {
   fflush(stdout);
 }
 
+void BuildSystemFrontendDelegate::commandHadError(Command* command, StringRef data) {
+  fwrite(data.data(), data.size(), 1, stderr);
+  fflush(stderr);
+}
+
+void BuildSystemFrontendDelegate::commandHadNote(Command* command, StringRef data) {
+  fwrite(data.data(), data.size(), 1, stdout);
+  fflush(stdout);
+}
+
+void BuildSystemFrontendDelegate::commandHadWarning(Command* command, StringRef data) {
+  fwrite(data.data(), data.size(), 1, stdout);
+  fflush(stdout);
+}
+
 void BuildSystemFrontendDelegate::commandFinished(Command*, CommandResult) {
 }
 

--- a/lib/BuildSystem/ExternalCommand.cpp
+++ b/lib/BuildSystem/ExternalCommand.cpp
@@ -242,14 +242,14 @@ void ExternalCommand::provideValue(BuildSystemCommandInterface& bsci,
   assert(value.isExistingInput() || value.isMissingInput() ||
          value.isMissingOutput() || value.isFailedInput() ||
          value.isVirtualInput()  || value.isSkippedCommand() ||
-         value.isDirectoryTreeSignature());
+         value.isDirectoryTreeSignature() || value.isStaleFileRemoval());
 
   // If the input should cause this command to skip, how should it skip?
   auto getSkipValueForInput = [&]() -> llvm::Optional<BuildValue> {
     // If the value is an signature, existing, or virtual input, we are always
     // good.
     if (value.isDirectoryTreeSignature() | value.isExistingInput() ||
-        value.isVirtualInput())
+        value.isVirtualInput() || value.isStaleFileRemoval())
       return llvm::None;
 
     // We explicitly allow running the command against a missing output, under

--- a/unittests/BuildSystem/BuildSystemTaskTests.cpp
+++ b/unittests/BuildSystem/BuildSystemTaskTests.cpp
@@ -776,4 +776,14 @@ commands:
   ASSERT_FALSE(std::find(messages.begin(), messages.end(), "cannot remove stale file '" + linkFileList + "': No such file or directory") != messages.end());
 }
 
+TEST(BuildSystemTaskTests, staleFileRemovalPathIsPrefixedByPath) {
+  ASSERT_TRUE(pathIsPrefixedByPath("/foo/bar", "/foo"));
+  ASSERT_TRUE(pathIsPrefixedByPath("/foo", "/foo"));
+  ASSERT_TRUE(pathIsPrefixedByPath("/foo/", "/foo"));
+  ASSERT_TRUE(pathIsPrefixedByPath("/foo", "/foo/"));
+
+  ASSERT_FALSE(pathIsPrefixedByPath("/bar", "/foo"));
+  ASSERT_FALSE(pathIsPrefixedByPath("/foobar", "/foo"));
+}
+
 }

--- a/unittests/BuildSystem/BuildSystemTaskTests.cpp
+++ b/unittests/BuildSystem/BuildSystemTaskTests.cpp
@@ -728,7 +728,7 @@ commands:
     ASSERT_EQ(std::vector<std::string>({
       "commandPreparing(C.1)",
       "commandStarted(C.1)",
-      "commandFinished(C.1)",
+      "commandFinished(C.1: 0)",
     }), delegate.getMessages());
   }
 

--- a/unittests/BuildSystem/MockBuildSystemDelegate.h
+++ b/unittests/BuildSystem/MockBuildSystemDelegate.h
@@ -123,6 +123,28 @@ public:
     }
   }
 
+  virtual void commandHadError(Command* command, StringRef data) {
+    llvm::errs() << "error: " << command->getName() << ": " << data.str() << "\n";
+    {
+      std::unique_lock<std::mutex> lock(messagesMutex);
+      messages.push_back(data.str());
+    }
+  }
+
+  virtual void commandHadNote(Command* command, StringRef data) {
+    if (trackAllMessages) {
+      std::unique_lock<std::mutex> lock(messagesMutex);
+      messages.push_back(("commandNote(" + command->getName() + ") " + data).str());
+    }
+  }
+
+  virtual void commandHadWarning(Command* command, StringRef data) {
+    if (trackAllMessages) {
+      std::unique_lock<std::mutex> lock(messagesMutex);
+      messages.push_back(("commandWarning(" + command->getName() + ") " + data).str());
+    }
+  }
+
   virtual void commandFinished(Command* command, CommandResult result) {
     if (trackAllMessages) {
       std::unique_lock<std::mutex> lock(messagesMutex);


### PR DESCRIPTION
These are cherry-picked commits from `master` for stale file removal fixes we want to take for Swift 4.0.

The changes are from the following PRs: #158, #167, #169, #170 and #175.