### PR TITLE
Fix a race in doesNotProcessDependenciesAfterCancellation

### DIFF
--- a/unittests/BuildSystem/BuildSystemTaskTests.cpp
+++ b/unittests/BuildSystem/BuildSystemTaskTests.cpp
@@ -249,6 +249,7 @@ TEST(BuildSystemTaskTests, doesNotProcessDependenciesAfterCancellation) {
       }
     }
 
+    sleep(1);
     system.cancel();
   });
 


### PR DESCRIPTION
There appears to be a race between launching `sleep` and the cancellation which lets this test fallback to SIGKILL some of the time. This delay makes sure `sleep` has finished launching and can receive the `SIGINT` that is being sent by build cancellation.