### PR TITLE
Report extended results in commandProcessFinished

### DIFF
--- a/Xcode/Configs/Version.xcconfig
+++ b/Xcode/Configs/Version.xcconfig
@@ -13,7 +13,7 @@
 // Define the C API version
 //
 // See products/libllbuild/include/llbuild/version.h.in for version history
-LLBUILD_C_API_VERSION = 4
+LLBUILD_C_API_VERSION = 5
 
 // We define both the version value and a named version.  The latter is useful
 // in Swift conditional compilation, where we don't currently have the ability

--- a/examples/c-api/buildsystem/main.c
+++ b/examples/c-api/buildsystem/main.c
@@ -179,8 +179,7 @@ static void command_process_had_output(void* context,
 static void command_process_finished(void* context,
                                      llb_buildsystem_command_t* command,
                                      llb_buildsystem_process_t* process,
-                                     llb_buildsystem_command_result_t result,
-                                     int exit_status) {
+                                     const llb_buildsystem_command_extended_result_t* result) {
 }
 
 int main(int argc, char **argv) {

--- a/include/llbuild/BuildSystem/BuildExecutionQueue.h
+++ b/include/llbuild/BuildSystem/BuildExecutionQueue.h
@@ -27,6 +27,7 @@ namespace buildsystem {
 class BuildExecutionQueueDelegate;
 class Command;
 enum class CommandResult;
+struct CommandExtendedResult;
 
 /// Opaque type which allows the queue implementation to maintain additional
 /// state and associate subsequent requests (e.g., \see executeProcess()) with
@@ -230,14 +231,11 @@ public:
   /// become invalid as soon as the client returns from this API call.
   ///
   /// \param result - Whether the process suceeded, failed or was cancelled.
-  /// \param exitStatus - The raw exit status of the process, or -1 if an error
-  /// was encountered.
   //
   // FIXME: Need to include additional information on the status here, e.g., the
   // signal status, and the process output (if buffering).
   virtual void commandProcessFinished(Command*, ProcessHandle handle,
-                                      CommandResult result,
-                                      int exitStatus) = 0;
+                                      const CommandExtendedResult& result) = 0;
 };
 
 /// Create an execution queue that schedules jobs to individual lanes with a

--- a/include/llbuild/BuildSystem/BuildSystemFrontend.h
+++ b/include/llbuild/BuildSystem/BuildSystemFrontend.h
@@ -276,13 +276,11 @@ public:
   /// become invalid as soon as the client returns from this API call.
   ///
   /// \param result - Whether the process suceeded, failed or was cancelled.
-  /// \param exitStatus - The raw exit status of the process.
   //
   // FIXME: Need to include additional information on the status here, e.g., the
   // signal status, and the process output (if buffering).
   virtual void commandProcessFinished(Command*, ProcessHandle handle,
-                                      CommandResult result,
-                                      int exitStatus);
+                                      const CommandExtendedResult& result);
 
   /// Called when a cycle is detected by the build engine and it cannot make
   /// forward progress.

--- a/include/llbuild/BuildSystem/CommandResult.h
+++ b/include/llbuild/BuildSystem/CommandResult.h
@@ -13,6 +13,8 @@
 #ifndef LLBUILD_BUILDSYSTEM_COMMAND_RESULT_H
 #define LLBUILD_BUILDSYSTEM_COMMAND_RESULT_H
 
+#include <inttypes.h>
+
 namespace llbuild {
 namespace buildsystem {
 
@@ -22,6 +24,32 @@ enum class CommandResult {
   Failed,
   Cancelled,
   Skipped,
+};
+
+/// Extended result of a command execution.
+struct CommandExtendedResult {
+  CommandResult result; /// The final status of the command
+  int exitStatus;       /// The exit code
+
+  uint64_t utime;       /// User time (in us)
+  uint64_t stime;       /// Sys time (in us)
+  uint64_t maxrss;      /// Max RSS (in bytes)
+
+
+  CommandExtendedResult(CommandResult result, int exitStatus, uint64_t utime = 0,
+                uint64_t stime = 0, uint64_t maxrss = 0)
+    : result(result), exitStatus(exitStatus)
+    , utime(utime), stime(stime), maxrss(maxrss)
+  {}
+
+  static CommandExtendedResult makeFailed(int exitStatus = -1) {
+    return CommandExtendedResult(CommandResult::Failed, exitStatus);
+  }
+
+  static CommandExtendedResult makeCancelled(int exitStatus = -1) {
+    return CommandExtendedResult(CommandResult::Cancelled, exitStatus);
+  }
+
 };
 
 }

--- a/lib/BuildSystem/BuildSystemFrontend.cpp
+++ b/lib/BuildSystem/BuildSystemFrontend.cpp
@@ -229,12 +229,11 @@ public:
   }
 
   virtual void commandProcessFinished(Command* command, ProcessHandle handle,
-                                      CommandResult result,
-                                      int exitStatus) override {
+                                      const CommandExtendedResult& result) override {
     static_cast<BuildSystemFrontendDelegate*>(&getSystem().getDelegate())->
       commandProcessFinished(
           command, BuildSystemFrontendDelegate::ProcessHandle { handle.id },
-          result, exitStatus);
+          result);
   }
 };
 
