### PR TITLE
Merge "missing inputs" error messages

### DIFF
--- a/include/llbuild/BuildSystem/ExternalCommand.h
+++ b/include/llbuild/BuildSystem/ExternalCommand.h
@@ -19,6 +19,7 @@
 #include "llbuild/BuildSystem/CommandResult.h"
 
 #include "llvm/ADT/Optional.h"
+#include "llvm/ADT/SmallPtrSet.h"
 #include "llvm/ADT/StringRef.h"
 
 #include <string>
@@ -71,9 +72,9 @@ class ExternalCommand : public Command {
   /// If not None, the command should be skipped with the provided BuildValue.
   llvm::Optional<BuildValue> skipValue;
 
-  /// If true, the command had a missing input (this implies ShouldSkip is
-  /// true).
-  bool hasMissingInput = false;
+  /// If there are any elements, the command had missing input nodes
+  /// (this implies ShouldSkip is true).
+  SmallPtrSet<Node*, 1> missingInputNodes;
 
   /// If true, the command can legally be updated if the output state allows it.
   bool canUpdateIfNewer = true;

--- a/tests/BuildSystem/Build/missing-inputs.llbuild
+++ b/tests/BuildSystem/Build/missing-inputs.llbuild
@@ -10,8 +10,7 @@
 # RUN: cat %t.out
 # RUN: %{FileCheck} %s --input-file %t.out --check-prefix=CHECK-FAILURE
 #
-# CHECK-FAILURE: missing input 'input' and no rule to build it
-# CHECK-FAILURE: cannot build 'output-1' due to missing input
+# CHECK-FAILURE: cannot build 'output-1' due to missing inputs: 'input'
 # CHECK-FAILURE-NOT: missing input 'output-2' and no rule to build it
 
 # RUN: touch %t.build/input

--- a/tests/BuildSystem/Build/missing-node.llbuild
+++ b/tests/BuildSystem/Build/missing-node.llbuild
@@ -6,8 +6,7 @@
 # RUN: %{llbuild} buildsystem build --serial --chdir %t.build > %t.out 2> %t.err || true
 # RUN: %{FileCheck} %s --input-file %t.err --check-prefix=CHECK-FAILURE-ERR
 #
-# CHECK-FAILURE-ERR: missing input 'output' and no rule to build it
-# CHECK-FAILURE-ERR: cannot build target {{.*}} due to missing input
+# CHECK-FAILURE-ERR: cannot build target {{.*}} due to missing inputs: 'output'
 # CHECK-FAILURE-ERR: error: build had 1 command failures
 
 client:


### PR DESCRIPTION
This should make it easier for users to see which missing inputs belong to which task.

See rdar://problem/35260583

Right now we log two messages:

- missing input ‘…’ and no rule to build it
- cannot build '...' due to missing input

This PR merges them into one:

- cannot build '...' due to missing inputs: ...

I am not entirely sure if this the implementation we want for this. Should we keep the early message that mentions the missing input in addition to adding it to the second error message? Should we fail the build early and put the merged message where the first one is currently?