### PR TITLE
[Core] Fix a crash introduced by key ID cache.

### DIFF
--- a/lib/Core/BuildEngine.cpp
+++ b/lib/Core/BuildEngine.cpp
@@ -1161,7 +1161,12 @@ public:
     }
 
     // Otherwise, use our builtin key table.
-    return keyTable.insert(std::make_pair(key, keyTable.size())).first->second;
+    //
+    // The RHS of the mapping is actually ignored, we use the StringMap's ptr
+    // identity because it allows us to efficiently map back to the key string
+    // in `getRuleInfoForKey`.
+    auto it = keyTable.insert(std::make_pair(key, 0)).first;
+    return (KeyID)(uintptr_t)it->getKey().data();
   }
 
   RuleInfo& getRuleInfoForKey(const KeyType& key) {
@@ -1190,7 +1195,7 @@ public:
     } else {
       // Note that we don't need to lock `keyTable` here because the key entries
       // themselves don't change once created.
-      key = llvm::StringMapEntry<bool>::GetStringMapEntryFromKeyData(
+      key = llvm::StringMapEntry<KeyID>::GetStringMapEntryFromKeyData(
           (const char*)(uintptr_t)keyID).getKey();
     }
     return addRule(keyID, delegate.lookupRule(key));

--- a/tests/BuildSystem/Build/discovered-compiler-deps.llbuild
+++ b/tests/BuildSystem/Build/discovered-compiler-deps.llbuild
@@ -27,6 +27,15 @@
 # CHECK-AFTER-MOD: CC output-1
 # CHECK-AFTER-MOD: cat output-1 > output
 
+
+# Check that we can successfully build without a database.
+#
+# RUN: %{llbuild} buildsystem build --no-db --serial --chdir %t.build > %t.nodb.out
+# RUN: %{FileCheck} --check-prefix=CHECK-NO-DB --input-file=%t.nodb.out %s
+#
+# CHECK-NO-DB: CC output-1
+# CHECK-NO-DB: cat output-1 > output
+
 client:
   name: basic
 


### PR DESCRIPTION
 - I forgot that we actually used the StringMap entry identity elsewhere, and we
   had no unit test for this (fixed).

 - This would cause the engine to crash when discovered dependencies were used
   in an engine with no database attached.

 - <rdar://problem/39148068> Crash when database is missing