### PR TITLE
[CMake] install llbuild executable

### DIFF
--- a/products/llbuild/CMakeLists.txt
+++ b/products/llbuild/CMakeLists.txt
@@ -13,3 +13,14 @@ target_link_libraries(llbuild
 if(NOT ${CMAKE_SYSTEM_NAME} STREQUAL "Windows")
   target_link_libraries(llbuild curses)
 endif()
+
+install(TARGETS llbuild
+        COMPONENT llbuild
+        DESTINATION bin)
+
+add_custom_target(install-llbuild
+                  DEPENDS llbuild
+                  COMMENT "Installing llbuild..."
+                  COMMAND "${CMAKE_COMMAND}"
+                          -DCMAKE_INSTALL_COMPONENT=llbuild
+                          -P "${CMAKE_BINARY_DIR}/cmake_install.cmake")


### PR DESCRIPTION
Hello,

From my understanding of the README, one should be able to use `llbuild` after using CMake to build and install the project.

However, there was no `install` command for the `llbuild` executable.
If it is not meant to be installed, feel free to close this PR!