### PR TITLE
Improved build cancellation

### DIFF
--- a/include/llbuild/Core/BuildEngine.h
+++ b/include/llbuild/Core/BuildEngine.h
@@ -280,8 +280,8 @@ public:
 
   /// Cancel the currently running build.
   ///
-  /// The engine guarantees that it will not *start* any task after it has been
-  /// cancelled.
+  /// The engine guarantees that it will not *start* any task after processing
+  /// the current engine work loop iteration after it has been cancelled.
   ///
   /// This method is thread-safe.
   ///

--- a/include/llbuild/Core/BuildEngine.h
+++ b/include/llbuild/Core/BuildEngine.h
@@ -91,6 +91,9 @@ struct Result {
 /// complete its computation and provide the output. The Task is responsible for
 /// providing the engine with the computed value when ready using \see
 /// BuildEngine::taskIsComplete().
+///
+/// A task which has been cancelled may be destroyed without any of the above
+/// behaviors having been completed.
 class Task {
 public:
   Task() {}
@@ -275,6 +278,21 @@ public:
   /// discovered currently.
   const ValueType& build(const KeyType& key);
 
+  /// Cancel the currently running build.
+  ///
+  /// The engine guarantees that it will not *start* any task after it has been
+  /// cancelled.
+  ///
+  /// This method is thread-safe.
+  ///
+  /// This method should only be used when a build is actively running. Invoking
+  /// this method before a build has started will have no effect.
+  //
+  // FIXME: This method is hard to use correctly, we should modify build to
+  // return an explicit object to represent an in-flight build, and then expose
+  // cancellation on that.
+  void cancelBuild();
+  
   /// Attach a database for persisting build state.
   ///
   /// A database should only be attached immediately after creating the engine,

--- a/lib/Core/BuildEngine.cpp
+++ b/lib/Core/BuildEngine.cpp
@@ -20,6 +20,7 @@
 
 #include "BuildEngineTrace.h"
 
+#include <atomic>
 #include <algorithm>
 #include <cassert>
 #include <cstdio>
@@ -71,6 +72,9 @@ class BuildEngineImpl {
   /// The current build iteration, used to sequentially timestamp build results.
   uint64_t currentTimestamp = 0;
 
+  /// Whether the build should be cancelled.
+  std::atomic<bool> buildCancelled{ false };
+  
   /// The queue of input requests to process.
   struct TaskInputRequest {
     /// The task making the request.
@@ -640,6 +644,13 @@ private:
     while (true) {
       bool didWork = false;
 
+      // Cancel the build, if requested.
+      if (buildCancelled) {
+        // Force completion of all outstanding tasks.
+        cancelRemainingTasks();
+        return false;
+      }
+      
       // Process all of the pending rule scan requests.
       //
       // FIXME: We don't want to process all of these requests, this amounts to
@@ -1266,6 +1277,7 @@ public:
       trace->buildStarted();
 
     // Run the build engine, to process any necessary tasks.
+    buildCancelled = false;
     bool success = executeTasks(key);
     
     // Update the build database, if attached.
@@ -1306,6 +1318,15 @@ public:
     return ruleInfo.result.value;
   }
 
+  void cancelBuild() {
+    // Set the build cancelled marker.
+    //
+    // We do not need to handle waking the engine up, if it is waiting, because
+    // our current cancellation model requires us to wait for all outstanding
+    // tasks in any case.
+    buildCancelled = true;
+  }
+  
   bool attachDB(std::unique_ptr<BuildDB> database, std::string* error_out) {
     assert(!db && "invalid attachDB() call");
     assert(currentTimestamp == 0 && "invalid attachDB() call");
@@ -1501,6 +1522,10 @@ void BuildEngine::addRule(Rule&& rule) {
 
 const ValueType& BuildEngine::build(const KeyType& key) {
   return static_cast<BuildEngineImpl*>(impl)->build(key);
+}
+
+void BuildEngine::cancelBuild() {
+  return static_cast<BuildEngineImpl*>(impl)->cancelBuild();
 }
 
 void BuildEngine::dumpGraphToFile(const std::string& path) {

--- a/llbuild.xcodeproj/project.pbxproj
+++ b/llbuild.xcodeproj/project.pbxproj
@@ -125,6 +125,7 @@
 		E120B9ED1E4E65EB00B28469 /* BinaryCodingTests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E120B9EB1E4E65EB00B28469 /* BinaryCodingTests.cpp */; };
 		E120B9EE1E4E65EB00B28469 /* ShellUtilityTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E120B9EC1E4E65EB00B28469 /* ShellUtilityTest.cpp */; };
 		E120B9F11E4E669F00B28469 /* BinaryCodingPerfTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = E120B9F01E4E669F00B28469 /* BinaryCodingPerfTests.mm */; };
+		E124FC922075370E00ECCC50 /* BuildEngineCancellationTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E124FC912075370D00ECCC50 /* BuildEngineCancellationTest.cpp */; };
 		E12BFF181C4972D900B8D20F /* libsqlite3.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = E1E221081A00B82100957481 /* libsqlite3.dylib */; };
 		E12BFF191C4972E000B8D20F /* libcurses.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = E15B6EC61B546A2C00643066 /* libcurses.dylib */; };
 		E12BFF1A1C4972F000B8D20F /* libllbuildBuildSystem.a in Frameworks */ = {isa = PBXBuildFile; fileRef = E1B839571B541BFD00DB876B /* libllbuildBuildSystem.a */; };
@@ -853,6 +854,7 @@
 		E120B9EC1E4E65EB00B28469 /* ShellUtilityTest.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ShellUtilityTest.cpp; sourceTree = "<group>"; };
 		E120B9EF1E4E65FC00B28469 /* BinaryCoding.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BinaryCoding.h; sourceTree = "<group>"; };
 		E120B9F01E4E669F00B28469 /* BinaryCodingPerfTests.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = BinaryCodingPerfTests.mm; sourceTree = "<group>"; };
+		E124FC912075370D00ECCC50 /* BuildEngineCancellationTest.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = BuildEngineCancellationTest.cpp; sourceTree = "<group>"; };
 		E12E12A71AD50AE500ACE7B3 /* CommandLineStatusOutput.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = CommandLineStatusOutput.cpp; sourceTree = "<group>"; };
 		E12E12A81AD50AE500ACE7B3 /* CommandLineStatusOutput.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CommandLineStatusOutput.h; sourceTree = "<group>"; };
 		E138129C1C536CFC000092C0 /* FileSystem.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FileSystem.h; sourceTree = "<group>"; };
@@ -1855,6 +1857,7 @@
 			isa = PBXGroup;
 			children = (
 				E1A224B619F998D40059043E /* CMakeLists.txt */,
+				E124FC912075370D00ECCC50 /* BuildEngineCancellationTest.cpp */,
 				E1A224B519F998D40059043E /* BuildEngineTest.cpp */,
 				E1A0B1001C9717BA006DA08F /* DependencyInfoParserTest.cpp */,
 				E10FE0D61B7313D50059D086 /* DepsBuildEngineTest.cpp */,
@@ -3128,6 +3131,7 @@
 				E1A0B1011C9717BA006DA08F /* DependencyInfoParserTest.cpp in Sources */,
 				E1A224F619F99D940059043E /* BuildEngineTest.cpp in Sources */,
 				E10FE0D71B7313D50059D086 /* DepsBuildEngineTest.cpp in Sources */,
+				E124FC922075370E00ECCC50 /* BuildEngineCancellationTest.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/unittests/Core/BuildEngineCancellationTest.cpp
+++ b/unittests/Core/BuildEngineCancellationTest.cpp
@@ -1,0 +1,155 @@
+//===- unittests/Core/BuildEngineCancellationTest.cpp ---------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2017-2018 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#include "llbuild/Core/BuildEngine.h"
+
+#include "llbuild/Core/BuildDB.h"
+
+#include "llvm/ADT/StringMap.h"
+#include "llvm/Support/ErrorHandling.h"
+
+#include "gtest/gtest.h"
+
+#include <unordered_map>
+#include <vector>
+
+using namespace llbuild;
+using namespace llbuild::core;
+
+namespace {
+
+class SimpleBuildEngineDelegate : public core::BuildEngineDelegate {
+private:
+  virtual core::Rule lookupRule(const core::KeyType& key) override {
+    // We never expect dynamic rule lookup.
+    fprintf(stderr, "error: unexpected rule lookup for \"%s\"\n",
+            key.c_str());
+    abort();
+    return core::Rule();
+  }
+
+  virtual void cycleDetected(const std::vector<core::Rule*>& items) override {
+    error("unexpected cycle detected");
+  }
+
+  virtual void error(const Twine& message) override {
+    fprintf(stderr, "error: %s\n", message.str().c_str());
+    abort();
+  }
+};
+
+static int32_t intFromValue(const core::ValueType& value) {
+  assert(value.size() == 4);
+  return ((value[0] << 0) |
+          (value[1] << 8) |
+          (value[2] << 16) |
+          (value[3] << 24));
+}
+static core::ValueType intToValue(int32_t value) {
+  std::vector<uint8_t> result(4);
+  result[0] = (value >> 0) & 0xFF;
+  result[1] = (value >> 8) & 0xFF;
+  result[2] = (value >> 16) & 0xFF;
+  result[3] = (value >> 24) & 0xFF;
+  return result;
+}
+
+// Simple task implementation which takes a fixed set of dependencies, evaluates
+// them all, and then provides the output.
+class SimpleTask : public Task {
+public:
+  typedef std::function<std::vector<KeyType>()> InputListingFnType;
+  typedef std::function<int(const std::vector<int>&)> ComputeFnType;
+
+private:
+  InputListingFnType listInputs;
+  std::vector<int> inputValues;
+  ComputeFnType compute;
+
+public:
+  SimpleTask(InputListingFnType listInputs, ComputeFnType compute)
+      : listInputs(listInputs), compute(compute)
+  {
+  }
+
+  virtual void start(BuildEngine& engine) override {
+    // Compute the list of inputs.
+    auto inputs = listInputs();
+
+    // Request all of the inputs.
+    inputValues.resize(inputs.size());
+    for (int i = 0, e = inputs.size(); i != e; ++i) {
+      engine.taskNeedsInput(this, inputs[i], i);
+    }
+  }
+
+  virtual void provideValue(BuildEngine&, uintptr_t inputID,
+                            const ValueType& value) override {
+    // Update the input values.
+    assert(inputID < inputValues.size());
+    inputValues[inputID] = intFromValue(value);
+  }
+
+  virtual void inputsAvailable(core::BuildEngine& engine) override {
+    engine.taskIsComplete(this, intToValue(compute(inputValues)));
+  }
+};
+
+// Helper function for creating a simple action.
+typedef std::function<Task*(BuildEngine&)> ActionFn;
+
+static ActionFn simpleAction(const std::vector<KeyType>& inputs,
+                             SimpleTask::ComputeFnType compute) {
+  return [=] (BuildEngine& engine) {
+    return engine.registerTask(new SimpleTask([inputs]{ return inputs; },
+                                              compute)); };
+}
+
+TEST(BuildEngineCancellationTest, basic) {
+  std::vector<std::string> builtKeys;
+  SimpleBuildEngineDelegate delegate;
+  core::BuildEngine engine(delegate);
+  bool cancelIt = false;
+  engine.addRule({
+      "value-A", simpleAction({}, [&] (const std::vector<int>& inputs) {
+          builtKeys.push_back("value-A");
+          fprintf(stderr, "building A (and cancelling ? %d)\n", cancelIt);
+          if (cancelIt) {
+            engine.cancelBuild();
+          }
+          return 2; }) });
+  engine.addRule({
+      "result",
+      simpleAction({"value-A"},
+                   [&] (const std::vector<int>& inputs) {
+                     EXPECT_EQ(1U, inputs.size());
+                     EXPECT_EQ(2, inputs[0]);
+                     builtKeys.push_back("result");
+                     return inputs[0] * 3;
+                   }) });
+
+  // Build the result, cancelling during the first task.
+  cancelIt = true;
+  auto result = engine.build("result");
+  EXPECT_EQ(0U, result.size());
+  EXPECT_EQ(1U, builtKeys.size());
+  EXPECT_EQ("value-A", builtKeys[0]);
+
+  // Build again, without cancelling; both tasks should run.
+  cancelIt = false;
+  EXPECT_EQ(2 * 3, intFromValue(engine.build("result")));
+  EXPECT_EQ(2U, builtKeys.size());
+  EXPECT_EQ("value-A", builtKeys[0]);
+  EXPECT_EQ("result", builtKeys[1]);
+}
+
+}

--- a/unittests/Core/CMakeLists.txt
+++ b/unittests/Core/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_llbuild_unittest(CoreTests
   BuildEngineTest.cpp
+  BuildEngineCancellationTest.cpp
   DependencyInfoParserTest.cpp
   DepsBuildEngineTest.cpp
   MakefileDepsParserTest.cpp


### PR DESCRIPTION
This PR moves llbuild to use a proper cancellation model that actually cancels outstanding tasks, versus simply causing them to return "cancelled" build results. This fixes some serious issues with cancellation causing unnecessary rebuilds.