### PR TITLE
llbuild error/warning delegate method should include the build key

### DIFF
--- a/lib/BuildSystem/ExternalCommand.cpp
+++ b/lib/BuildSystem/ExternalCommand.cpp
@@ -358,9 +358,8 @@ BuildValue ExternalCommand::execute(BuildSystemCommandInterface& bsci,
       inputsStream.flush();
 
       // FIXME: Design the logging and status output APIs.
-      bsci.getDelegate().error(
-          "", {}, (Twine("cannot build '") + outputs[0]->getName() +
-                   "' due to missing inputs: " + inputs));
+      bsci.getDelegate().commandHadError(this, "cannot build '" + outputs[0]->getName().str() +
+                                         "' due to missing inputs: " + inputs);
 
       // Report the command failure.
       bsci.getDelegate().hadCommandFailure();


### PR DESCRIPTION
This switches applicable calls to `error()` over to the `commandHadError()` delegate method in order to provide more contextual information about errors to clients.

rdar://problem/39126321