### PR TITLE
<rdar://problem/34873210> When the new build system  fails with build system errors, they are not surfaced in the issue navigator

### DIFF
--- a/include/llbuild/BuildSystem/BuildSystemFrontend.h
+++ b/include/llbuild/BuildSystem/BuildSystemFrontend.h
@@ -111,11 +111,6 @@ private:
 
   /// Default implementation, cannot be overriden by subclasses.
   virtual void setFileContentsBeingParsed(StringRef buffer) override;
-
-  /// Provides a default error implementation which will delegate to the
-  /// provided source manager. Cannot be overriden by subclasses.
-  virtual void error(StringRef filename, const Token& at,
-                     const Twine& message) override;
   
 public:
   /// Create a frontend delegate.
@@ -156,6 +151,11 @@ public:
 
   /// Report a non-file specific error message.
   void error(const Twine& message);
+
+  /// Provides a default error implementation which will delegate to the
+  /// provided source manager.
+  virtual void error(StringRef filename, const Token& at,
+                     const Twine& message) override;
   
   /// @}
 

--- a/products/libllbuild/BuildSystem-C-API.cpp
+++ b/products/libllbuild/BuildSystem-C-API.cpp
@@ -381,6 +381,19 @@ public:
       free((char *)rules[i].key);
     }
   }
+
+  virtual void error(StringRef filename, const Token& at, const Twine& message) override {
+    if (cAPIDelegate.handle_diagnostic) {
+      cAPIDelegate.handle_diagnostic(cAPIDelegate.context,
+                                     llb_buildsystem_diagnostic_kind_error,
+                                     filename.str().c_str(),
+                                     -1,
+                                     -1,
+                                     message.str().c_str());
+    } else {
+        BuildSystemFrontendDelegate::error(filename, at, message);
+    }
+  }
 };
 
 class CAPIBuildSystem {


### PR DESCRIPTION
Pass calls to `BuildSystemFrontendDelegate::error()` on to the C API delegate via `handle_diagnostic`.