### PR TITLE
Added guard so including macOS target is limited to an Apple platform

### DIFF
--- a/products/llbuildSwift/CMakeLists.txt
+++ b/products/llbuildSwift/CMakeLists.txt
@@ -5,7 +5,10 @@ set(SOURCES
 
 # Link C API.
 list(APPEND additional_args -I ${CMAKE_CURRENT_SOURCE_DIR}/../libllbuild/include -lllbuild)
-list(APPEND additional_args -target x86_64-apple-macosx10.10)
+ 
+if(APPLE)
+  list(APPEND additional_args -target x86_64-apple-macosx10.10)
+endif()
 
 # Add swift bindings target if swift compiler is present.
 if (SWIFTC_FOUND)


### PR DESCRIPTION
Including the x86_64-apple-macosx10.10 target causes a build failure on Linux. I added a guard around the line so it only gets included when building on an Apple (i.e. macOS) platform.