### PR TITLE
Improve "node is produced by multiple commands" diagnostic

### DIFF
--- a/Xcode/Configs/Version.xcconfig
+++ b/Xcode/Configs/Version.xcconfig
@@ -13,7 +13,7 @@
 // Define the C API version
 //
 // See products/libllbuild/include/llbuild/llbuild.h for version history
-LLBUILD_C_API_VERSION = 5
+LLBUILD_C_API_VERSION = 6
 
 // We define both the version value and a named version.  The latter is useful
 // in Swift conditional compilation, where we don't currently have the ability

--- a/include/llbuild/BuildSystem/BuildSystem.h
+++ b/include/llbuild/BuildSystem/BuildSystem.h
@@ -180,6 +180,14 @@ public:
   /// \param data - The error message.
   virtual void commandHadError(Command*, StringRef data) = 0;
 
+  /// Called to report an error that relates to multiple commands.
+  ///
+  /// For example, an error where multiple commands are trying to
+  /// build the same node.
+  ///
+  /// \param data - The error message.
+  virtual void commandsHadError(std::vector<Command*>, StringRef data) = 0;
+
   /// Called to report a note during the execution of a command.
   ///
   /// \param data - The note message.

--- a/include/llbuild/BuildSystem/BuildSystemFrontend.h
+++ b/include/llbuild/BuildSystem/BuildSystemFrontend.h
@@ -212,6 +212,14 @@ public:
   /// \param data - The error message.
   virtual void commandHadError(Command*, StringRef data) override;
 
+  /// Called to report an error that relates to multiple commands.
+  ///
+  /// For example, an error where multiple commands are trying to
+  /// build the same node.
+  ///
+  /// \param data - The error message.
+  virtual void commandsHadError(std::vector<Command*>, StringRef data) override;
+
   /// Called to report a note during the execution of a command.
   ///
   /// \param data - The note message.

--- a/lib/BuildSystem/BuildSystem.cpp
+++ b/lib/BuildSystem/BuildSystem.cpp
@@ -660,12 +660,9 @@ class ProducedNodeTask : public Task {
     }
 
     // We currently do not support building nodes which have multiple producers.
-    auto producerA = node.getProducers()[0];
-    auto producerB = node.getProducers()[1];
-    getBuildSystem(engine).error(
-        "", "unable to build node: '" + node.getName() + "' (node is produced "
-        "by multiple commands; e.g., '" + producerA->getName() + "' and '" +
-        producerB->getName() + "')");
+    getBuildSystem(engine).getDelegate().commandsHadError(node.getProducers(),
+                    "unable to build node: '" + node.getName().str() +
+                    "' (node is produced by multiple commands)");
     isInvalid = true;
   }
 

--- a/lib/BuildSystem/BuildSystemFrontend.cpp
+++ b/lib/BuildSystem/BuildSystemFrontend.cpp
@@ -497,6 +497,11 @@ void BuildSystemFrontendDelegate::commandHadError(Command* command, StringRef da
   fflush(stderr);
 }
 
+void BuildSystemFrontendDelegate::commandsHadError(std::vector<Command*> commands, StringRef data) {
+  fwrite(data.data(), data.size(), 1, stderr);
+  fflush(stderr);
+}
+
 void BuildSystemFrontendDelegate::commandHadNote(Command* command, StringRef data) {
   fwrite(data.data(), data.size(), 1, stdout);
   fflush(stdout);

--- a/products/libllbuild/BuildSystem-C-API.cpp
+++ b/products/libllbuild/BuildSystem-C-API.cpp
@@ -257,6 +257,17 @@ public:
     }
   }
 
+  virtual void commandsHadError(std::vector<Command*> commands,  StringRef message) override {
+    if (cAPIDelegate.commands_had_error) {
+      llb_data_t cMessage { message.size(), (const uint8_t*) message.data() };
+      cAPIDelegate.commands_had_error(
+          cAPIDelegate.context,
+          (llb_buildsystem_command_t**) commands.data(),
+          commands.size(),
+          &cMessage);
+    }
+  }
+
   virtual void commandHadNote(Command* command, StringRef message) override {
     if (cAPIDelegate.command_had_note) {
       llb_data_t cMessage { message.size(), (const uint8_t*) message.data() };

--- a/products/libllbuild/include/llbuild/buildsystem.h
+++ b/products/libllbuild/include/llbuild/buildsystem.h
@@ -339,6 +339,19 @@ typedef struct llb_buildsystem_delegate_t_ {
                             llb_buildsystem_command_t* command,
                             const llb_data_t* data);
 
+  /// Called to report an error that relates to multiple commands.
+  ///
+  /// For example, an error where multiple commands are trying to
+  /// build the same node.
+  ///
+  /// Xparam commands The commands this error is related to.
+  /// Xparam numberOfCommands The number of commands.
+  /// Xparam data The error message.
+  void (*commands_had_error)(void* context,
+                             llb_buildsystem_command_t** commands,
+                             unsigned numberOfCommands,
+                             const llb_data_t* data);
+
   /// Called to report a note during the execution of a command.
   ///
   /// Xparam data The note message.

--- a/products/libllbuild/include/llbuild/llbuild.h
+++ b/products/libllbuild/include/llbuild/llbuild.h
@@ -38,6 +38,8 @@
 ///
 /// Version History:
 ///
+/// 6: Added `commands_had_error` delegate method.
+///
 /// 5: Added `llb_buildsystem_command_extended_result_t`, changed command_process_finished signature.
 ///
 /// 4: Added llb_buildsystem_build_node.

--- a/products/libllbuild/include/llbuild/version.h
+++ b/products/libllbuild/include/llbuild/version.h
@@ -15,5 +15,5 @@
 //
 //===----------------------------------------------------------------------===//
 
-#define LLBUILD_C_API_VERSION 5
+#define LLBUILD_C_API_VERSION 6
 

--- a/unittests/BuildSystem/MockBuildSystemDelegate.h
+++ b/unittests/BuildSystem/MockBuildSystemDelegate.h
@@ -126,6 +126,14 @@ public:
     }
   }
 
+  virtual void commandsHadError(std::vector<Command*> commands, StringRef data) {
+    llvm::errs() << "error: " << commands[0]->getName() << ": " << data.str() << "\n";
+    {
+      std::unique_lock<std::mutex> lock(messagesMutex);
+      messages.push_back(data.str());
+    }
+  }
+
   virtual void commandHadNote(Command* command, StringRef data) {
     if (trackAllMessages) {
       std::unique_lock<std::mutex> lock(messagesMutex);


### PR DESCRIPTION
Introduce a new delegate method `commandsHadError` which allows transferring information about multiple commands. For now, only the "node is produced by multiple commands" error is going to use this method.

See rdar://problem/39126255