### PR TITLE
[Xcode] Add an easy way to enable code signing.

### DIFF
--- a/Xcode/Configs/Common.xcconfig
+++ b/Xcode/Configs/Common.xcconfig
@@ -13,7 +13,7 @@
 // Set the default product name.
 PRODUCT_NAME = $(TARGET_NAME)
 
-// Set the versioning system to "Apple Generic" for all projects.
+// Set the versioning system to "Apple Generic" for all targets.
 VERSIONING_SYSTEM = apple-generic
 
 // Do not always search user paths.
@@ -21,3 +21,17 @@ ALWAYS_SEARCH_USER_PATHS = NO
 
 // Headermaps are disabled.
 USE_HEADERMAP = NO
+
+// MARK: Signing Support
+
+// Enable code signing, if appropriate.
+LLBUILD_ENABLE_SIGNING = NO
+
+LLBUILD_CODE_SIGN_IDENTITY = $(LLBUILD_CODE_SIGN_IDENTITY__$(LLBUILD_ENABLE_SIGNING))
+LLBUILD_CODE_SIGN_IDENTITY__NO =
+LLBUILD_CODE_SIGN_IDENTITY__YES = -
+
+// The entitlements to use for binaries.
+CODE_SIGN_ENTITLEMENTS = $(LLBUILD_CODE_SIGN_ENTITLEMENTS__producttype_eq_$(PRODUCT_TYPE:identifier))
+LLBUILD_CODE_SIGN_ENTITLEMENTS__producttype_eq_com_apple_product_type_tool = $(LLBUILD_TOOL_CODE_SIGN_ENTITLEMENTS)
+LLBUILD_TOOL_CODE_SIGN_ENTITLEMENTS =

--- a/llbuild.xcodeproj/project.pbxproj
+++ b/llbuild.xcodeproj/project.pbxproj
@@ -3253,7 +3253,8 @@
 		E1604CAF1BB9E01D001153A1 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				INSTALL_PATH = "$(DT_TOOLCHAIN_DIR)/usr/local/bin";
+				CODE_SIGN_IDENTITY = "$(LLBUILD_CODE_SIGN_IDENTITY)";
+				INSTALL_PATH = "$(DT_TOOLCHAIN_DIR)/usr/bin";
 				SKIP_INSTALL = NO;
 			};
 			name = Debug;
@@ -3261,7 +3262,8 @@
 		E1604CB01BB9E01D001153A1 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				INSTALL_PATH = "$(DT_TOOLCHAIN_DIR)/usr/local/bin";
+				CODE_SIGN_IDENTITY = "$(LLBUILD_CODE_SIGN_IDENTITY)";
+				INSTALL_PATH = "$(DT_TOOLCHAIN_DIR)/usr/bin";
 				SKIP_INSTALL = NO;
 			};
 			name = Release;
@@ -3484,6 +3486,7 @@
 		E1A224C819F999B80059043E /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CODE_SIGN_IDENTITY = "$(LLBUILD_CODE_SIGN_IDENTITY)";
 				INSTALL_PATH = "$(DT_TOOLCHAIN_DIR)/usr/local/bin";
 				PRODUCT_NAME = llbuild;
 				SKIP_INSTALL = NO;
@@ -3493,6 +3496,7 @@
 		E1A224C919F999B80059043E /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CODE_SIGN_IDENTITY = "$(LLBUILD_CODE_SIGN_IDENTITY)";
 				INSTALL_PATH = "$(DT_TOOLCHAIN_DIR)/usr/local/bin";
 				PRODUCT_NAME = llbuild;
 				SKIP_INSTALL = NO;
@@ -3692,6 +3696,7 @@
 		E1D191C41B47232B000C4E95 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CODE_SIGN_IDENTITY = "$(LLBUILD_CODE_SIGN_IDENTITY)";
 				CURRENT_PROJECT_VERSION = 1;
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
@@ -3711,6 +3716,7 @@
 		E1D191C51B47232B000C4E95 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CODE_SIGN_IDENTITY = "$(LLBUILD_CODE_SIGN_IDENTITY)";
 				CURRENT_PROJECT_VERSION = 1;
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;


### PR DESCRIPTION
 - This isn't actually on, but it makes it easy to turn on via a simple change
   to the xcconfig file.