### PR TITLE
[BuildSystem] Add support for a directory structure tracking node.

### DIFF
--- a/docs/buildsystem.rst
+++ b/docs/buildsystem.rst
@@ -89,6 +89,17 @@ These are the supported node types:
   dependency is missing, the build system will typically end up scanning the
   directory before all content is produced, and this will result in the first
   build being incomplete, and the next build redoing the remainder of the work.
+
+* Directory Tree Structure Nodes: These are like directory tree nodes, but
+  instead of tracking all attributes of the directory, they will change only
+  when the *structure* of the directory (recursively) changes. That is, they
+  will not rerun when the contents of files in the directory are modified, only
+  when files are added or removed, or files change type.
+
+  This is useful for clients which infer properties based purely on a directory
+  structure. Such clients can use this node type to track when to redo that
+  computation, and use additional dependencies on particular files for any items
+  within the structure whose content are relevant to the task.
   
 * Virtual Nodes: Nodes matching the name ``'<.*>'``, e.g. ``<gate-task>``, are
   *assumed* to be virtual nodes, and are used for adding arbitrary edges to the
@@ -331,6 +342,12 @@ The following attributes are currently supported:
        directory instead of a file path. By default, the build system assumes
        that nodes matching the pattern ``'.*/'`` (e.g., ``/tmp/``) are directory
        nodes. This attribute can be used to override that default.
+
+   * - is-directory-structure
+     - A boolean value, indicating whether the node should represent the
+       directory structure of a file path. Such nodes should be name as
+       '<path>/' (which would normally be a directory node), and then this
+       attributed used to change the type.
 
    * - is-virtual
      - A boolean value, indicating whether or not the node is "virtual". By

--- a/include/llbuild/BuildSystem/BuildKey.h
+++ b/include/llbuild/BuildSystem/BuildKey.h
@@ -42,6 +42,10 @@ public:
     /// A key used to identify the signature of a complete directory tree.
     DirectoryTreeSignature,
 
+    /// A key used to identify the signature of a complete directory tree
+    /// structure.
+    DirectoryTreeStructureSignature,
+
     /// A key used to identify a node.
     Node,
 
@@ -104,6 +108,11 @@ public:
     return BuildKey('S', path);
   }
 
+  /// Create a key for computing the structure of a directory.
+  static BuildKey makeDirectoryTreeStructureSignature(StringRef path) {
+    return BuildKey('s', path);
+  }
+
   /// Create a key for computing a node result.
   static BuildKey makeNode(StringRef path) {
     return BuildKey('N', path);
@@ -131,6 +140,7 @@ public:
     case 'D': return Kind::DirectoryContents;
     case 'N': return Kind::Node;
     case 'S': return Kind::DirectoryTreeSignature;
+    case 's': return Kind::DirectoryTreeStructureSignature;
     case 'T': return Kind::Target;
     case 'X': return Kind::CustomTask;
     default:
@@ -145,6 +155,9 @@ public:
   }
   bool isDirectoryTreeSignature() const {
     return getKind() == Kind::DirectoryTreeSignature;
+  }
+  bool isDirectoryTreeStructureSignature() const {
+    return getKind() == Kind::DirectoryTreeStructureSignature;
   }
   bool isNode() const { return getKind() == Kind::Node; }
   bool isTarget() const { return getKind() == Kind::Target; }
@@ -176,6 +189,11 @@ public:
 
   StringRef getDirectoryTreeSignaturePath() const {
     assert(isDirectoryTreeSignature());
+    return StringRef(key.data()+1, key.size()-1);
+  }
+
+  StringRef getDirectoryTreeStructureSignaturePath() const {
+    assert(isDirectoryTreeStructureSignature());
     return StringRef(key.data()+1, key.size()-1);
   }
 

