### PR TITLE
Replace existing uses of `stringstream`

### DIFF
--- a/lib/Commands/CommandUtil.cpp
+++ b/lib/Commands/CommandUtil.cpp
@@ -18,9 +18,9 @@
 #include "llbuild/Ninja/Parser.h"
 
 #include "llvm/ADT/STLExtras.h"
+#include "llvm/Support/raw_ostream.h"
 
 #include <iostream>
-#include <sstream>
 
 using namespace llbuild;
 using namespace llbuild::commands;
@@ -44,22 +44,24 @@ static char hexdigit(unsigned input) {
 }
 
 std::string util::escapedString(const char* start, unsigned length) {
-  std::stringstream result;
+  std::string result;
+  llvm::raw_string_ostream resultStream(result);
   for (unsigned i = 0; i != length; ++i) {
     char c = start[i];
     if (c == '"') {
-      result << "\\\"";
+      resultStream << "\\\"";
     } else if (isprint(c)) {
-      result << c;
+      resultStream << c;
     } else if (c == '\n') {
-      result << "\\n";
+      resultStream << "\\n";
     } else {
-      result << "\\x"
+      resultStream << "\\x"
              << hexdigit(((unsigned char) c >> 4) & 0xF)
              << hexdigit((unsigned char) c & 0xF);
     }
   }
-  return result.str();
+  resultStream.flush();
+  return result;
 }
 std::string util::escapedString(const std::string& string) {
   return escapedString(string.data(), string.size());

--- a/lib/Core/SQLiteBuildDB.cpp
+++ b/lib/Core/SQLiteBuildDB.cpp
@@ -17,12 +17,12 @@
 #include "llbuild/Core/BuildEngine.h"
 
 #include "llvm/ADT/STLExtras.h"
+#include "llvm/Support/raw_ostream.h"
 
 #include <cassert>
 #include <cerrno>
 #include <cstring>
 #include <mutex>
-#include <sstream>
 
 #include <sqlite3.h>
 
@@ -51,14 +51,16 @@ class SQLiteBuildDB : public BuildDB {
     const char* err_message = sqlite3_errmsg(db);
     const char* filename = sqlite3_db_filename(db, "main");
 
-    std::stringstream out;
-    out << "error: accessing build database \"" << filename << "\": " << err_message;
+    std::string out;
+    llvm::raw_string_ostream outStream(out);
+    outStream << "error: accessing build database \"" << filename << "\": " << err_message;
 
     if (err_code == SQLITE_BUSY || err_code == SQLITE_LOCKED) {
-      out << " Possibly there are two concurrent builds running in the same filesystem location.";
+      outStream << " Possibly there are two concurrent builds running in the same filesystem location.";
     }
 
-    return out.str();
+    outStream.flush();
+    return out;
   }
 
 public:

--- a/unittests/Core/SQLiteBuildDBTest.cpp
+++ b/unittests/Core/SQLiteBuildDBTest.cpp
@@ -17,8 +17,6 @@
 
 #include "gtest/gtest.h"
 
-#include <sstream>
-
 #include <sqlite3.h>
 
 using namespace llbuild;


### PR DESCRIPTION
Inspired by https://github.com/apple/swift-llbuild/pull/255#discussion_r177496068 I went ahead and replaced existing uses, some of which I previously introduced unnoticed.