### PR TITLE
[Linux] Use SIGSYS over SIGUNUSED.

### DIFF
--- a/lib/BuildSystem/LaneBasedExecutionQueue.cpp
+++ b/lib/BuildSystem/LaneBasedExecutionQueue.cpp
@@ -278,7 +278,7 @@ public:
 #if defined(__linux__)
     sigset_t mostSignals;
     sigemptyset(&mostSignals);
-    for (int i = 1; i < SIGUNUSED; ++i) {
+    for (int i = 1; i < SIGSYS; ++i) {
       if (i == SIGKILL || i == SIGSTOP) continue;
       sigaddset(&mostSignals, i);
     }

--- a/lib/Commands/NinjaBuildCommand.cpp
+++ b/lib/Commands/NinjaBuildCommand.cpp
@@ -1181,7 +1181,7 @@ buildCommand(BuildContext& context, ninja::Command* command) {
 #if defined(__linux__)
       sigset_t mostSignals;
       sigemptyset(&mostSignals);
-      for (int i = 1; i < SIGUNUSED; ++i) {
+      for (int i = 1; i < SIGSYS; ++i) {
         if (i == SIGKILL || i == SIGSTOP) continue;
         sigaddset(&mostSignals, i);
       }


### PR DESCRIPTION
 - SIGUNUSED is removed in newer versions of glibc.

 - https://bugs.swift.org/browse/SR-6409