--- a/include/llbuild/BuildSystem/BuildNode.h
+++ b/include/llbuild/BuildSystem/BuildNode.h
@@ -32,11 +32,16 @@ namespace buildsystem {
   
 // FIXME: Figure out how this is going to be organized.
 class BuildNode : public Node {
-  /// Whether or not this node is a directory.
+  /// Whether or not this node represents a full directory.
   //
   // FIXME: We need a type enumeration here.
   bool directory;
 
+  /// Whether or not this node represents the full directory structure.
+  //
+  // FIXME: We need a type enumeration here.
+  bool directoryStructure;
+  
   /// Whether or not this node is "virtual" (i.e., not a filesystem path).
   bool virtualNode;
 
@@ -53,9 +58,11 @@ class BuildNode : public Node {
   bool mutated;
 
 public:
-  explicit BuildNode(StringRef name, bool isDirectory, bool isVirtual,
+  explicit BuildNode(StringRef name, bool isDirectory,
+                     bool isDirectoryStructure, bool isVirtual,
                      bool isCommandTimestamp, bool isMutated)
-      : Node(name), directory(isDirectory), virtualNode(isVirtual),
+      : Node(name), directory(isDirectory),
+        directoryStructure(isDirectoryStructure), virtualNode(isVirtual),
         commandTimestamp(isCommandTimestamp), mutated(isMutated) {}
 
   /// Check whether this is a "virtual" (non-filesystem related) node.
@@ -64,6 +71,10 @@ public:
   /// Check whether this node is intended to represent a directory's contents
   /// recursively.
   bool isDirectory() const { return directory; }
+
+  /// Check whether this node is intended to represent a directory's structure
+  /// recursively.
+  bool isDirectoryStructure() const { return directoryStructure; }
 
   bool isCommandTimestamp() const { return commandTimestamp; }
 

--- a/include/llbuild/BuildSystem/BuildValue.h
+++ b/include/llbuild/BuildSystem/BuildValue.h
@@ -57,6 +57,9 @@ class BuildValue {
     /// The signature of a directories contents.
     DirectoryTreeSignature,
 
+    /// The signature of a directories structure.
+    DirectoryTreeStructureSignature,
+
     /// A value produced by stale file removal.
     StaleFileRemoval,
 
@@ -122,7 +125,8 @@ class BuildValue {
   } stringValues = {0, 0};
 
   bool kindHasCommandSignature() const {
-    return isSuccessfulCommand() || isDirectoryTreeSignature();
+    return isSuccessfulCommand() || isDirectoryTreeSignature() ||
+      isDirectoryTreeStructureSignature();
   }
 
   bool kindHasStringList() const {
@@ -291,6 +295,9 @@ public:
   static BuildValue makeDirectoryTreeSignature(uint64_t signature) {
     return BuildValue(Kind::DirectoryTreeSignature, signature);
   }
+  static BuildValue makeDirectoryTreeStructureSignature(uint64_t signature) {
+    return BuildValue(Kind::DirectoryTreeStructureSignature, signature);
+  }
   static BuildValue makeMissingOutput() {
     return BuildValue(Kind::MissingOutput);
   }
@@ -334,6 +341,9 @@ public:
   bool isDirectoryTreeSignature() const {
     return kind == Kind::DirectoryTreeSignature;
   }
+  bool isDirectoryTreeStructureSignature() const {
+    return kind == Kind::DirectoryTreeStructureSignature;
+  }
   bool isStaleFileRemoval() const { return kind == Kind::StaleFileRemoval; }
   
   bool isMissingOutput() const { return kind == Kind::MissingOutput; }
@@ -359,6 +369,12 @@ public:
   
   uint64_t getDirectoryTreeSignature() const {
     assert(isDirectoryTreeSignature() && "invalid call for value kind");
+    return commandSignature;
+  }
+  
+  uint64_t getDirectoryTreeStructureSignature() const {
+    assert(isDirectoryTreeStructureSignature() &&
+           "invalid call for value kind");
     return commandSignature;
   }
 

--- a/lib/BuildSystem/BuildKey.cpp
+++ b/lib/BuildSystem/BuildKey.cpp
@@ -27,6 +27,7 @@ StringRef BuildKey::stringForKind(BuildKey::Kind kind) {
     CASE(CustomTask);
     CASE(DirectoryContents);
     CASE(DirectoryTreeSignature);
+    CASE(DirectoryTreeStructureSignature);
     CASE(Node);
     CASE(Target);
     CASE(Unknown);
@@ -53,6 +54,10 @@ void BuildKey::dump(raw_ostream& os) const {
   }
   case Kind::DirectoryTreeSignature: {
     os << ", path='" << getDirectoryTreeSignaturePath() << "'";
+    break;
+  }
+  case Kind::DirectoryTreeStructureSignature: {
+    os << ", path='" << getDirectoryTreeStructureSignaturePath() << "'";
     break;
   }
   case Kind::Node: {

--- a/lib/BuildSystem/BuildNode.cpp
+++ b/lib/BuildSystem/BuildNode.cpp
@@ -28,7 +28,19 @@ bool BuildNode::configureAttribute(const ConfigureContext& ctx, StringRef name,
   if (name == "is-directory") {
     if (value == "true") {
       directory = true;
-      virtualNode = false;
+      directoryStructure = virtualNode = false;
+    } else if (value == "false") {
+      directory = false;
+    } else {
+      ctx.error("invalid value: '" + value + "' for attribute '"
+                + name + "'");
+      return false;
+    }
+    return true;
+  } else if (name == "is-directory-structure") {
+    if (value == "true") {
+      directoryStructure = true;
+      directory = virtualNode = false;
     } else if (value == "false") {
       directory = false;
     } else {
@@ -40,7 +52,7 @@ bool BuildNode::configureAttribute(const ConfigureContext& ctx, StringRef name,
   } else if (name == "is-virtual") {
     if (value == "true") {
       virtualNode = true;
-      directory = false;
+      directory = directoryStructure = false;
     } else if (value == "false") {
       virtualNode = false;
       commandTimestamp = false;
@@ -54,7 +66,7 @@ bool BuildNode::configureAttribute(const ConfigureContext& ctx, StringRef name,
     if (value == "true") {
       commandTimestamp = true;
       virtualNode = true;
-      directory = false;
+      directory = directoryStructure = false;
     } else if (value == "false") {
       commandTimestamp = false;
     } else {

--- a/lib/BuildSystem/ExternalCommand.cpp
+++ b/lib/BuildSystem/ExternalCommand.cpp
@@ -242,13 +242,16 @@ void ExternalCommand::provideValue(BuildSystemCommandInterface& bsci,
   assert(value.isExistingInput() || value.isMissingInput() ||
          value.isMissingOutput() || value.isFailedInput() ||
          value.isVirtualInput()  || value.isSkippedCommand() ||
-         value.isDirectoryTreeSignature() || value.isStaleFileRemoval());
+         value.isDirectoryTreeSignature() ||
+         value.isDirectoryTreeStructureSignature() ||
+         value.isStaleFileRemoval());
 
   // If the input should cause this command to skip, how should it skip?
   auto getSkipValueForInput = [&]() -> llvm::Optional<BuildValue> {
     // If the value is an signature, existing, or virtual input, we are always
     // good.
-    if (value.isDirectoryTreeSignature() | value.isExistingInput() ||
+    if (value.isDirectoryTreeSignature() ||
+        value.isDirectoryTreeStructureSignature() || value.isExistingInput() ||
         value.isVirtualInput() || value.isStaleFileRemoval())
       return llvm::None;
 

--- a/products/libllbuild/BuildSystem-C-API.cpp
+++ b/products/libllbuild/BuildSystem-C-API.cpp
@@ -358,7 +358,13 @@ public:
           break;
         case BuildKey::Kind::DirectoryTreeSignature:
           buildKey.kind = llb_build_key_kind_directory_tree_signature;
-          buildKey.key = strdup(key.getDirectoryTreeSignaturePath().str().c_str());
+          buildKey.key = strdup(
+              key.getDirectoryTreeSignaturePath().str().c_str());
+          break;
+        case BuildKey::Kind::DirectoryTreeStructureSignature:
+          buildKey.kind = llb_build_key_kind_directory_tree_structure_signature;
+          buildKey.key = strdup(
+              key.getDirectoryTreeStructureSignaturePath().str().c_str());
           break;
         case BuildKey::Kind::Node:
           buildKey.kind = llb_build_key_kind_node;

--- a/products/libllbuild/include/llbuild/buildsystem.h
+++ b/products/libllbuild/include/llbuild/buildsystem.h
@@ -135,6 +135,9 @@ typedef enum {
 
   /// An invalid key kind.
   llb_build_key_kind_unknown = 6,
+
+  /// A key used to identify the signature of a complete directory tree.
+  llb_build_key_kind_directory_tree_structure_signature = 7,
 } llb_build_key_kind_t;
 
 /// The BuildKey encodes the key space used by the BuildSystem when using the

--- a/tests/BuildSystem/Build/directory-tree-structure-signatures.llbuild
+++ b/tests/BuildSystem/Build/directory-tree-structure-signatures.llbuild
@@ -1,4 +1,4 @@
-# Check the handling of directory tree signatures.
+# Check the handling of directory tree structure signatures.
 #
 # We check the node used against three kinds of directories: missing, a file, an
 # actual directory.
@@ -42,15 +42,17 @@
 # CHECK-MODIFIED: DTS-DIR-CHANGED
 
 
-# Check that a mutation of a file is detected.
+# Check that a mutation of a file is ignored.
 #
 # RUN: echo "mutated" >> %t.build/dir/subdir/file
 # RUN: %{llbuild} buildsystem build --serial --chdir %t.build > %t.mutated.out
+# RUN: echo EOF. >> %t.mutated.out
 # RUN: %{FileCheck} --check-prefix=CHECK-MUTATED --input-file=%t.mutated.out %s
 #
 # CHECK-MUTATED-NOT: DTS-MISSING-CHANGED
 # CHECK-MUTATED-NOT: DTS-FILE-CHANGED
-# CHECK-MUTATED: DTS-DIR-CHANGED
+# CHECK-MUTATED-NOT: DTS-DIR-CHANGED
+# CHECK-MUTATED: EOF.
 
 client:
   name: basic
@@ -58,6 +60,14 @@ client:
 targets:
   "": ["<all>"]
 
+nodes:
+  "missing-dir/":
+    is-directory-structure: true
+  "file/":
+    is-directory-structure: true
+  "dir/":
+    is-directory-structure: true
+    
 commands:
   C.all:
     tool: phony


### PR DESCRIPTION
 - This is like the existing node which tracks a directory (recursively), but it
   only considers the structural elements of the directory (the files and their
   modes).