### PR TITLE
[Ninja] Shell-quote $in and $out

### DIFF
--- a/lib/Basic/ShellUtility.cpp
+++ b/lib/Basic/ShellUtility.cpp
@@ -18,7 +18,7 @@ namespace basic {
 
 void appendShellEscapedString(llvm::raw_ostream& os, StringRef string) {
 
-  static const std::string whitelist = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ-_/:@#%+=.,";
+  static const std::string whitelist = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890-_/:@#%+=.,";
   auto pos = string.find_first_not_of(whitelist);
 
   // We don't need any escaping just append the string and return.

--- a/tests/Ninja/Loader/builds.ninja
+++ b/tests/Ninja/Loader/builds.ninja
@@ -95,3 +95,13 @@ rule target11_rule
      command = target11 ${in} -o ${out}
 build target11: target11_rule target11_inputA | target11_inputB
      description = this is empty: "${out}" here
+
+# Check shell-quoting for $in and $out
+#
+# CHECK: build "target12 foo": target12_rule
+# CHECK-NEXT: command = "target12_rule 'target12 inputA' -o 'target12 foo'"
+# CHECK-NOT: depfile = "'target12 foo.d'"
+rule target12_rule
+  command = target12_rule $in -o $out
+  depfile = $out.d
+build target12$ foo: target12_rule target12$ inputA

--- a/unittests/Basic/ShellUtilityTest.cpp
+++ b/unittests/Basic/ShellUtilityTest.cpp
@@ -21,8 +21,8 @@ namespace {
 
 TEST(UtilityTest, basic) {
   // No escapable char.
-  std::string output = shellEscaped("input");
-  EXPECT_EQ(output, "input");
+  std::string output = shellEscaped("input01");
+  EXPECT_EQ(output, "input01");
 
   // Space.
   output = shellEscaped("input A");


### PR DESCRIPTION
According to the Ninja Manual, the $in and $out variables should be shell-quoted (if needed) if they appear in the commands. See https://ninja-build.org/manual.html#ref_log.

