### PR TITLE
Do not crash if we get any sqlite errors in getKeyID().

### DIFF
--- a/include/llbuild/Core/BuildDB.h
+++ b/include/llbuild/Core/BuildDB.h
@@ -34,8 +34,11 @@ public:
 
   /// Get a unique ID for the given key.
   ///
-  /// This method is thread safe, and cannot fail.
-  virtual KeyID getKeyID(const KeyType& key) = 0;
+  /// This method is thread safe.
+  ///
+  /// \param key [out] The key whose unique ID is being returned.
+  /// \param error_out [out] Error string if return value is 0.
+  virtual KeyID getKeyID(const KeyType& key, std::string *error_out) = 0;
 
   /// Get the key corresponding to a key ID.
   ///

--- a/lib/Core/BuildEngine.cpp
+++ b/lib/Core/BuildEngine.cpp
@@ -1141,7 +1141,13 @@ public:
   KeyID getKeyID(const KeyType& key) {
     // Delegate if we have a database.
     if (db) {
-      return db->getKeyID(key);
+      std::string error;
+      KeyID id = db->getKeyID(key, &error);
+      if (!error.empty()) {
+        delegate.error(error);
+        cancelRemainingTasks();
+      }
+      return id;
     }
 
     // Otherwise use our builtin key table.

--- a/lib/Core/SQLiteBuildDB.cpp
+++ b/lib/Core/SQLiteBuildDB.cpp
@@ -417,7 +417,7 @@ public:
   /// Inserts a key if not present and always returns keyID
   /// Sometimes key will be inserted for a lookup operation
   /// but that is okay because it'll be added at somepoint anyway
-  virtual KeyID getKeyID(const KeyType& key) override {
+  virtual KeyID getKeyID(const KeyType& key, std::string *error_out) override {
     std::lock_guard<std::mutex> guard(dbMutex);
     int result;
 
@@ -449,9 +449,8 @@ public:
     assert(result == SQLITE_OK);
     result = sqlite3_step(insertIntoKeysStmt);
     if (result != SQLITE_DONE) {
-      // FIXME: We need to support error reporting here, but the engine cannot
-      // handle it currently.
-      abort();
+      *error_out = getCurrentErrorMessage();
+      return 0;
     }
 
     return sqlite3_last_insert_rowid(db);

--- a/unittests/Core/BuildEngineTest.cpp
+++ b/unittests/Core/BuildEngineTest.cpp
@@ -424,7 +424,7 @@ TEST(BuildEngineTest, incrementalDependency) {
     
     std::unordered_map<KeyType, Result> ruleResults;
 
-    virtual KeyID getKeyID(const KeyType& key) override {
+    virtual KeyID getKeyID(const KeyType& key, std::string *error_out) override {
       auto it = keyTable.insert(std::make_pair(key, false)).first;
       return (KeyID)(uintptr_t)it->getKey().data();
     }


### PR DESCRIPTION
See <rdar://problem/33897555>

I don't have a good idea on how to test this as we would need to lock the database at exactly the right time to hit this. We have some existing tests for similar errors already, though, so I think this should be fine.