### PR TITLE
[Core] Fix a race condition in task cancellation.

### DIFF
--- a/lib/BuildSystem/BuildSystem.cpp
+++ b/lib/BuildSystem/BuildSystem.cpp
@@ -1125,7 +1125,7 @@ Rule BuildSystemEngineDelegate::lookupRule(const KeyType& keyData) {
       if (node->isVirtual()) {
         return Rule{
           keyData,
-          /*Action=*/ [node](BuildEngine& engine) -> Task* {
+          /*Action=*/ [](BuildEngine& engine) -> Task* {
             return engine.registerTask(new VirtualInputNodeTask());
           },
           /*IsValid=*/ [node](BuildEngine& engine, const Rule& rule,


### PR DESCRIPTION
 - This also renames the cancellation method to be more obvious about
   when it is used.

 - When task cancellation was done as part of an error handling path,
   there was a potential race with any outstanding work being completed.
   We solve this by forcing (engine-level) cancellation to wait for any
   outstanding work before completing (to avoid needing to introduce
   any additional synchronization logic).

 - This is currently very improbable, since errors aren’t ever expected,
   but that will change once we expose engine cancellation to clients.