### PR TITLE
[BuildSystem] Add an experimental feature to expose both views of a s…

### DIFF
--- a/tests/BuildSystem/Build/dep-on-link-target.llbuild
+++ b/tests/BuildSystem/Build/dep-on-link-target.llbuild
@@ -1,0 +1,67 @@
+# Check behavior when a command directly depends on a file seen through a
+# symbolic link.
+#
+# RUN: rm -rf %t.build
+# RUN: mkdir -p %t.build
+# RUN: echo "input" > %t.build/input
+# RUN: cp %s %t.build/build.llbuild
+# RUN: %{llbuild} buildsystem build --serial --chdir %t.build > %t.out
+# RUN: %{FileCheck} --input-file=%t.out %s --check-prefix=CHECK-INITIAL
+# RUN: diff %t.build/input %t.build/output
+#
+# CHECK-INITIAL: LINK
+# CHECK-INITIAL: CONSUMER
+
+
+# Check that a null build does nothing.
+#
+# RUN: %{llbuild} buildsystem build --serial --chdir %t.build > %t2.out
+# RUN: echo "END-OF-FILE" >> %t2.out
+# RUN: %{FileCheck} --input-file=%t2.out %s --check-prefix=CHECK-REBUILD
+#
+# CHECK-REBUILD-NOT: LINK
+# CHECK-REBUILD-NOT: CONSUMER
+
+
+# Check that a modification triggers only the re-consumption.
+#
+# RUN: echo "MOD" >> %t.build/input
+# RUN: %{llbuild} buildsystem build --serial --chdir %t.build > %t3.out
+# RUN: %{FileCheck} --input-file=%t3.out %s --check-prefix=CHECK-AFTER-MOD
+# RUN: diff %t.build/input %t.build/output
+#
+# CHECK-AFTER-MOD-NOT: LINK
+# CHECK-AFTER-MOD: CONSUMER
+
+
+# Check that another null build does nothing.
+#
+# RUN: %{llbuild} buildsystem build --serial --chdir %t.build > %t4.out
+# RUN: echo "END-OF-FILE" >> %t4.out
+# RUN: %{FileCheck} --input-file=%t4.out %s --check-prefix=CHECK-REBUILD
+
+client:
+  name: basic
+
+targets:
+  "": ["output"]
+  
+commands:
+  C.consumer:
+    tool: shell
+    description: CONSUMER
+    inputs: ["link"]
+    outputs: ["output"]
+    args: cp link output
+
+  C.phony:
+    tool: phony
+    inputs: ["<link>"]
+    outputs: ["link"]
+    
+  C.link:
+    tool: symlink
+    description: LINK
+    outputs: ["<link>"]
+    link-output-path: "link"
+    contents: input


### PR DESCRIPTION
…ymlink.

 - There was previously no way to safely see the `stat()`-level consistency of a
   symlink target, this adds an experimental (albeit very clunky) way to do so
   by declaring a separate argument to define the link output path from the
   declared output node.