### PR TITLE
[CMake] Add option to enable assertion in release mode

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -218,6 +218,12 @@ append_if(CXX_SUPPORTS_UNREACHABLE_CODE_FLAG "-Wunreachable-code" CMAKE_CXX_FLAG
 check_cxx_compiler_flag("-Werror -Woverloaded-virtual" CXX_SUPPORTS_OVERLOADED_VIRTUAL)
 append_if(CXX_SUPPORTS_OVERLOADED_VIRTUAL "-Woverloaded-virtual" CMAKE_CXX_FLAGS)
 
+# Release configuration has assertions disabled, enable them if asked to.
+if(LLBUILD_ENABLE_ASSERTIONS)
+  string(REPLACE "-DNDEBUG" "" CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE}")
+  string(REPLACE "-DNDEBUG" "" CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE}")
+endif()
+
 ###
 
 # Process CMakeLists files for our subdirectories.


### PR DESCRIPTION
This adds an option to enable assertions when building in release mode,
example invocation:
```
cmake -G Ninja -DCMAKE_BUILD_TYPE:=Release -DLLBUILD_ENABLE_ASSERTIONS:=YES ..
```  

