### PR TITLE
warning: cannot remove stale file '...': No such file or directory

### DIFF
--- a/lib/BuildSystem/BuildSystem.cpp
+++ b/lib/BuildSystem/BuildSystem.cpp
@@ -2503,7 +2503,10 @@ class StaleFileRemovalCommand : public Command {
       if (getBuildSystem(bsci.getBuildEngine()).getDelegate().getFileSystem().remove(fileToDelete)) {
         bsci.getDelegate().commandHadNote(this, "Removed stale file '" + fileToDelete + "'\n");
       } else {
-        bsci.getDelegate().commandHadWarning(this, "cannot remove stale file '" + fileToDelete + "': " + strerror(errno) + "\n");
+        // Do not warn if the file has already been deleted.
+        if (errno != ENOENT) {
+          bsci.getDelegate().commandHadWarning(this, "cannot remove stale file '" + fileToDelete + "': " + strerror(errno) + "\n");
+        }
       }
     }
 

--- a/unittests/BuildSystem/MockBuildSystemDelegate.cpp
+++ b/unittests/BuildSystem/MockBuildSystemDelegate.cpp
@@ -19,8 +19,8 @@ using namespace llbuild::unittests;
 
 MockExecutionQueueDelegate::MockExecutionQueueDelegate() {}
 
-MockBuildSystemDelegate::MockBuildSystemDelegate(bool trackAllMessages)
-    : BuildSystemDelegate("mock", 0), trackAllMessages(trackAllMessages)
+MockBuildSystemDelegate::MockBuildSystemDelegate(bool trackAllMessages, std::shared_ptr<basic::FileSystem> fileSystem)
+    : BuildSystemDelegate("mock", 0), fileSystem(fileSystem), trackAllMessages(trackAllMessages)
 {
 }
 

--- a/unittests/BuildSystem/MockBuildSystemDelegate.h
+++ b/unittests/BuildSystem/MockBuildSystemDelegate.h
@@ -53,8 +53,7 @@ private:
 };
   
 class MockBuildSystemDelegate : public BuildSystemDelegate {
-  std::unique_ptr<basic::FileSystem> fileSystem =
-    basic::createLocalFileSystem();
+  std::shared_ptr<basic::FileSystem> fileSystem;
   std::vector<std::string> messages;
   std::mutex messagesMutex;
   
@@ -63,7 +62,8 @@ class MockBuildSystemDelegate : public BuildSystemDelegate {
   bool trackAllMessages;
   
 public:
-  MockBuildSystemDelegate(bool trackAllMessages = false);
+    MockBuildSystemDelegate(bool trackAllMessages = false,
+                            std::shared_ptr<basic::FileSystem> fileSystem = basic::createLocalFileSystem());
 
   std::vector<std::string> getMessages() {
     {


### PR DESCRIPTION
Do not warn if a stale file has already been deleted.

This also changes the unit tests, so that they use a custom FS implementation which keeps track of deletion attempts, because we were relying on those warnings before for the test assertions.

See <rdar://problem/35913100>