### PR TITLE
[Swift Bindings] Re-add CMake support for building Swift bindings.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,12 @@ else()
   set(cmake_3_2_USES_TERMINAL USES_TERMINAL)
 endif()
 
+# Configure the default set of bindings to build.
+if(NOT DEFINED LLBUILD_SUPPORT_BINDINGS)
+  set(LLBUILD_SUPPORT_BINDINGS "")
+endif()
+
+
 # Include standard CMake modules.
 include(CMakeParseArguments)
 include(CheckCXXCompilerFlag)
@@ -68,6 +74,25 @@ set(LLBUILD_LIBRARY_OUTPUT_INTDIR ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_CFG_INTDIR
 find_package(Lit)
 find_package(FileCheck)
 find_package(PythonInterp)
+
+# Check if we should build the Swift bindings.
+if (";${LLBUILD_SUPPORT_BINDINGS};" MATCHES ";Swift;")
+  # Find swiftc on OSX using `xcrun --find swiftc` and `find_package` on Linux.
+  if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+    execute_process(
+        COMMAND xcrun --find swiftc
+        OUTPUT_VARIABLE SWIFTC_EXECUTABLE
+        OUTPUT_STRIP_TRAILING_WHITESPACE)
+    set(SWIFTC_FOUND TRUE)
+    message(STATUS "Found swiftc: ${SWIFTC_EXECUTABLE}")
+  else()
+    find_package(Swiftc)
+  endif()
+else()
+  message(STATUS "Not building Swift bindings")
+  set(SWIFTC_EXECUTABLE)
+  set(SWIFTC_FOUND FALSE)
+endif()
 
 ###
 # Setup compiler and project build settings

--- a/products/CMakeLists.txt
+++ b/products/CMakeLists.txt
@@ -4,3 +4,4 @@ add_subdirectory(swift-build-tool)
 
 # Public API products.
 add_subdirectory(libllbuild)
+add_subdirectory(llbuildSwift)

--- a/products/llbuildSwift/CMakeLists.txt
+++ b/products/llbuildSwift/CMakeLists.txt
@@ -1,0 +1,12 @@
+# Set sources.
+set(SOURCES 
+  BuildSystemBindings.swift
+  CoreBindings.swift)
+
+# Link C API.
+list(APPEND additional_args -I ${CMAKE_CURRENT_SOURCE_DIR}/../libllbuild/include -lllbuild)
+
+# Add swift bindings target if swift compiler is present.
+if (SWIFTC_FOUND)
+  add_swift_module(libllbuildSwift llbuildSwift libllbuild "${SOURCES}" "${additional_args}")
+endif()


### PR DESCRIPTION
In order to use llbuild's Swift API in SwiftPM, we need to build the
bindings as part of Swift's build script. This is the first step in that
direction.