### PR TITLE
Add command reporting delegate methods to C API

### DIFF
--- a/products/libllbuild/BuildSystem-C-API.cpp
+++ b/products/libllbuild/BuildSystem-C-API.cpp
@@ -250,6 +250,36 @@ public:
     }
   }
 
+  virtual void commandHadError(Command* command, StringRef message) override {
+    if (cAPIDelegate.command_had_error) {
+      llb_data_t cMessage { message.size(), (const uint8_t*) message.data() };
+      cAPIDelegate.command_had_error(
+          cAPIDelegate.context,
+          (llb_buildsystem_command_t*) command,
+          &cMessage);
+    }
+  }
+
+  virtual void commandHadNote(Command* command, StringRef message) override {
+    if (cAPIDelegate.command_had_note) {
+      llb_data_t cMessage { message.size(), (const uint8_t*) message.data() };
+      cAPIDelegate.command_had_note(
+          cAPIDelegate.context,
+          (llb_buildsystem_command_t*) command,
+          &cMessage);
+    }
+  }
+
+  virtual void commandHadWarning(Command* command, StringRef message) override {
+    if (cAPIDelegate.command_had_warning) {
+      llb_data_t cMessage { message.size(), (const uint8_t*) message.data() };
+      cAPIDelegate.command_had_warning(
+         cAPIDelegate.context,
+         (llb_buildsystem_command_t*) command,
+         &cMessage);
+    }
+  }
+
   virtual void commandProcessStarted(Command* command,
                                      ProcessHandle handle) override {
     if (cAPIDelegate.command_process_started) {

--- a/products/libllbuild/public-api/llbuild/buildsystem.h
+++ b/products/libllbuild/public-api/llbuild/buildsystem.h
@@ -320,6 +320,27 @@ typedef struct llb_buildsystem_delegate_t_ {
                            llb_buildsystem_command_t* command,
                            llb_buildsystem_command_result_t result);
 
+  /// Called to report an error during the execution of a command.
+  ///
+  /// Xparam data The error message.
+  void (*command_had_error)(void* context,
+                            llb_buildsystem_command_t* command,
+                            const llb_data_t* data);
+
+  /// Called to report a note during the execution of a command.
+  ///
+  /// Xparam data The note message.
+  void (*command_had_note)(void* context,
+                           llb_buildsystem_command_t* command,
+                           const llb_data_t* data);
+
+  /// Called to report a warning during the execution of a command.
+  ///
+  /// Xparam data The warning message.
+  void (*command_had_warning)(void* context,
+                           llb_buildsystem_command_t* command,
+                           const llb_data_t* data);
+
   /// Called when a command's job has started executing an external process.
   ///
   /// The system guarantees that any commandProcessStarted() call will be paired

--- a/products/libllbuild/public-api/llbuild/llbuild.h
+++ b/products/libllbuild/public-api/llbuild/llbuild.h
@@ -38,12 +38,14 @@
 ///
 /// Version History:
 ///
+/// 3: Added command_had_error, command_had_note and command_had_warning delegate methods.
+///
 /// 2: Added `llb_buildsystem_command_result_t` parameter to command_finished.
 ///
 /// 1: Added `environment` parameter to llb_buildsystem_invocation_t.
 ///
 /// 0: Pre-history
-#define LLBUILD_API_VERSION 2
+#define LLBUILD_API_VERSION 3
 
 /// Get the full version of the llbuild library.
 LLBUILD_EXPORT const char* llb_get_full_version_string(void);


### PR DESCRIPTION
This is a follow-up to #158 to add the newly added delegate methods to llbuild's C API.