### PR TITLE
Fix parsing of some special characters in .d files

### DIFF
--- a/lib/Core/MakefileDepsParser.cpp
+++ b/lib/Core/MakefileDepsParser.cpp
@@ -30,10 +30,6 @@ static bool isWordChar(int c) {
   case ' ':
   case '$':
   case ':':
-  case ';':
-  case '=':
-  case '|':
-  case '%':
     return false;
   default:
     return true;

--- a/unittests/Core/MakefileDepsParserTest.cpp
+++ b/unittests/Core/MakefileDepsParserTest.cpp
@@ -103,7 +103,7 @@ TEST(MakefileDepsParserTest, basic) {
   // Check error case if leading garbage.
   actions.errors.clear();
   actions.records.clear();
-  input = "  =$ a";
+  input = "  $ a";
   MakefileDepsParser(input.data(), input.size(), actions).parse();
   EXPECT_EQ(1U, actions.errors.size());
   EXPECT_EQ(actions.errors[0],
@@ -134,6 +134,15 @@ TEST(MakefileDepsParserTest, basic) {
   EXPECT_EQ(1U, actions.records.size());
   EXPECT_EQ(RuleRecord("a", { "b" }),
             actions.records[0]);
+
+  // Check that we can parse filenames with special characters.
+  actions.errors.clear();
+  actions.records.clear();
+  input = "/=>\\ ;|%.o : /=>\\ ;|%.swift";
+  MakefileDepsParser(input.data(), input.size(), actions).parse();
+  EXPECT_EQ(0U, actions.errors.size());
+  EXPECT_EQ(1U, actions.records.size());
+  EXPECT_EQ(RuleRecord("/=> ;|%.o", { "/=> ;|%.swift" }), actions.records[0]);
   
 }
 


### PR DESCRIPTION
All of these are actually valid characters in filenames, so we should allow them to appear in `.d` files.

<rdar://problem/32670559> Failure building '=>.swift' (error reading dependency file: unexpected character in prerequisites)