### PR TITLE
Move ownership of the FileSystem into BuildSystem

### DIFF
--- a/include/llbuild/BuildSystem/BuildSystem.h
+++ b/include/llbuild/BuildSystem/BuildSystem.h
@@ -95,9 +95,6 @@ public:
   /// Called by the build system to get the current client version.
   uint32_t getVersion() const { return version; }
 
-  /// Get the file system to use for access.
-  virtual basic::FileSystem& getFileSystem() = 0;
-
   /// Called by the build file loader to register the current file contents.
   //
   // FIXME: This is a total hack, and should be cleaned up.
@@ -211,11 +208,14 @@ private:
 
 public:
   /// Create a build system with the given delegate.
-  explicit BuildSystem(BuildSystemDelegate& delegate);
+  BuildSystem(BuildSystemDelegate& delegate, std::unique_ptr<basic::FileSystem> fileSystem);
   ~BuildSystem();
 
   /// Return the delegate the engine was configured with.
   BuildSystemDelegate& getDelegate();
+
+  /// Get the file system to use for access.
+  basic::FileSystem& getFileSystem();
 
   /// @name Client API
   /// @{

--- a/include/llbuild/BuildSystem/BuildSystemCommandInterface.h
+++ b/include/llbuild/BuildSystem/BuildSystemCommandInterface.h
@@ -68,6 +68,9 @@ public:
   /// @name BuildSystem API
   /// @{
 
+  /// Get the file system
+  virtual basic::FileSystem& getFileSystem() = 0;
+
   /// Add a job to be executed.
   virtual void addJob(QueueJob&&) = 0;
 

--- a/include/llbuild/BuildSystem/BuildSystemFrontend.h
+++ b/include/llbuild/BuildSystem/BuildSystemFrontend.h
@@ -58,6 +58,7 @@ enum class CommandResult;
 class BuildSystemFrontend {
   BuildSystemFrontendDelegate& delegate;
   const BuildSystemInvocation& invocation;
+  std::unique_ptr<basic::FileSystem> fileSystem;
   llvm::Optional<BuildSystem> buildSystem;
 
 private:
@@ -66,7 +67,8 @@ private:
 
 public:
   BuildSystemFrontend(BuildSystemFrontendDelegate& delegate,
-                      const BuildSystemInvocation& invocation);
+                      const BuildSystemInvocation& invocation,
+                      std::unique_ptr<basic::FileSystem> fileSystem);
 
   /// @name Accessors
   /// @{
@@ -133,9 +135,6 @@ public:
                               StringRef name,
                               uint32_t version);
   virtual ~BuildSystemFrontendDelegate();
-
-  /// Get the file system to use for access.
-  virtual basic::FileSystem& getFileSystem() override = 0;
 
   /// Called by the build system to get a tool definition, must be provided by
   /// subclasses.

--- a/lib/BuildSystem/BuildSystem.cpp
+++ b/lib/BuildSystem/BuildSystem.cpp
@@ -86,9 +86,7 @@ public:
     return entry.first->getKey();
   }
 
-  virtual FileSystem& getFileSystem() override {
-    return getSystemDelegate().getFileSystem();
-  }
+  virtual FileSystem& getFileSystem() override;
   
   virtual void setFileContentsBeingParsed(StringRef buffer) override;
   
