### PR TITLE
Make Command::shouldShowStatus available in C and Swift

### DIFF
--- a/products/libllbuild/BuildSystem-C-API.cpp
+++ b/products/libllbuild/BuildSystem-C-API.cpp
@@ -676,6 +676,12 @@ void llb_buildsystem_command_get_name(llb_buildsystem_command_t* command_p,
   key_out->data = (const uint8_t*) name.data();
 }
 
+bool llb_buildsystem_command_should_show_status(
+    llb_buildsystem_command_t* command_p) {
+  auto command = (Command*) command_p;
+  return command->shouldShowStatus();
+}
+
 char* llb_buildsystem_command_get_description(
     llb_buildsystem_command_t* command_p) {
   auto command = (Command*) command_p;

--- a/products/libllbuild/include/llbuild/buildsystem.h
+++ b/products/libllbuild/include/llbuild/buildsystem.h
@@ -578,6 +578,13 @@ LLBUILD_EXPORT void
 llb_buildsystem_command_get_name(llb_buildsystem_command_t* command,
                                  llb_data_t* key_out);
 
+/// Whether the default status reporting shows status for the command.
+///
+/// \returns A boolean describing wether status reporting should show status
+/// for the command.
+LLBUILD_EXPORT bool
+llb_buildsystem_command_should_show_status(llb_buildsystem_command_t* command);
+
 /// Get the description for the given command.
 ///
 /// \returns The command description, as a new C string. The client is

--- a/products/llbuildSwift/BuildSystemBindings.swift
+++ b/products/llbuildSwift/BuildSystemBindings.swift
@@ -171,6 +171,11 @@ public struct Command: Hashable {
         return stringFromData(data)
     }
 
+    /// Whether the default status reporting shows status for the command.
+    public var shouldShowStatus: Bool {
+        return llb_buildsystem_command_should_show_status(handle)
+    }
+
     /// The description provided by the command.
     public var description: String {
         let name = llb_buildsystem_command_get_description(handle)!


### PR DESCRIPTION
Can someone help me understand how to build `llbuildSwift` with CMake? I know I can built `llbuildSwift` with SwiftPM, but it isn't working currently because of the recent changes to version.h