@@ -546,8 +545,7 @@ commandProcessHadOutput(Command* command, ProcessHandle handle,
 
 void BuildSystemFrontendDelegate::
 commandProcessFinished(Command*, ProcessHandle handle,
-                       CommandResult result,
-                       int exitStatus) {
+                       const CommandExtendedResult& result) {
   auto impl = static_cast<BuildSystemFrontendDelegateImpl*>(this->impl);
   std::unique_lock<std::mutex> lock(impl->processOutputBuffersMutex);
 

--- a/lib/BuildSystem/LaneBasedExecutionQueue.cpp
+++ b/lib/BuildSystem/LaneBasedExecutionQueue.cpp
@@ -325,7 +325,7 @@ public:
             context.job.getForCommand(), handle,
             Twine("unable to open output pipe (") + strerror(errno) + ")");
         getDelegate().commandProcessFinished(context.job.getForCommand(),
-                                             handle, CommandResult::Failed, -1);
+                                             handle, CommandExtendedResult::makeFailed());
         return CommandResult::Failed;
       }
 
@@ -409,7 +409,7 @@ public:
               context.job.getForCommand(), handle,
               Twine("unable to spawn process (") + strerror(result) + ")");
           getDelegate().commandProcessFinished(context.job.getForCommand(), handle,
-                                               CommandResult::Failed, -1);
+                                               CommandExtendedResult::makeFailed());
           pid = -1;
         } else {
           spawnedProcesses.insert(pid);
@@ -475,7 +475,7 @@ public:
           context.job.getForCommand(), handle,
           Twine("unable to wait for process (") + strerror(errno) + ")");
       getDelegate().commandProcessFinished(context.job.getForCommand(), handle,
-                                           CommandResult::Failed, -1);
+                                           CommandExtendedResult::makeFailed(status));
       return CommandResult::Failed;
     }
 
@@ -483,10 +483,13 @@ public:
     //   arg2: user time, in us
     //   arg3: sys time, in us
     //   arg4: memory usage, in bytes
-    subprocessInterval.arg2 = (uint64_t(usage.ru_utime.tv_sec) * 1000000000 +
-                               uint64_t(usage.ru_utime.tv_usec) * 1000);
-    subprocessInterval.arg3 = (uint64_t(usage.ru_stime.tv_sec) * 1000000000 +
-                               uint64_t(usage.ru_stime.tv_usec) * 1000);
+    uint64_t utime = (uint64_t(usage.ru_utime.tv_sec) * 1000000000 +
+                      uint64_t(usage.ru_utime.tv_usec) * 1000);
+    uint64_t stime = (uint64_t(usage.ru_stime.tv_sec) * 1000000000 +
+                      uint64_t(usage.ru_stime.tv_usec) * 1000);
+
+    subprocessInterval.arg2 = utime;
+    subprocessInterval.arg3 = stime;
     subprocessInterval.arg4 = usage.ru_maxrss;
     
     // FIXME: We should report a statistic for how much output we read from the
@@ -495,8 +498,10 @@ public:
     // Notify of the process completion.
     bool cancelled = WIFSIGNALED(status) && (WTERMSIG(status) == SIGINT || WTERMSIG(status) == SIGKILL);
     CommandResult commandResult = cancelled ? CommandResult::Cancelled : (status == 0) ? CommandResult::Succeeded : CommandResult::Failed;
+    CommandExtendedResult extendedResult(commandResult, status, utime, stime,
+                                         usage.ru_maxrss);
     getDelegate().commandProcessFinished(context.job.getForCommand(), handle,
-                                         commandResult, status);
+                                         extendedResult);
     return commandResult;
   }
 };