@@ -155,6 +153,9 @@ class BuildSystemImpl : public BuildSystemCommandInterface {
 
   /// The delegate the BuildSystem was configured with.
   BuildSystemDelegate& delegate;
+
+  /// The file system used by the build system
+  std::unique_ptr<basic::FileSystem> fileSystem;
 
   /// The name of the main input file.
   std::string mainFilename;
@@ -223,8 +224,10 @@ class BuildSystemImpl : public BuildSystemCommandInterface {
 
 public:
   BuildSystemImpl(class BuildSystem& buildSystem,
-                  BuildSystemDelegate& delegate)
+                  BuildSystemDelegate& delegate,
+                  std::unique_ptr<basic::FileSystem> fileSystem)
       : buildSystem(buildSystem), delegate(delegate),
+        fileSystem(std::move(fileSystem)),
         fileDelegate(*this), engineDelegate(*this), buildEngine(engineDelegate),
         executionQueue() {}
 
@@ -234,6 +237,10 @@ public:
 
   BuildSystemDelegate& getDelegate() override {
     return delegate;
+  }
+
+  basic::FileSystem& getFileSystem() override {
+    return *fileSystem;
   }
 
   // FIXME: We should eliminate this, it isn't well formed when loading
@@ -348,6 +355,12 @@ static BuildSystemImpl& getBuildSystem(BuildEngine& engine) {
   return static_cast<BuildSystemEngineDelegate*>(
       engine.getDelegate())->getBuildSystem();
 }
+
+
+FileSystem& BuildSystemFileDelegate::getFileSystem() {
+  return system.getFileSystem();
+}
+
   
 /// This is the task used to "build" a target, it translates between the request
 /// for building a target key and the requests for all of its nodes.
@@ -453,7 +466,7 @@ class FileInputNodeTask : public Task {
     // different node types.
     assert(!node.isVirtual());
     auto info = node.getFileInfo(
-        getBuildSystem(engine).getDelegate().getFileSystem());
+        getBuildSystem(engine).getFileSystem());
     if (info.isMissing()) {
       engine.taskIsComplete(this, BuildValue::makeMissingInput().toData());
       return;
@@ -484,7 +497,7 @@ public:
     // to rebuild it), and thus the additional stat is only one small part of
     // the work we need to perform.
     auto info = node.getFileInfo(
-        getBuildSystem(engine).getDelegate().getFileSystem());
+        getBuildSystem(engine).getFileSystem());
     if (info.isMissing()) {
       return value.isMissingInput();
     } else {
@@ -724,7 +737,7 @@ class DirectoryContentsTask : public Task {
     //
     // FIXME: We should probably be using the directory value here, but that
     // requires reworking some of the value encoding for the directory.
-    auto info = getBuildSystem(engine).getDelegate().getFileSystem().getFileInfo(
+    auto info = getBuildSystem(engine).getFileSystem().getFileInfo(
         path);
     if (info.isMissing()) {
       engine.taskIsComplete(
@@ -759,7 +772,7 @@ public:
                             const BuildValue& value) {
     // The result is valid if the existence matches the existing value type, and
     // the file information remains the same.
-    auto info = getBuildSystem(engine).getDelegate().getFileSystem().getFileInfo(
+    auto info = getBuildSystem(engine).getFileSystem().getFileInfo(
         path);
     if (info.isMissing()) {
       return value.isMissingInput();
@@ -1655,7 +1668,7 @@ class ShellCommand : public ExternalCommand {
 
     for (const auto& depsPath: depsPaths) {
       // Read the dependencies file.
-      auto input = bsci.getDelegate().getFileSystem().getFileContents(depsPath);
+      auto input = bsci.getFileSystem().getFileContents(depsPath);
       if (!input) {
         getBuildSystem(bsci.getBuildEngine()).error(
             depsPath, "unable to open dependencies file (" + depsPath + ")");
@@ -1945,7 +1958,7 @@ class ClangShellCommand : public ExternalCommand {
                                      Task* task,
                                      QueueJobContext* context) {
     // Read the dependencies file.
-    auto input = bsci.getDelegate().getFileSystem().getFileContents(depsPath);
+    auto input = bsci.getFileSystem().getFileContents(depsPath);
     if (!input) {
       getBuildSystem(bsci.getBuildEngine()).error(
           depsPath, "unable to open dependencies file (" + depsPath + ")");
@@ -2124,7 +2137,7 @@ class MkdirCommand : public ExternalCommand {
 
     // Otherwise, the result is valid if the directory still exists.
     auto info = getOutputs()[0]->getFileInfo(
-        system.getDelegate().getFileSystem());
+        system.getFileSystem());
     if (info.isMissing())
       return false;
 
@@ -2146,7 +2159,7 @@ class MkdirCommand : public ExternalCommand {
                                                Task* task,
                                                QueueJobContext* context) override {
     auto output = getOutputs()[0];
-    if (!bsci.getDelegate().getFileSystem().createDirectories(
+    if (!bsci.getFileSystem().createDirectories(
             output->getName())) {
       getBuildSystem(bsci.getBuildEngine()).error(
           "", "unable to create directory '" + output->getName() + "'");
@@ -2341,7 +2354,7 @@ class SymlinkCommand : public Command {
 
     // Otherwise, assume the result is valid if its link status matches the
     // previous one.
-    auto info = system.getDelegate().getFileSystem().getLinkInfo(outputPath);
+    auto info = system.getFileSystem().getLinkInfo(outputPath);
     if (info.isMissing())
       return false;
 
@@ -2386,7 +2399,7 @@ class SymlinkCommand : public Command {
     {
       auto parent = llvm::sys::path::parent_path(outputPath);
       if (!parent.empty()) {
-        (void) bsci.getDelegate().getFileSystem().createDirectories(parent);
+        (void) bsci.getFileSystem().createDirectories(parent);
       }
     }
 
@@ -2414,7 +2427,7 @@ class SymlinkCommand : public Command {
     }
 
     // Capture the *link* information of the output.
-    FileInfo outputInfo = bsci.getDelegate().getFileSystem().getLinkInfo(
+    FileInfo outputInfo = bsci.getFileSystem().getLinkInfo(
         outputPath);
       
     // Complete with a successful result.
@@ -2738,7 +2751,7 @@ class StaleFileRemovalCommand : public Command {
         continue;
       }
 
-      if (getBuildSystem(bsci.getBuildEngine()).getDelegate().getFileSystem().remove(fileToDelete)) {
+      if (getBuildSystem(bsci.getBuildEngine()).getFileSystem().remove(fileToDelete)) {
         bsci.getDelegate().commandHadNote(this, "Removed stale file '" + fileToDelete + "'\n");
       } else {
         // Do not warn if the file has already been deleted.
@@ -2873,8 +2886,8 @@ BuildSystemFileDelegate::lookupNode(StringRef name,
 
 #pragma mark - BuildSystem
 
-BuildSystem::BuildSystem(BuildSystemDelegate& delegate)
-    : impl(new BuildSystemImpl(*this, delegate))
+BuildSystem::BuildSystem(BuildSystemDelegate& delegate, std::unique_ptr<basic::FileSystem> fileSystem)
+  : impl(new BuildSystemImpl(*this, delegate, std::move(fileSystem)))
 {
 }
 
@@ -2884,6 +2897,10 @@ BuildSystem::~BuildSystem() {
 
 BuildSystemDelegate& BuildSystem::getDelegate() {
   return static_cast<BuildSystemImpl*>(impl)->getDelegate();
+}
+
+basic::FileSystem& BuildSystem::getFileSystem() {
+  return static_cast<BuildSystemImpl*>(impl)->getFileSystem();
 }
 
 bool BuildSystem::loadDescription(StringRef mainFilename) {

--- a/lib/BuildSystem/BuildSystemFrontend.cpp
+++ b/lib/BuildSystem/BuildSystemFrontend.cpp
@@ -587,17 +587,17 @@ bool BuildSystemFrontend::initialize() {
   // Create the build system.
   buildSystem.emplace(delegate, std::move(fileSystem));
 
-  // Load the build file.
-  if (!buildSystem->loadDescription(invocation.buildFilePath))
-    return false;
-
   // Register the system back pointer.
   //
   // FIXME: Eliminate this.
   auto delegateImpl =
-    static_cast<BuildSystemFrontendDelegateImpl*>(delegate.impl);
+  static_cast<BuildSystemFrontendDelegateImpl*>(delegate.impl);
   delegateImpl->system = buildSystem.getPointer();
-  
+
+  // Load the build file.
+  if (!buildSystem->loadDescription(invocation.buildFilePath))
+    return false;
+
   // Enable tracing, if requested.
   if (!invocation.traceFilePath.empty()) {
     std::string error;

--- a/lib/BuildSystem/ExternalCommand.cpp
+++ b/lib/BuildSystem/ExternalCommand.cpp
@@ -191,7 +191,7 @@ bool ExternalCommand::isResultValid(BuildSystem& system,
     // could enforce and error on the missing output if not annotated, and we
     // could enable behavior to remove such output files if annotated prior to
     // running the command.
-    auto info = node->getFileInfo(system.getDelegate().getFileSystem());
+    auto info = node->getFileInfo(system.getFileSystem());
 
     // If this output is mutated by the build, we can't rely on equivalence,
     // only existence.
@@ -338,7 +338,7 @@ ExternalCommand::computeCommandResult(BuildSystemCommandInterface& bsci) {
       outputInfos.push_back(FileInfo{});
     } else {
       outputInfos.push_back(node->getFileInfo(
-                                bsci.getDelegate().getFileSystem()));
+                                bsci.getFileSystem()));
     }
   }
   return BuildValue::makeSuccessfulCommand(outputInfos, getSignature());
@@ -385,7 +385,7 @@ BuildValue ExternalCommand::execute(BuildSystemCommandInterface& bsci,
       // FIXME: Need to use the filesystem interfaces.
       auto parent = llvm::sys::path::parent_path(node->getName());
       if (!parent.empty()) {
-        (void) bsci.getDelegate().getFileSystem().createDirectories(parent);
+        (void) bsci.getFileSystem().createDirectories(parent);
       }
     }
   }

--- a/lib/BuildSystem/SwiftTools.cpp
+++ b/lib/BuildSystem/SwiftTools.cpp
@@ -430,7 +430,7 @@ public:
   bool processDiscoveredDependencies(BuildSystemCommandInterface& bsci,
                                      core::Task* task, StringRef depsPath) {
     // Read the dependencies file.
-    auto input = bsci.getDelegate().getFileSystem().getFileContents(depsPath);
+    auto input = bsci.getFileSystem().getFileContents(depsPath);
     if (!input) {
       bsci.getDelegate().error(
           "", {},
@@ -552,7 +552,7 @@ public:
     //
     // FIXME: This should really be done using an additional implicit input, so
     // it only happens once per build.
-    (void) bsci.getDelegate().getFileSystem().createDirectories(tempsPath);
+    (void) bsci.getFileSystem().createDirectories(tempsPath);
  
     SmallString<64> outputFileMapPath;
     getOutputFileMapPath(outputFileMapPath);

--- a/lib/Commands/BuildSystemCommand.cpp
+++ b/lib/Commands/BuildSystemCommand.cpp
@@ -504,8 +504,6 @@ public:
     signalWatchingPipe[1] = -1;
   }
 
-  virtual basic::FileSystem& getFileSystem() override { return *fileSystem; }
-
   virtual void hadCommandFailure() override {
     // Call the base implementation.
     BuildSystemFrontendDelegate::hadCommandFailure();
@@ -568,7 +566,8 @@ static int executeBuildCommand(std::vector<std::string> args) {
 
   // Create the frontend object.
   BasicBuildSystemFrontendDelegate delegate(sourceMgr, invocation);
-  BuildSystemFrontend frontend(delegate, invocation);
+  BuildSystemFrontend frontend(delegate, invocation,
+                               basic::createLocalFileSystem());
   if (!frontend.build(targetToBuild)) {
     // If there were failed commands, report the count and return an error.
     if (delegate.getNumFailedCommands()) {

--- a/products/swift-build-tool/main.cpp
+++ b/products/swift-build-tool/main.cpp
@@ -26,16 +26,11 @@ using namespace llbuild;
 using namespace llbuild::buildsystem;
 
 class BasicBuildSystemFrontendDelegate : public BuildSystemFrontendDelegate {
-  std::unique_ptr<basic::FileSystem> fileSystem;
-    
 public:
   BasicBuildSystemFrontendDelegate(llvm::SourceMgr& sourceMgr,
                                    const BuildSystemInvocation& invocation)
     : BuildSystemFrontendDelegate(sourceMgr, invocation,
-                                  "swift-build", /*version=*/0),
-      fileSystem(basic::createLocalFileSystem()) {}
-
-  virtual basic::FileSystem& getFileSystem() override { return *fileSystem; }
+                                  "swift-build", /*version=*/0) {}
 
   virtual void hadCommandFailure() override {
     // Call the base implementation.
@@ -101,7 +96,7 @@ static int execute(ArrayRef<std::string> args) {
 
   // Create the frontend object.
   BasicBuildSystemFrontendDelegate delegate(sourceMgr, invocation);
-  BuildSystemFrontend frontend(delegate, invocation);
+  BuildSystemFrontend frontend(delegate, invocation, basic::createLocalFileSystem());
   if (!frontend.build(targetToBuild)) {
     return 1;
   }

--- a/unittests/BuildSystem/BuildSystemFrontendTest.cpp
+++ b/unittests/BuildSystem/BuildSystemFrontendTest.cpp
@@ -50,7 +50,6 @@ namespace {
 /// Allows for command skipping via ``commandsToSkip``.
 class TestBuildSystemFrontendDelegate : public BuildSystemFrontendDelegate {
   using super = BuildSystemFrontendDelegate;
-  FileSystem& fs;
 
   std::mutex traceMutex;
   std::string traceData;
@@ -58,10 +57,8 @@ class TestBuildSystemFrontendDelegate : public BuildSystemFrontendDelegate {
 
 public:
   TestBuildSystemFrontendDelegate(SourceMgr& sourceMgr,
-                                  const BuildSystemInvocation& invocation,
-                                  FileSystem& fs):
+                                  const BuildSystemInvocation& invocation):
       BuildSystemFrontendDelegate(sourceMgr, invocation, "client", 0),
-      fs(fs),
       traceStream(traceData)
   {
   }
@@ -188,10 +185,6 @@ public:
     super::commandProcessFinished(command, handle, result, exitStatus);
   }
 
-  virtual FileSystem& getFileSystem() override {
-    return fs;
-  }
-
   virtual std::unique_ptr<Tool> lookupTool(StringRef name) override {
     return nullptr;
   }
@@ -259,10 +252,10 @@ commands:
 )END");
 
   {
-    TestBuildSystemFrontendDelegate delegate(sourceMgr, invocation, *fs);
+    TestBuildSystemFrontendDelegate delegate(sourceMgr, invocation);
     delegate.commandsToSkip.insert("2");
 
-    BuildSystemFrontend frontend(delegate, invocation);
+    BuildSystemFrontend frontend(delegate, invocation, std::move(fs));
     ASSERT_TRUE(frontend.build(""));
 
     ASSERT_TRUE(delegate.checkTrace(R"END(
@@ -292,9 +285,9 @@ commandFinished: 3: 0
   // re-run 3. 1 doesn't have to run at all, so we don't expect to get asked
   // if it should start.
   {
-    TestBuildSystemFrontendDelegate delegate(sourceMgr, invocation, *fs);
+    TestBuildSystemFrontendDelegate delegate(sourceMgr, invocation);
 
-    BuildSystemFrontend frontend(delegate, invocation);
+    BuildSystemFrontend frontend(delegate, invocation, std::move(fs));
     ASSERT_TRUE(frontend.build(""));
 
     ASSERT_TRUE(delegate.checkTrace(R"END(
@@ -341,10 +334,10 @@ commands:
 )END");
 
   {
-    TestBuildSystemFrontendDelegate delegate(sourceMgr, invocation, *fs);
+    TestBuildSystemFrontendDelegate delegate(sourceMgr, invocation);
     delegate.commandsToSkip.insert("1");
 
-    BuildSystemFrontend frontend(delegate, invocation);
+    BuildSystemFrontend frontend(delegate, invocation, std::move(fs));
     ASSERT_FALSE(frontend.build(""));
     ASSERT_EQ(1u, delegate.getNumFailedCommands());
 
@@ -367,9 +360,9 @@ hadCommandFailure
 
   // If we rebuild incrementally without skipping, we expect to run 1 and 2.
   {
-    TestBuildSystemFrontendDelegate delegate(sourceMgr, invocation, *fs);
+    TestBuildSystemFrontendDelegate delegate(sourceMgr, invocation);
 
-    BuildSystemFrontend frontend(delegate, invocation);
+    BuildSystemFrontend frontend(delegate, invocation, std::move(fs));
     ASSERT_TRUE(frontend.build(""));
 
     ASSERT_TRUE(delegate.checkTrace(R"END(
@@ -413,10 +406,10 @@ commands:
         outputs: ["2"]
 )END");
 
-  TestBuildSystemFrontendDelegate delegate(sourceMgr, invocation, *fs);
+  TestBuildSystemFrontendDelegate delegate(sourceMgr, invocation);
   delegate.commandsToSkip.insert("1");
   
-  BuildSystemFrontend frontend(delegate, invocation);
+  BuildSystemFrontend frontend(delegate, invocation, std::move(fs));
   ASSERT_TRUE(frontend.build(""));
 
   ASSERT_TRUE(delegate.checkTrace(R"END(
@@ -459,10 +452,10 @@ commands:
   // We need to delete the symlink ourselves, because llvm's remove()
   // currently refuses to delete symlinks.
 
-  TestBuildSystemFrontendDelegate delegate(sourceMgr, invocation, *fs);
+  TestBuildSystemFrontendDelegate delegate(sourceMgr, invocation);
   delegate.commandsToSkip.insert("1");
   
-  BuildSystemFrontend frontend(delegate, invocation);
+  BuildSystemFrontend frontend(delegate, invocation, std::move(fs));
   ASSERT_TRUE(frontend.build(""));
 
   ASSERT_TRUE(delegate.checkTrace(R"END(
@@ -488,8 +481,8 @@ client:
   name: client
 )END");
 
-  TestBuildSystemFrontendDelegate delegate(sourceMgr, invocation, *fs);
-  BuildSystemFrontend frontend(delegate, invocation);
+  TestBuildSystemFrontendDelegate delegate(sourceMgr, invocation);
+  BuildSystemFrontend frontend(delegate, invocation, std::move(fs));
 
   ASSERT_FALSE(frontend.buildNode("/missing"));
   ASSERT_TRUE(delegate.checkTrace("error: missing input '/missing' and no rule to build it\n"));

--- a/unittests/BuildSystem/BuildSystemFrontendTest.cpp
+++ b/unittests/BuildSystem/BuildSystemFrontendTest.cpp
@@ -255,7 +255,7 @@ commands:
     TestBuildSystemFrontendDelegate delegate(sourceMgr, invocation);
     delegate.commandsToSkip.insert("2");
 
-    BuildSystemFrontend frontend(delegate, invocation, std::move(fs));
+    BuildSystemFrontend frontend(delegate, invocation, createLocalFileSystem());
     ASSERT_TRUE(frontend.build(""));
 
     ASSERT_TRUE(delegate.checkTrace(R"END(
@@ -287,7 +287,7 @@ commandFinished: 3: 0
   {
     TestBuildSystemFrontendDelegate delegate(sourceMgr, invocation);
 
-    BuildSystemFrontend frontend(delegate, invocation, std::move(fs));
+    BuildSystemFrontend frontend(delegate, invocation, createLocalFileSystem());
     ASSERT_TRUE(frontend.build(""));
 
     ASSERT_TRUE(delegate.checkTrace(R"END(
@@ -337,7 +337,7 @@ commands:
     TestBuildSystemFrontendDelegate delegate(sourceMgr, invocation);
     delegate.commandsToSkip.insert("1");
 
-    BuildSystemFrontend frontend(delegate, invocation, std::move(fs));
+    BuildSystemFrontend frontend(delegate, invocation, createLocalFileSystem());
     ASSERT_FALSE(frontend.build(""));
     ASSERT_EQ(1u, delegate.getNumFailedCommands());
 
@@ -362,7 +362,7 @@ hadCommandFailure
   {
     TestBuildSystemFrontendDelegate delegate(sourceMgr, invocation);
 
-    BuildSystemFrontend frontend(delegate, invocation, std::move(fs));
+    BuildSystemFrontend frontend(delegate, invocation, createLocalFileSystem());
     ASSERT_TRUE(frontend.build(""));
 
     ASSERT_TRUE(delegate.checkTrace(R"END(
@@ -409,7 +409,7 @@ commands:
   TestBuildSystemFrontendDelegate delegate(sourceMgr, invocation);
   delegate.commandsToSkip.insert("1");
   
-  BuildSystemFrontend frontend(delegate, invocation, std::move(fs));
+  BuildSystemFrontend frontend(delegate, invocation, createLocalFileSystem());
   ASSERT_TRUE(frontend.build(""));
 
   ASSERT_TRUE(delegate.checkTrace(R"END(
@@ -455,7 +455,7 @@ commands:
   TestBuildSystemFrontendDelegate delegate(sourceMgr, invocation);
   delegate.commandsToSkip.insert("1");
   
-  BuildSystemFrontend frontend(delegate, invocation, std::move(fs));
+  BuildSystemFrontend frontend(delegate, invocation, createLocalFileSystem());
   ASSERT_TRUE(frontend.build(""));
 
   ASSERT_TRUE(delegate.checkTrace(R"END(
@@ -482,7 +482,7 @@ client:
 )END");
 
   TestBuildSystemFrontendDelegate delegate(sourceMgr, invocation);
-  BuildSystemFrontend frontend(delegate, invocation, std::move(fs));
+  BuildSystemFrontend frontend(delegate, invocation, createLocalFileSystem());
 
   ASSERT_FALSE(frontend.buildNode("/missing"));
   ASSERT_TRUE(delegate.checkTrace("error: missing input '/missing' and no rule to build it\n"));

--- a/unittests/BuildSystem/MockBuildSystemDelegate.cpp
+++ b/unittests/BuildSystem/MockBuildSystemDelegate.cpp
@@ -19,8 +19,8 @@ using namespace llbuild::unittests;
 
 MockExecutionQueueDelegate::MockExecutionQueueDelegate() {}
 
-MockBuildSystemDelegate::MockBuildSystemDelegate(bool trackAllMessages, std::shared_ptr<basic::FileSystem> fileSystem)
-    : BuildSystemDelegate("mock", 0), fileSystem(fileSystem), trackAllMessages(trackAllMessages)
+MockBuildSystemDelegate::MockBuildSystemDelegate(bool trackAllMessages)
+    : BuildSystemDelegate("mock", 0), trackAllMessages(trackAllMessages)
 {
 }
 

--- a/unittests/BuildSystem/MockBuildSystemDelegate.h
+++ b/unittests/BuildSystem/MockBuildSystemDelegate.h
@@ -53,7 +53,6 @@ private:
 };
   
 class MockBuildSystemDelegate : public BuildSystemDelegate {
-  std::shared_ptr<basic::FileSystem> fileSystem;
   std::vector<std::string> messages;
   std::mutex messagesMutex;
   
@@ -62,8 +61,7 @@ class MockBuildSystemDelegate : public BuildSystemDelegate {
   bool trackAllMessages;
   
 public:
-    MockBuildSystemDelegate(bool trackAllMessages = false,
-                            std::shared_ptr<basic::FileSystem> fileSystem = basic::createLocalFileSystem());
+    MockBuildSystemDelegate(bool trackAllMessages = false);
 
   std::vector<std::string> getMessages() {
     {
@@ -71,8 +69,6 @@ public:
       return messages;
     }
   }
-  
-  virtual basic::FileSystem& getFileSystem() { return *fileSystem; }
   
   virtual void setFileContentsBeingParsed(StringRef buffer) {}
 


### PR DESCRIPTION
This will allow a single place for file system configuration to be
applied (i.e. wrapping with a device/inode agnostic variant).