### PR TITLE
Fix static analyzer warnings about zero-allocations

### DIFF
--- a/include/llbuild/BuildSystem/BuildValue.h
+++ b/include/llbuild/BuildSystem/BuildValue.h
@@ -171,13 +171,15 @@ private:
     for (auto value: values) {
       size += value.size() + 1;
     }
-    char *p, *contents = p = new char[size];
+    // Make sure to allocate at least 1 byte.
+    char *p, *contents = p = new char[size + 1];
     for (auto value: values) {
       assert(value.find('\0') == StringRef::npos);
       memcpy(p, value.data(), value.size());
       p += value.size();
       *p++ = '\0';
     }
+    *p = '\0';
     stringValues.contents = contents;
     stringValues.size = size;
   }
@@ -188,13 +190,15 @@ private:
     for (auto value: values) {
       size += value.size() + 1;
     }
-    char *p, *contents = p = new char[size];
+    // Make sure to allocate at least 1 byte.
+    char *p, *contents = p = new char[size + 1];
     for (auto value: values) {
       assert(value.find('\0') == StringRef::npos);
       memcpy(p, value.data(), value.size());
       p += value.size();
       *p++ = '\0';
     }
+    *p = '\0';
     stringValues.contents = contents;
     stringValues.size = size;
   }


### PR DESCRIPTION
Although doing this is technically legal, as the C++ Standard states: "The effect of dereferencing a pointer returned as a request for zero size is undefined."

So it's not very useful. And the static analyzer doesn't like it anyways. So always allocate at least one byte and null-terminate the entire thing. I specifically didn't just set p/contents to nullptr if size == 0 because that would simply introduce a different analyzer warning.