### PR TITLE
Add file-system client config attribute support

### DIFF
--- a/docs/buildsystem.rst
+++ b/docs/buildsystem.rst
@@ -226,6 +226,11 @@ present.
 
   The version field is optional, and defaults to 0.
 
+  A file-system field may be supplied that toggles how the build system handles
+  file system use. The `default` mode uses detailed stat information for
+  detecting file changes. The `device-agnostic` mode will ignore device and
+  inode values.
+
   Additional string keys and values may be specified here, and are passed to the
   client to handle.
 

--- a/tests/BuildSystem/Build/file-system-opts-errors.llbuild
+++ b/tests/BuildSystem/Build/file-system-opts-errors.llbuild
@@ -1,0 +1,23 @@
+# config error in file system opts
+#
+# RUN: rm -rf %t.build
+# RUN: mkdir -p %t.build
+# RUN: cp %s %t.build/build.llbuild
+# RUN: %{llbuild} buildsystem build --serial --chdir %t.build > %t.out 2> %t.err || true
+# RUN: %{FileCheck} --check-prefix CHECK-ERR --input-file %t.err %s
+#
+
+client:
+  name: basic
+  # CHECK-ERR: build.llbuild:[[@LINE-1]]:3: error: unsupported client file-system: 'not-a-file-system'
+  # CHECK-ERR: error: unable to load build file
+  file-system: not-a-file-system
+
+targets:
+  "": ["output"]
+
+commands:
+  dummy:
+    tool: shell
+    outputs: ["output"]
+    args: echo "foo" > output

--- a/tests/BuildSystem/Build/file-system-opts.llbuild
+++ b/tests/BuildSystem/Build/file-system-opts.llbuild
@@ -1,0 +1,92 @@
+# Check basic building functionality with the device-agnostic file system.
+#
+# RUN: rm -rf %t.build
+# RUN: mkdir -p %t.build
+# RUN: touch "%t.build/input A"
+# RUN: cp %s %t.build/build.llbuild
+# RUN: %{llbuild} buildsystem build --serial --chdir %t.build --trace %t.trace > %t.out
+# RUN: %{FileCheck} --input-file=%t.out %s
+# RUN: diff "%t.build/input A" %t.build/output
+#
+# CHECK: /usr/bin/env
+# CHECK: ENV_KEY=ENV_VALUE_1
+# CHECK-NOT: PATH=
+# CHECK-NEXT: /usr/bin/env
+# CHECK: ENV_KEY=ENV_VALUE_2
+# CHECK: LLBUILD_TASK_ID=0
+# CHECK: PATH=random-overridden-path
+# CHECK: cp 'input A' output
+
+# Check the engine trace.
+#
+# RUN: %{FileCheck} --input-file=%t.trace %s --check-prefix CHECK-TRACE
+#
+# CHECK-TRACE: "build-started"
+# CHECK-TRACE: "new-rule", "R1", "Tbasic"
+# CHECK-TRACE: "new-rule", "R2", "Noutput"
+# CHECK-TRACE: "new-rule", "R3", "Ccp-output"
+# CHECK-TRACE: "new-rule", "R4", "N<env-2>"
+# CHECK-TRACE: "build-ended"
+
+# Check that a null build does nothing.
+#
+# RUN: %{llbuild} buildsystem build --serial --chdir %t.build > %t2.out
+# RUN: echo "PREVENT-EMPTY-FILE" >> %t2.out
+# RUN: %{FileCheck} --input-file=%t2.out %s --check-prefix=CHECK-REBUILD
+#
+# CHECK-REBUILD-NOT: cp 'input A' output
+
+# Check that we properly copy the output when the input changes.
+#
+# RUN: echo mod >> "%t.build/input A"
+# RUN: %{llbuild} buildsystem build --serial --chdir %t.build > %t3.out
+# RUN: %{FileCheck} --input-file=%t3.out %s --check-prefix=CHECK-REBUILD-MODIFIED
+# RUN: diff "%t.build/input A" %t.build/output
+#
+# CHECK-REBUILD-MODIFIED: cp 'input A' output
+
+# Check that we properly copy the output when the output isn't present.
+#
+# RUN: rm -rf %t.build/output
+# RUN: %{llbuild} buildsystem build --serial --chdir %t.build > %t4.out
+# RUN: %{FileCheck} --input-file=%t4.out %s --check-prefix=CHECK-REBUILD-OUTPUT-REMOVED
+# RUN: diff "%t.build/input A" %t.build/output
+#
+# CHECK-REBUILD-OUTPUT-REMOVED: cp 'input A' output
+
+client:
+  name: basic
+  file-system: device-agnostic
+
+targets:
+  basic: ["output"]
+
+# define the default target to execute when this manifest is loaded.
+default: basic
+
+commands:
+  "<env-1>":
+    tool: shell
+    outputs: ["<env-1>"]
+    args: ["/usr/bin/env"]
+    env:
+      ENV_KEY: ENV_VALUE_1
+    inherit-env: false
+
+  "<env-2>":
+    tool: shell
+    inputs: ["<env-1>"]
+    outputs: ["<env-2>"]
+    args: /usr/bin/env | /usr/bin/sort
+    env:
+      ENV_KEY: ENV_VALUE_2
+      PATH: random-overridden-path
+
+  cp-output:
+    tool: shell
+    inputs: ["input A", "<env-1>", "<env-2>"]
+    outputs: ["output"]
+    # FIXME: Design a limited mechanism for substitution. Might be tool specific.
+    args: ["cp", "input A", "output"]
+
+


### PR DESCRIPTION
Allows setting 'device-agnostic' file system in the build file

rdar://problem/37445150