### PR TITLE
[BuildSystem] Validate target name before building it

### DIFF
--- a/lib/BuildSystem/BuildSystem.cpp
+++ b/lib/BuildSystem/BuildSystem.cpp
@@ -1499,6 +1499,13 @@ bool BuildSystemImpl::build(StringRef target) {
     target = getBuildDescription().getDefaultTarget();
   }
 
+  // Validate the target name.
+  auto &targets = getBuildDescription().getTargets();
+  if (targets.find(target) == targets.end()) {
+    error(getMainFilename(), "No target named '" + target + "' in build description");
+    return false;
+  }
+
   return build(BuildKey::makeTarget(target)).hasValue();
 }
 

--- a/tests/BuildSystem/Build/missing-target.llbuild
+++ b/tests/BuildSystem/Build/missing-target.llbuild
@@ -1,0 +1,22 @@
+# Check we display an error if the given target is not present.
+#
+# RUN: rm -rf %t.build
+# RUN: mkdir -p %t.build
+# RUN: cp %s %t.build/build.llbuild
+# RUN: %{llbuild} buildsystem build does-not-exist --chdir %t.build &> %t.out || true
+# RUN: %{FileCheck} --input-file=%t.out %s
+#
+# CHECK: No target named 'does-not-exist' in build description
+
+client:
+  name: basic
+
+targets:
+  tee: ["<command>"]
+
+commands:
+  "<command>":
+    tool: shell
+    inputs: []
+    outputs: [<command>]
+    args: ["echo", "hi"]


### PR DESCRIPTION
<rdar://problem/31675430> swift-build-tool crashes when wrong target name is passed