### PR TITLE
[BuildSystem] Fix bug in directory structure node spuriously rebuilding.

### DIFF
--- a/lib/BuildSystem/BuildSystem.cpp
+++ b/lib/BuildSystem/BuildSystem.cpp
@@ -1017,11 +1017,12 @@ class DirectoryTreeStructureSignatureTask : public Task {
     using llvm::hash_combine;
     llvm::hash_code code = hash_value(path);
 
-    // Only merge the structure information on the directory itself (including a
-    // random code to represent the directory).
+    // Only merge the structure information on the directory itself.
     {
+      // We need to merge mode information about the directory itself, in case
+      // it changes type.
       auto value = BuildValue::fromData(directoryValue);
-      if (value.isExistingInput()) {
+      if (value.isDirectoryContents()) {
         code = hash_combine(code, value.getOutputInfo().mode);
       } else {
         code = hash_combine(

--- a/tests/BuildSystem/Build/directory-tree-structure-signatures.llbuild
+++ b/tests/BuildSystem/Build/directory-tree-structure-signatures.llbuild
@@ -33,13 +33,29 @@
 # RUN: mkdir -p %t.build/missing-dir
 # RUN: mkdir -p %t.build/dir/subdir
 # RUN: echo "created" > %t.build/dir/subdir/file
+# RUN: echo "created" > %t.build/dir/file2
 # RUN: echo "modified" > %t.build/file
 # RUN: %{llbuild} buildsystem build --serial --chdir %t.build > %t.modified.out
 # RUN: %{FileCheck} --check-prefix=CHECK-MODIFIED --input-file=%t.modified.out %s
 #
 # CHECK-MODIFIED: DTS-MISSING-CHANGED
-# CHECK-MODIFIED: DTS-FILE-CHANGED
+# CHECK-MODIFIED-NOT: DTS-FILE-CHANGED
 # CHECK-MODIFIED: DTS-DIR-CHANGED
+
+
+# Check that type transitions are detected.
+#
+# RUN: rm -rf %t.build/missing-dir
+# RUN: rm -rf %t.build/file
+# RUN: rm -rf %t.build/dir/file2
+# RUN: mkdir -p %t.build/file
+# RUN: mkdir -p %t.build/dir/file2
+# RUN: %{llbuild} buildsystem build --serial --chdir %t.build > %t.type-changed.out
+# RUN: %{FileCheck} --check-prefix=CHECK-TYPE-CHANGED --input-file=%t.type-changed.out %s
+#
+# CHECK-TYPE-CHANGED: DTS-MISSING-CHANGED
+# CHECK-TYPE-CHANGED: DTS-FILE-CHANGED
+# CHECK-TYPE-CHANGED: DTS-DIR-CHANGED
 
 
 # Check that a mutation of a file is ignored.
@@ -53,6 +69,22 @@
 # CHECK-MUTATED-NOT: DTS-FILE-CHANGED
 # CHECK-MUTATED-NOT: DTS-DIR-CHANGED
 # CHECK-MUTATED: EOF.
+
+
+# Check that replacing the file with an equivalent one is ignored.
+#
+# RUN: rm -f %t.build/dir/subdir/file
+# RUN: echo "created" > %t.build/dir/subdir/file
+# RUN: echo "mutated" >> %t.build/dir/subdir/file
+# RUN: touch -r /dev/null %t.build/dir/subdir
+# RUN: %{llbuild} buildsystem build --serial --chdir %t.build > %t.mutated.out
+# RUN: echo EOF. >> %t.mutated.out
+# RUN: %{FileCheck} --check-prefix=CHECK-REPLACEMENT --input-file=%t.mutated.out %s
+#
+# CHECK-REPLACEMENT-NOT: DTS-MISSING-CHANGED
+# CHECK-REPLACEMENT-NOT: DTS-FILE-CHANGED
+# CHECK-REPLACEMENT-NOT: DTS-DIR-CHANGED
+# CHECK-REPLACEMENT: EOF.
 
 client:
   name: basic


### PR DESCRIPTION
 - This wasn't properly restricting itself to ignoring the non-relevant mode
   information on the scanning of the directory contents.

 - <rdar://problem/36358682> llbuild reruns directory structure commands on file mutation