### PR TITLE
[BuildSystem] Shell escape Swift executable for version cmd

### DIFF
--- a/lib/BuildSystem/BuildSystem.cpp
+++ b/lib/BuildSystem/BuildSystem.cpp
@@ -2194,7 +2194,7 @@ public:
     // FIXME: Need a decent subprocess interface.
     SmallString<256> command;
     llvm::raw_svector_ostream commandOS(command);
-    commandOS << executable;
+    commandOS << basic::shellEscaped(executable);
     commandOS << " " << "--version";
 
     // Read the result.


### PR DESCRIPTION
The path to compiler wasn't shell escaped and this lead to some output
on stderr if there was a space (or other unescaped char) in the Swift
compiler path. The printed output is relatively "harmless" and doesn't
actually contribute to a build failure.

- https://bugs.swift.org/browse/SR-7323
- <rdar://problem/39076084> [SR-7323]: SPM can't handle spaces in path to Xcode