### PR TITLE
[tests/Ninja/Loader] Make shell-quote test more robust

### DIFF
--- a/tests/Ninja/Loader/builds.ninja
+++ b/tests/Ninja/Loader/builds.ninja
@@ -100,7 +100,7 @@ build target11: target11_rule target11_inputA | target11_inputB
 #
 # CHECK: build "target12 foo": target12_rule
 # CHECK-NEXT: command = "target12_rule 'target12 inputA' -o 'target12 foo'"
-# CHECK-NOT: depfile = "'target12 foo.d'"
+# CHECK: depfile = "target12 foo.d"
 rule target12_rule
   command = target12_rule $in -o $out
   depfile = $out.d


### PR DESCRIPTION
The correct check for the "depfile" line should only contain single quotes
around the variable portion. I.e., 'target12 foo'.d not 'target12 foo.d'. To
avoid future fragility, change the `CHECK-NOT` to an explicit `CHECK`.

Sorry for the noise!