### PR TITLE
Add DeviceAgnosticFileSystem wrapper class

### DIFF
--- a/include/llbuild/Basic/FileSystem.h
+++ b/include/llbuild/Basic/FileSystem.h
@@ -86,7 +86,7 @@ public:
 std::unique_ptr<FileSystem> createLocalFileSystem();
 
 
-// Device/inode agnostic filesystem wrapper
+/// Device/inode agnostic filesystem wrapper
 class DeviceAgnosticFileSystem : public FileSystem {
 private:
   std::unique_ptr<FileSystem> impl;
@@ -123,15 +123,23 @@ public:
 
   virtual FileInfo getFileInfo(const std::string& path) override {
     auto info = impl->getFileInfo(path);
+
+    // Device and inode numbers may (will) change when relocating files to
+    // another device. Here we explicitly, unconditionally override them with 0,
+    // enabling an entire build tree to be relocated or copied yet retain the
+    // ability to perform incremental builds.
     info.device = 0;
     info.inode = 0;
+
     return info;
   }
 
   virtual FileInfo getLinkInfo(const std::string& path) override {
     auto info = impl->getLinkInfo(path);
+
     info.device = 0;
     info.inode = 0;
+
     return info;
   }
 };

--- a/lib/Basic/FileSystem.cpp
+++ b/lib/Basic/FileSystem.cpp
@@ -130,6 +130,11 @@ bool FileSystem::createDirectories(const std::string& path) {
   return createDirectories(parent) && createDirectory(path);
 }
 
+
+std::unique_ptr<llvm::MemoryBuffer>
+DeviceAgnosticFileSystem::getFileContents(const std::string& path) {
+  return impl->getFileContents(path);
+}
 namespace {
 
 class LocalFileSystem : public FileSystem {
@@ -201,4 +206,9 @@ public:
 
 std::unique_ptr<FileSystem> basic::createLocalFileSystem() {
   return llvm::make_unique<LocalFileSystem>();
+}
+
+std::unique_ptr<FileSystem>
+basic::DeviceAgnosticFileSystem::from(std::unique_ptr<FileSystem> fs) {
+  return llvm::make_unique<DeviceAgnosticFileSystem>(std::move(fs));
 }

--- a/llbuild.xcodeproj/xcshareddata/xcschemes/llbuild (external tests).xcscheme
+++ b/llbuild.xcodeproj/xcshareddata/xcschemes/llbuild (external tests).xcscheme
@@ -40,6 +40,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
       </Testables>
@@ -59,6 +60,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/llbuild.xcodeproj/xcshareddata/xcschemes/llbuild.xcscheme
+++ b/llbuild.xcodeproj/xcshareddata/xcschemes/llbuild.xcscheme
@@ -68,8 +68,9 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      codeCoverageEnabled = "YES"
-      shouldUseLaunchSchemeArgsEnv = "YES">
+      language = ""
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      codeCoverageEnabled = "YES">
       <Testables>
          <TestableReference
             skipped = "NO">
@@ -98,6 +99,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"


### PR DESCRIPTION
Clears all device and inode numbers of FileInfo objects return by the
underlying FileSystem object.