--- a/llbuild.xcodeproj/project.pbxproj
+++ b/llbuild.xcodeproj/project.pbxproj
@@ -791,6 +791,26 @@
 		40377C7C2061D24200C0FD4D /* Package.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Package.swift; sourceTree = "<group>"; };
 		403B1A48205312000018A322 /* version.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = version.h; sourceTree = "<group>"; };
 		40F4F4F220531D8A00170EE1 /* version.h.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = version.h.in; sourceTree = "<group>"; };
+		40F638CE2051EDC800A1CFBE /* count-lines-2 */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = "count-lines-2"; sourceTree = "<group>"; };
+		40F638CF2051EDC800A1CFBE /* count-lines-4 */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = "count-lines-4"; sourceTree = "<group>"; };
+		40F638D02051EDC800A1CFBE /* count-lines-3 */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = "count-lines-3"; sourceTree = "<group>"; };
+		40F638D12051EDC800A1CFBE /* simplebuild.py */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.script.python; path = simplebuild.py; sourceTree = "<group>"; };
+		40F638D22051EDC800A1CFBE /* simple-make */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = "simple-make"; sourceTree = "<group>"; };
+		40F638D32051EDC800A1CFBE /* util.py */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.script.python; path = util.py; sourceTree = "<group>"; };
+		40F638D42051EDC800A1CFBE /* README.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
+		40F638D52051EDC800A1CFBE /* count-lines-1 */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = "count-lines-1"; sourceTree = "<group>"; };
+		40F638D82051EDC800A1CFBE /* basic.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = basic.swift; sourceTree = "<group>"; };
+		40F638DA2051EDC800A1CFBE /* README.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
+		40F638DB2051EDC800A1CFBE /* .gitignore */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = .gitignore; sourceTree = "<group>"; };
+		40F638DD2051EDC800A1CFBE /* index.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = index.html; sourceTree = "<group>"; };
+		40F638DE2051EDC800A1CFBE /* PlayLife.js */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.javascript; path = PlayLife.js; sourceTree = "<group>"; };
+		40F638DF2051EDC800A1CFBE /* Package.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Package.swift; sourceTree = "<group>"; };
+		40F638E22051EDC800A1CFBE /* LifeBoard.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LifeBoard.swift; sourceTree = "<group>"; };
+		40F638E32051EDC800A1CFBE /* LifeBoard+Build.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "LifeBoard+Build.swift"; sourceTree = "<group>"; };
+		40F638E42051EDC800A1CFBE /* BuildLife.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BuildLife.swift; sourceTree = "<group>"; };
+		40F638E62051EDC800A1CFBE /* main.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; };
+		40F638E92051EDC800A1CFBE /* README.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
+		40F638EA2051EDC800A1CFBE /* main.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = main.c; sourceTree = "<group>"; };
 		40F638EC2053043D00A1CFBE /* Version.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Version.xcconfig; sourceTree = "<group>"; };
 		54E187B61CD296EA00F7EC89 /* BuildNode.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BuildNode.h; sourceTree = "<group>"; };
 		54E187B71CD296EA00F7EC89 /* ExternalCommand.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ExternalCommand.h; sourceTree = "<group>"; };
@@ -1309,6 +1329,113 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		40F638CC2051EDC800A1CFBE /* examples */ = {
+			isa = PBXGroup;
+			children = (
+				40F638CD2051EDC800A1CFBE /* simple-make */,
+				40F638D62051EDC800A1CFBE /* swift-bindings */,
+				40F638D92051EDC800A1CFBE /* GameOfLife */,
+				40F638E72051EDC800A1CFBE /* c-api */,
+			);
+			path = examples;
+			sourceTree = "<group>";
+		};
+		40F638CD2051EDC800A1CFBE /* simple-make */ = {
+			isa = PBXGroup;
+			children = (
+				40F638CE2051EDC800A1CFBE /* count-lines-2 */,
+				40F638CF2051EDC800A1CFBE /* count-lines-4 */,
+				40F638D02051EDC800A1CFBE /* count-lines-3 */,
+				40F638D12051EDC800A1CFBE /* simplebuild.py */,
+				40F638D22051EDC800A1CFBE /* simple-make */,
+				40F638D32051EDC800A1CFBE /* util.py */,
+				40F638D42051EDC800A1CFBE /* README.md */,
+				40F638D52051EDC800A1CFBE /* count-lines-1 */,
+			);
+			path = "simple-make";
+			sourceTree = "<group>";
+		};
+		40F638D62051EDC800A1CFBE /* swift-bindings */ = {
+			isa = PBXGroup;
+			children = (
+				40F638D72051EDC800A1CFBE /* core */,
+			);
+			path = "swift-bindings";
+			sourceTree = "<group>";
+		};
+		40F638D72051EDC800A1CFBE /* core */ = {
+			isa = PBXGroup;
+			children = (
+				40F638D82051EDC800A1CFBE /* basic.swift */,
+			);
+			path = core;
+			sourceTree = "<group>";
+		};
+		40F638D92051EDC800A1CFBE /* GameOfLife */ = {
+			isa = PBXGroup;
+			children = (
+				40F638DA2051EDC800A1CFBE /* README.md */,
+				40F638DB2051EDC800A1CFBE /* .gitignore */,
+				40F638DC2051EDC800A1CFBE /* Static */,
+				40F638DF2051EDC800A1CFBE /* Package.swift */,
+				40F638E02051EDC800A1CFBE /* Sources */,
+			);
+			path = GameOfLife;
+			sourceTree = "<group>";
+		};
+		40F638DC2051EDC800A1CFBE /* Static */ = {
+			isa = PBXGroup;
+			children = (
+				40F638DD2051EDC800A1CFBE /* index.html */,
+				40F638DE2051EDC800A1CFBE /* PlayLife.js */,
+			);
+			path = Static;
+			sourceTree = "<group>";
+		};
+		40F638E02051EDC800A1CFBE /* Sources */ = {
+			isa = PBXGroup;
+			children = (
+				40F638E12051EDC800A1CFBE /* GameOfLife */,
+				40F638E52051EDC800A1CFBE /* LifeServer */,
+			);
+			path = Sources;
+			sourceTree = "<group>";
+		};
+		40F638E12051EDC800A1CFBE /* GameOfLife */ = {
+			isa = PBXGroup;
+			children = (
+				40F638E22051EDC800A1CFBE /* LifeBoard.swift */,
+				40F638E32051EDC800A1CFBE /* LifeBoard+Build.swift */,
+				40F638E42051EDC800A1CFBE /* BuildLife.swift */,
+			);
+			path = GameOfLife;
+			sourceTree = "<group>";
+		};
+		40F638E52051EDC800A1CFBE /* LifeServer */ = {
+			isa = PBXGroup;
+			children = (
+				40F638E62051EDC800A1CFBE /* main.swift */,
+			);
+			path = LifeServer;
+			sourceTree = "<group>";
+		};
+		40F638E72051EDC800A1CFBE /* c-api */ = {
+			isa = PBXGroup;
+			children = (
+				40F638E82051EDC800A1CFBE /* buildsystem */,
+			);
+			path = "c-api";
+			sourceTree = "<group>";
+		};
+		40F638E82051EDC800A1CFBE /* buildsystem */ = {
+			isa = PBXGroup;
+			children = (
+				40F638E92051EDC800A1CFBE /* README.md */,
+				40F638EA2051EDC800A1CFBE /* main.c */,
+			);
+			path = buildsystem;
+			sourceTree = "<group>";
+		};
 		9DB0478A1DF9D39E006CDF52 /* BuildSystem */ = {
 			isa = PBXGroup;
 			children = (
@@ -1413,6 +1540,7 @@
 				E14144901EBDA4A10046F282 /* Xcode */,
 				E1A223FD19F990F10059043E /* products */,
 				E1A2240419F991530059043E /* lib */,
+				40F638CC2051EDC800A1CFBE /* examples */,
 				E19C3FD51B98C1A70035E1AA /* tests */,
 				E1C404B51A03090D003392BA /* perftests */,
 				E1A224B219F998D40059043E /* unittests */,
@@ -1453,10 +1581,10 @@
 		E1A223FD19F990F10059043E /* products */ = {
 			isa = PBXGroup;
 			children = (
-				BC8DEF0420300AAF00E9EF0C /* llbuildSwift */,
 				E1A2240119F991350059043E /* llbuild */,
 				E1ADC22F1A8591F600D5387C /* libllbuild */,
 				E1D191B71B472305000C4E95 /* llbuild-framework */,
+				BC8DEF0420300AAF00E9EF0C /* llbuildSwift */,
 				E1604CB21BB9E032001153A1 /* swift-build-tool */,
 				E1A2240019F991350059043E /* CMakeLists.txt */,
 			);

--- a/products/libllbuild/BuildSystem-C-API.cpp
+++ b/products/libllbuild/BuildSystem-C-API.cpp
@@ -314,15 +314,20 @@ public:
   }
   
   virtual void commandProcessFinished(Command* command, ProcessHandle handle,
-                                      CommandResult commandResult,
-                                      int exitStatus) override {
+                                      const CommandExtendedResult& commandResult) override {
     if (cAPIDelegate.command_process_finished) {
+      llb_buildsystem_command_extended_result_t result;
+      result.result = get_command_result(commandResult.result);
+      result.exit_status = commandResult.exitStatus;
+      result.utime = commandResult.utime;
+      result.stime = commandResult.stime;
+      result.maxrss = commandResult.maxrss;
+
       cAPIDelegate.command_process_finished(
           cAPIDelegate.context,
           (llb_buildsystem_command_t*) command,
           (llb_buildsystem_process_t*) handle.id,
-          get_command_result(commandResult),
-          exitStatus);
+          &result);
     }
   }
 

--- a/products/libllbuild/include/llbuild/buildsystem.h
+++ b/products/libllbuild/include/llbuild/buildsystem.h
@@ -95,6 +95,15 @@ typedef enum {
   llb_buildsystem_command_result_skipped = 3,
 } llb_buildsystem_command_result_t;
 
+/// Extended result of a command execution
+typedef struct llb_buildsystem_command_extended_result_t_ {
+  llb_buildsystem_command_result_t result;  /// Result of command execution
+  int exit_status;                          /// The exit code
+  uint64_t utime;                           /// User time (in us)
+  uint64_t stime;                           /// Sys time (in us)
+  uint64_t maxrss;                          /// Max RSS (in bytes)
+} llb_buildsystem_command_extended_result_t;
+
 /// Status change event kinds.
 typedef enum {
   /// Indicates the command is being scanned to determine if it needs to run.
@@ -386,8 +395,7 @@ typedef struct llb_buildsystem_delegate_t_ {
   void (*command_process_finished)(void* context,
                                    llb_buildsystem_command_t* command,
                                    llb_buildsystem_process_t* process,
-                                   llb_buildsystem_command_result_t result,
-                                   int exit_status);
+                                   const llb_buildsystem_command_extended_result_t* result);
 
   /// Called when a cycle is detected by the build engine and it cannot make
   /// forward progress.

--- a/products/libllbuild/include/llbuild/llbuild.h
+++ b/products/libllbuild/include/llbuild/llbuild.h
@@ -38,6 +38,8 @@
 ///
 /// Version History:
 ///
+/// 5: Added `llb_buildsystem_command_extended_result_t`, changed command_process_finished signature.
+///
 /// 4: Added llb_buildsystem_build_node.
 ///
 /// 3: Added command_had_error, command_had_note and command_had_warning delegate methods.

--- a/products/llbuildSwift/BuildSystemBindings.swift
+++ b/products/llbuildSwift/BuildSystemBindings.swift
@@ -18,7 +18,7 @@ import Foundation
 
 import llbuild
 
-#if !LLBUILD_C_API_VERSION_4
+#if !LLBUILD_C_API_VERSION_5
   #if swift(>=4.2)
     #error("Unsupported llbuild C API version")
   #else
@@ -233,6 +233,23 @@ public enum CommandResult {
   }
 }
 
+/// Result of a command execution.
+public struct CommandExtendedResult {
+  public let result: CommandResult /// The result of a command execution
+  public let exitStatus: Int32     /// The exit code
+  public let utime: UInt64         /// User time (in us)
+  public let stime: UInt64         /// Sys time (in us)
+  public let maxRSS: UInt64        /// Max RSS (in bytes)
+
+  init(_ result: UnsafePointer<llb_buildsystem_command_extended_result_t>) {
+    self.result = CommandResult(result.pointee.result)
+    self.exitStatus = result.pointee.exit_status
+    self.utime = result.pointee.utime
+    self.stime = result.pointee.stime
+    self.maxRSS = result.pointee.maxrss
+  }
+}
+
 /// Status change event kinds.
 public enum CommandStatusKind {
     case isScanning
@@ -419,7 +436,7 @@ public protocol BuildSystemDelegate {
     ///
     /// - parameter result: Whether the process suceeded, failed or was cancelled.
     /// - parameter exitStatus: The raw exit status of the process.
-    func commandProcessFinished(_ command: Command, process: ProcessHandle, result: CommandResult, exitStatus: Int)
+    func commandProcessFinished(_ command: Command, process: ProcessHandle, result: CommandExtendedResult)
 
     /// Called when a cycle is detected by the build engine and it cannot make
     /// forward progress.
@@ -510,7 +527,7 @@ public final class BuildSystem {
         _delegate.command_process_started = { BuildSystem.toSystem($0!).commandProcessStarted(Command($1), ProcessHandle($2!)) }
         _delegate.command_process_had_error = { BuildSystem.toSystem($0!).commandProcessHadError(Command($1), ProcessHandle($2!), $3!) }
         _delegate.command_process_had_output = { BuildSystem.toSystem($0!).commandProcessHadOutput(Command($1), ProcessHandle($2!), $3!) }
-        _delegate.command_process_finished = { BuildSystem.toSystem($0!).commandProcessFinished(Command($1), ProcessHandle($2!), CommandResult($3), Int($4)) }
+        _delegate.command_process_finished = { BuildSystem.toSystem($0!).commandProcessFinished(Command($1), ProcessHandle($2!), CommandExtendedResult($3!)) }
         _delegate.cycle_detected = {
             var rules = [BuildKey]()
             UnsafeBufferPointer(start: $1, count: Int($2)).forEach {
@@ -690,8 +707,8 @@ public final class BuildSystem {
         delegate.commandProcessHadOutput(command, process: process, data: bytesFromData(data.pointee))
     }
 
-    private func commandProcessFinished(_ command: Command, _ process: ProcessHandle, _ result: CommandResult, _ exitStatus: Int) {
-        delegate.commandProcessFinished(command, process: process, result: result, exitStatus: exitStatus)
+    private func commandProcessFinished(_ command: Command, _ process: ProcessHandle, _ result: CommandExtendedResult) {
+        delegate.commandProcessFinished(command, process: process, result: result)
     }
 
     private func cycleDetected(_ rules: [BuildKey]) {

--- a/unittests/BuildSystem/BuildSystemFrontendTest.cpp
+++ b/unittests/BuildSystem/BuildSystemFrontendTest.cpp
@@ -176,13 +176,14 @@ public:
     super::commandProcessHadError(command, handle, message);
   }
 
-  virtual void commandProcessFinished(Command* command, ProcessHandle handle, CommandResult result,
-                                      int exitStatus) override {
+  virtual void commandProcessFinished(Command* command, ProcessHandle handle,
+                                      const CommandExtendedResult& result) override {
     {
         std::lock_guard<std::mutex> lock(traceMutex);
-        traceStream << __FUNCTION__ << ": " << command->getName() << ": " << exitStatus << "\n";
+        traceStream << __FUNCTION__ << ": " << command->getName() << ": "
+                    << result.exitStatus << "\n";
     }
-    super::commandProcessFinished(command, handle, result, exitStatus);
+    super::commandProcessFinished(command, handle, result);
   }
 
   virtual std::unique_ptr<Tool> lookupTool(StringRef name) override {

--- a/unittests/BuildSystem/LaneBasedExecutionQueueTest.cpp
+++ b/unittests/BuildSystem/LaneBasedExecutionQueueTest.cpp
@@ -47,8 +47,7 @@ namespace {
     virtual void commandProcessHadOutput(Command* command, ProcessHandle handle,
                                          StringRef data) override {}
     virtual void commandProcessFinished(Command* command, ProcessHandle handle,
-                                        CommandResult result,
-                                        int exitStatus) override {}
+                                        const CommandExtendedResult& result) override {}
   };
 
   class DummyCommand : public Command {

--- a/unittests/BuildSystem/MockBuildSystemDelegate.h
+++ b/unittests/BuildSystem/MockBuildSystemDelegate.h
@@ -48,8 +48,7 @@ private:
                                        StringRef data) {}
   
   virtual void commandProcessFinished(Command*, ProcessHandle handle,
-                                      CommandResult result,
-                                      int exitStatus) {}
+                                      const CommandExtendedResult& result) {}
 };
   
 class MockBuildSystemDelegate : public BuildSystemDelegate {


### PR DESCRIPTION
Collect user/system time and max RSS values for subprocesses and report
them via a new CommamdExtendedResults struct in the
commandProcessFinished callback.

rdar://problem/37889042