### PR TITLE
[BuildSystem] Fix symlink output value if the output is ever missing.

### DIFF
--- a/lib/BuildSystem/BuildSystem.cpp
+++ b/lib/BuildSystem/BuildSystem.cpp
@@ -2076,7 +2076,10 @@ class SymlinkCommand : public Command {
     // result for the output.
     assert(value.isSuccessfulCommand());
 
-    return BuildValue::makeExistingInput(value.getOutputInfo());
+    auto info = value.getOutputInfo();
+    if (info.isMissing())
+        return BuildValue::makeMissingOutput();
+    return BuildValue::makeExistingInput(info);
   }
 
   virtual bool isResultValid(BuildSystem& system,


### PR DESCRIPTION
 - This shouldn't normally be possible, since the command would have failed, but
   it can happen in corner cases when trying to use a simulated filesystem.

 - <rdar://problem/35403456> Crash in llbuild::buildsystem::BuildValue::makeExistingInput()