### PR TITLE
[BuildSystem] Buffer command output at frontend level.

### DIFF
--- a/include/llbuild/BuildSystem/BuildExecutionQueue.h
+++ b/include/llbuild/BuildSystem/BuildExecutionQueue.h
@@ -150,6 +150,9 @@ public:
 /// All delegate interfaces are invoked synchronously by the execution queue,
 /// and should defer any long running operations to avoid blocking the queue
 /// unnecessarily.
+///
+/// NOTE: The delegate *MUST* be thread-safe with respect to all calls, which
+/// will arrive concurrently and without any specified thread.
 class BuildExecutionQueueDelegate {
   // DO NOT COPY
   BuildExecutionQueueDelegate(const BuildExecutionQueueDelegate&)


### PR DESCRIPTION
 - The lower level shouldn't buffer the output, because clients might want to
   see the streaming output from commands as soon as it comes over the pipe.

 - <rdar://problem/32233420> llbuild shouldn't buffer subprocess output before sending to delegate