### PR TITLE
Support custom swiftc through cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,8 +81,11 @@ find_package(PythonInterp)
 
 # Check if we should build the Swift bindings.
 if (";${LLBUILD_SUPPORT_BINDINGS};" MATCHES ";Swift;")
+  if (SWIFTC_EXECUTABLE)
+    set(SWIFTC_FOUND TRUE)
+    message(STATUS "Using provided swiftc: ${SWIFTC_EXECUTABLE}")
   # Find swiftc on OSX using `xcrun --find swiftc` and `find_package` on Linux.
-  if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+  elseif (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
     execute_process(
         COMMAND xcrun --find swiftc
         OUTPUT_VARIABLE SWIFTC_EXECUTABLE

--- a/cmake/modules/Utility.cmake
+++ b/cmake/modules/Utility.cmake
@@ -175,7 +175,7 @@ function(add_swift_module target name deps sources additional_args)
   # Compile swiftmodule.
   add_custom_command(
       OUTPUT    ${OUTPUTS}
-      COMMAND   swiftc
+      COMMAND   ${SWIFTC_EXECUTABLE}
       ARGS      ${ARGS}
       DEPENDS   ${sources}
   )
@@ -197,7 +197,7 @@ function(add_swift_module target name deps sources additional_args)
   
   add_custom_command(
       OUTPUT    ${DYLIB_OUTPUT}
-      COMMAND   swiftc
+      COMMAND   ${SWIFTC_EXECUTABLE}
       ARGS      ${DYLYB_ARGS}
       DEPENDS   ${OUTPUTS}
   )


### PR DESCRIPTION
As soon as this is merged, I have a PR ready against `swift`'s `build-script` to provide the correct `SWIFTC_EXECUTABLE` path.