### PR TITLE
Prevent spurious rebuilds with SwiftPM builds of llbuild

### DIFF
--- a/products/libllbuild/include/llbuild/version.h
+++ b/products/libllbuild/include/llbuild/version.h
@@ -15,5 +15,5 @@
 //
 //===----------------------------------------------------------------------===//
 
-#define LLBUILD_C_API_VERSION 4
+#define LLBUILD_C_API_VERSION 5
 

--- a/utils/generate-version-h.sh
+++ b/utils/generate-version-h.sh
@@ -8,13 +8,13 @@ set -e
 
 # If not in Xcode, infer SRCROOT relative to this script
 if [ -z ${SRCROOT+x} ]; then
-    scriptroot=$(dirname ${BASH_SOURCE[0]})
+    scriptroot=$(dirname "${BASH_SOURCE[0]}")
     SRCROOT="${scriptroot}/.."
 fi;
 
 # Read the version out of the xcconfig file
 if [ -z ${LLBUILD_C_API_VERSION+x} ]; then
-    LLBUILD_C_API_VERSION=$(sed -n -e "s/.*LLBUILD_C_API_VERSION = \([0-9][0-9]*\).*/\1/p" "${SRCROOT}/Xcode/Configs/Version.xcconfig")
+    LLBUILD_C_API_VERSION=$(sed -n -e "s/.*LLBUILD_C_API_VERSION = \\([0-9][0-9]*\\).*/\\1/p" "${SRCROOT}/Xcode/Configs/Version.xcconfig")
 fi
 
 # Write out version.h from the template

--- a/utils/generate-version-h.sh
+++ b/utils/generate-version-h.sh
@@ -17,8 +17,13 @@ if [ -z ${LLBUILD_C_API_VERSION+x} ]; then
     LLBUILD_C_API_VERSION=$(sed -n -e "s/.*LLBUILD_C_API_VERSION = \\([0-9][0-9]*\\).*/\\1/p" "${SRCROOT}/Xcode/Configs/Version.xcconfig")
 fi
 
-# Write out version.h from the template
-sed -e "s/\${LLBUILD_C_API_VERSION}/${LLBUILD_C_API_VERSION}/" "${SRCROOT}/products/libllbuild/include/llbuild/version.h.in" > "${SRCROOT}/products/libllbuild/include/llbuild/version.h"
+# Write out version.h from the template, but only update the header if it actually changed, in order to prevent spurious rebuilds
+llbuild_version_tmp="$(mktemp)"
+llbuild_version="${SRCROOT}/products/libllbuild/include/llbuild/version.h"
+sed -e "s/\${LLBUILD_C_API_VERSION}/${LLBUILD_C_API_VERSION}/" "${SRCROOT}/products/libllbuild/include/llbuild/version.h.in" > "$llbuild_version_tmp"
+if ! diff "$llbuild_version_tmp" "$llbuild_version" > /dev/null ; then
+    mv "$llbuild_version_tmp" "$llbuild_version"
+fi
 
 # For use with SwiftPM, output the conditional compilation flag to stdout
 echo "-Xswiftc -DLLBUILD_C_API_VERSION_${LLBUILD_C_API_VERSION}"


### PR DESCRIPTION
The generate-version-h.sh script was writing a new version.h file (thus
updating the timestamp, thus triggering a change detection by the build
system) every time it was run, regardless of whether the content had
actually changed. Only update the file if doing so will actually change
the content, in order to make null builds actually work again.