### PR TITLE
[BuildSystem] Support disabling SIGINT on cancellation.

### DIFF
--- a/docs/buildsystem.rst
+++ b/docs/buildsystem.rst
@@ -525,6 +525,14 @@ attributes on commands, and not at the tool level.
    * - always-out-of-date
      - A boolean value, indicating whether the commands should be treated as
        being always out-of-date. The default is false.
+
+   * - can-safely-interrupt
+     - A boolean flag controlling whether this command is allowed to be sent a
+       SIGINT to cancel it during build cancellation. If false, the command will
+       not be interrupted, and the build system will wait for the default
+       timeout (10 seconds) before sending a SIGKILL. This is intended to give
+       tools which can leave an inconsistent file system state an opportunity to
+       clean up, before exiting. The default is true.
           
    * - deps
      - The path to an output file of the command which will contain information

--- a/include/llbuild/BuildSystem/BuildExecutionQueue.h
+++ b/include/llbuild/BuildSystem/BuildExecutionQueue.h
@@ -115,6 +115,11 @@ public:
   /// overlayed on top base environment supplied when creating the queue. If
   /// false, only the supplied environment will be passed to the subprocess.
   ///
+  /// \param canSafelyInterrupt If true, whether it is safe to attempt to SIGINT
+  /// the process to cancel it. If false, the process won't be interrupted
+  /// during cancellation and will be given a chance to complete (if it fails to
+  /// complete it will ultimately be sent a SIGKILL).
+  ///
   /// \returns Result of the process execution.
   //
   // FIXME: This interface will need to get more complicated, and provide the
@@ -123,7 +128,8 @@ public:
   executeProcess(QueueJobContext* context,
                  ArrayRef<StringRef> commandLine,
                  ArrayRef<std::pair<StringRef, StringRef>> environment,
-                 bool inheritEnvironment = true) = 0;
+                 bool inheritEnvironment = true,
+                 bool canSafelyInterrupt = true) = 0;
 
   /// @}
 

--- a/lib/BuildSystem/BuildSystem.cpp
+++ b/lib/BuildSystem/BuildSystem.cpp
@@ -1631,6 +1631,9 @@ class ShellCommand : public ExternalCommand {
   /// Whether to inherit the base environment.
   bool inheritEnv = true;
 
+  /// Whether it is safe to interrupt (SIGINT) the tool during cancellation.
+  bool canSafelyInterrupt = true;
+
   /// The cached signature, once computed -- 0 is used as a sentinel value.
   std::atomic<uint64_t> cachedSignature{ 0 };
   
@@ -1654,6 +1657,7 @@ class ShellCommand : public ExternalCommand {
     }
     code = hash_combine(code, int(depsStyle));
     code = hash_combine(code, int(inheritEnv));
+    code = hash_combine(code, int(canSafelyInterrupt));
     signature = size_t(code);
     if (signature == 0) {
       signature = 1;
@@ -1832,6 +1836,13 @@ public:
         return false;
       }
       return true;
+    } else if (name == "can-safely-interrupt") {
+      if (value != "true" && value != "false") {
+        ctx.error("invalid value: '" + value + "' for attribute '" +
+                  name + "'");
+        return false;
+      }
+      canSafelyInterrupt = value == "true";
     } else if (name == "inherit-env") {
       if (value != "true" && value != "false") {
         ctx.error("invalid value: '" + value + "' for attribute '" +
@@ -1894,8 +1905,9 @@ public:
                                                QueueJobContext* context) override {
     // Execute the command.
     auto result = bsci.getExecutionQueue().executeProcess(
-        context, args,
-        env, /*inheritEnvironment=*/inheritEnv);
+        context, args, env,
+        /*inheritEnvironment=*/inheritEnv,
+        /*canSafelyInterrupt=*/canSafelyInterrupt);
 
     if (result != CommandResult::Succeeded) {
       // If the command failed, there is no need to gather dependencies.


### PR DESCRIPTION
 - This adds support for a new field in the manifest which allows a client to
   disable use of SIGINT when cancelling certain tasks.

 - Some tools which run during a build, like `codesign`, can leave stray
   temporary files which will inhibit correct operation on the next build. Since
   the build system doesn't know about these files, it is useful to try and
   avoid interrupting the tool in the hopes that it will finish before our
   SIGKILL timeout expires and we force the tool to cancel.

 - <rdar://problem/38773503> Support for not killing codesign with SIGINT (llbuild work)