### PR TITLE
Cleanup up generate version.h build phase

### DIFF
--- a/llbuild.xcodeproj/project.pbxproj
+++ b/llbuild.xcodeproj/project.pbxproj
@@ -191,7 +191,6 @@
 		E1AAD28A1BC609F600F54680 /* BuildSystemFrontend.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E1AAD2891BC609F600F54680 /* BuildSystemFrontend.cpp */; };
 		E1AAD28E1BC65A1900F54680 /* BuildNode.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E1AAD28D1BC65A1900F54680 /* BuildNode.cpp */; };
 		E1AAD2901BC65AB200F54680 /* ExternalCommand.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E1AAD28F1BC65AB200F54680 /* ExternalCommand.cpp */; };
-		E1AAD2921BC65B5000F54680 /* SwiftTools.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E1AAD2911BC65B5000F54680 /* SwiftTools.cpp */; };
 		E1ADC23E1A85938C00D5387C /* C-API.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E1ADC2311A85922F00D5387C /* C-API.cpp */; };
 		E1ADC23F1A8593AD00D5387C /* llbuild.h in Headers */ = {isa = PBXBuildFile; fileRef = E1ADC2351A8592AA00D5387C /* llbuild.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		E1B3B9DC1E4D5A7A00DF1FBC /* MockBuildSystemDelegate.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E1B3B9DA1E4D5A7A00DF1FBC /* MockBuildSystemDelegate.cpp */; };
@@ -979,7 +978,6 @@
 		E1AAD28B1BC60A0F00F54680 /* BuildSystemFrontend.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BuildSystemFrontend.h; sourceTree = "<group>"; };
 		E1AAD28D1BC65A1900F54680 /* BuildNode.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = BuildNode.cpp; sourceTree = "<group>"; };
 		E1AAD28F1BC65AB200F54680 /* ExternalCommand.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ExternalCommand.cpp; sourceTree = "<group>"; };
-		E1AAD2911BC65B5000F54680 /* SwiftTools.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = SwiftTools.cpp; sourceTree = "<group>"; };
 		E1ADC2301A85922F00D5387C /* CMakeLists.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = CMakeLists.txt; sourceTree = "<group>"; };
 		E1ADC2311A85922F00D5387C /* C-API.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = "C-API.cpp"; sourceTree = "<group>"; };
 		E1ADC2341A85928100D5387C /* README.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
@@ -2097,7 +2095,6 @@
 				E1AAD28F1BC65AB200F54680 /* ExternalCommand.cpp */,
 				E1066C071BC5ACAB00B892CE /* LaneBasedExecutionQueue.cpp */,
 				E19880E91FA256D900E490FF /* POSIXEnvironment.h */,
-				E1AAD2911BC65B5000F54680 /* SwiftTools.cpp */,
 			);
 			path = BuildSystem;
 			sourceTree = "<group>";
@@ -2830,12 +2827,11 @@
 			);
 			name = "Generate version.h";
 			outputPaths = (
-				"$(BUILT_PRODUCTS_DIR)/products/libllbuild/include/llbuild/verison.h",
+				"$(BUILT_PRODUCTS_DIR)/products/libllbuild/include/llbuild/version.h",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "set -e\nmkdir -p \"${BUILT_PRODUCTS_DIR}/products/libllbuild/include/llbuild\"\nsed -e \"s/\\${LLBUILD_C_API_VERSION}/${LLBUILD_C_API_VERSION}/\" \"${PROJECT_DIR}/products/libllbuild/include/llbuild/version.h.in\" > \"${BUILT_PRODUCTS_DIR}/products/libllbuild/include/llbuild/version.h\"";
-			showEnvVarsInLog = 0;
+			shellScript = "# This script generates the version.h file.  It exists as a separate build\n# phase so that both the framework build and tests that import it\n# 'library-style' can depend on it existing\n\nset -e\nmkdir -p \"${BUILT_PRODUCTS_DIR}/products/libllbuild/include/llbuild\"\nsed -e \"s/\\${LLBUILD_C_API_VERSION}/${LLBUILD_C_API_VERSION}/\" \"${SCRIPT_INPUT_FILE_0}\" > \"${SCRIPT_OUTPUT_FILE_0}\"";
 		};
 		9D2107C51DFA07D700BE26FF /* Create Target Link */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -3188,7 +3184,6 @@
 				E1FC67F91BB1F427004EBC54 /* BuildValue.cpp in Sources */,
 				E1BE0AA61C458EB000AD0883 /* BuildExecutionQueue.cpp in Sources */,
 				E11F2B7F1E4D255B00176BAD /* BuildDescription.cpp in Sources */,
-				E1AAD2921BC65B5000F54680 /* SwiftTools.cpp in Sources */,
 				E1E4A5B41BFC1394001BFFC4 /* BuildKey.cpp in Sources */,
 				E1B8395E1B541C5900DB876B /* BuildFile.cpp in Sources */,
 				E104FB001B6568E0005C68A0 /* BuildSystem.cpp in Sources */,


### PR DESCRIPTION
Fix a typo in the output file declaration, add descriptive comment, and
have the script reference input/output file declarations directly.