### PR TITLE
Expose ability to build a node through the API.

### DIFF
--- a/include/llbuild/BuildSystem/BuildSystemFrontend.h
+++ b/include/llbuild/BuildSystem/BuildSystemFrontend.h
@@ -60,6 +60,10 @@ class BuildSystemFrontend {
   const BuildSystemInvocation& invocation;
   llvm::Optional<BuildSystem> buildSystem;
 
+private:
+
+  bool setupBuild();
+
 public:
   BuildSystemFrontend(BuildSystemFrontendDelegate& delegate,
                       const BuildSystemInvocation& invocation);
@@ -91,6 +95,11 @@ public:
   ///
   /// \returns True on success, or false if there were errors.
   bool build(StringRef targetToBuild);
+
+  /// Build a single node using the specified invocation parameters.
+  ///
+  /// \returns True on success, or false if there were errors.
+  bool buildNode(StringRef nodeToBuild);
 
   /// @}
 };

--- a/products/libllbuild/BuildSystem-C-API.cpp
+++ b/products/libllbuild/BuildSystem-C-API.cpp
@@ -485,6 +485,11 @@ public:
     return getFrontend().build(key);
   }
 
+  bool buildNode(const core::KeyType& key) {
+    frontendDelegate->resetForBuild();
+    return getFrontend().buildNode(key);
+  }
+
   void cancel() {
     frontendDelegate->cancel();
   }
@@ -633,6 +638,11 @@ bool llb_buildsystem_initialize(llb_buildsystem_t* system_p) {
 bool llb_buildsystem_build(llb_buildsystem_t* system_p, const llb_data_t* key) {
   CAPIBuildSystem* system = (CAPIBuildSystem*) system_p;
   return system->build(core::KeyType((const char*)key->data, key->length));
+}
+
+bool llb_buildsystem_build_node(llb_buildsystem_t* system_p, const llb_data_t* key) {
+  CAPIBuildSystem* system = (CAPIBuildSystem*) system_p;
+  return system->buildNode(core::KeyType((const char*)key->data, key->length));
 }
 
 void llb_buildsystem_cancel(llb_buildsystem_t* system_p) {

--- a/products/libllbuild/include/llbuild/buildsystem.h
+++ b/products/libllbuild/include/llbuild/buildsystem.h
@@ -438,11 +438,25 @@ llb_buildsystem_initialize(llb_buildsystem_t* system);
 /// This will automatically initialize the build system if it has not already
 /// been initialized.
 ///
-/// \param key The key to build.
+/// \param key Name of the target to build.
 /// \returns True on success, or false if the build was aborted (for example, if
 /// a cycle was discovered).
 LLBUILD_EXPORT bool
 llb_buildsystem_build(llb_buildsystem_t* system, const llb_data_t* key);
+
+/// Build a single node.
+///
+/// It is an unchecked error for the client to request multiple builds
+/// concurrently.
+///
+/// This will automatically initialize the build system if it has not already
+/// been initialized.
+///
+/// \param key Path to the node to build.
+/// \returns True on success, or false if the build was aborted (for example, if
+/// a cycle was discovered).
+LLBUILD_EXPORT bool
+llb_buildsystem_build_node(llb_buildsystem_t* system, const llb_data_t* key);
 
 /// Cancel any ongoing build.
 ///

--- a/products/libllbuild/include/llbuild/llbuild.h
+++ b/products/libllbuild/include/llbuild/llbuild.h
@@ -38,6 +38,8 @@
 ///
 /// Version History:
 ///
+/// 4: Added llb_buildsystem_build_node.
+///
 /// 3: Added command_had_error, command_had_note and command_had_warning delegate methods.
 ///
 /// 2: Added `llb_buildsystem_command_result_t` parameter to command_finished.
@@ -45,7 +47,7 @@
 /// 1: Added `environment` parameter to llb_buildsystem_invocation_t.
 ///
 /// 0: Pre-history
-#define LLBUILD_API_VERSION 3
+#define LLBUILD_API_VERSION 4
 
 /// Get the full version of the llbuild library.
 LLBUILD_EXPORT const char* llb_get_full_version_string(void);


### PR DESCRIPTION
`BuildSystem` was already able to build a single node (or really any key), but this adds the plumbing to expose it via the API.

<rdar://problem/31072405> Single File Compile/Analyze Support