### PR TITLE
Allow clients to provide fine-grained diagnostics

### DIFF
--- a/Xcode/Configs/Version.xcconfig
+++ b/Xcode/Configs/Version.xcconfig
@@ -13,7 +13,7 @@
 // Define the C API version
 //
 // See products/libllbuild/include/llbuild/llbuild.h for version history
-LLBUILD_C_API_VERSION = 5
+LLBUILD_C_API_VERSION = 6
 
 // We define both the version value and a named version.  The latter is useful
 // in Swift conditional compilation, where we don't currently have the ability

--- a/include/llbuild/BuildSystem/BuildSystem.h
+++ b/include/llbuild/BuildSystem/BuildSystem.h
@@ -38,6 +38,7 @@ class BuildExecutionQueue;
 class BuildKey;
 class BuildValue;
 class Command;
+class Node;
 class Tool;
 
 bool pathIsPrefixedByPath(std::string path, std::string prefixPath);
@@ -194,6 +195,16 @@ public:
   ///
   /// \param result - The result of command (e.g. success, failure, etc).
   virtual void commandFinished(Command*, CommandResult result) = 0;
+
+  /// Called by the build system to report a command could not build due to
+  /// missing inputs.
+  virtual void commandCannotBuildOutputDueToMissingInputs(Command*,
+               Node* output, SmallPtrSet<Node*, 1> inputs) = 0;
+
+  /// Called by the build system to report a node could not be built
+  /// because multiple commands are producing it.
+  virtual void cannotBuildNodeDueToMultipleProducers(Node* output,
+               std::vector<Command*>) = 0;
 };
 
 /// The BuildSystem class is used to perform builds using the native build

--- a/include/llbuild/BuildSystem/BuildSystemFrontend.h
+++ b/include/llbuild/BuildSystem/BuildSystemFrontend.h
@@ -15,6 +15,7 @@
 
 #include "llbuild/Basic/LLVM.h"
 #include "llbuild/BuildSystem/BuildSystem.h"
+#include "llbuild/BuildSystem/BuildNode.h"
 #include "llbuild/Core/BuildEngine.h"
 
 #include "llvm/ADT/ArrayRef.h"
@@ -226,6 +227,16 @@ public:
   ///
   /// \param result - The result of command (e.g. success, failure, etc).
   virtual void commandFinished(Command*, CommandResult result) override;
+
+  /// Called by the build system to report a command could not build due to
+  /// missing inputs.
+  virtual void commandCannotBuildOutputDueToMissingInputs(Command*,
+               Node* output, SmallPtrSet<Node*, 1> inputs) override;
+
+  /// Called by the build system to report a node could not be built
+  /// because multiple commands are producing it.
+  virtual void cannotBuildNodeDueToMultipleProducers(Node* output,
+               std::vector<Command*>) override;
 
   /// Called when a command's job has been started.
   ///

--- a/lib/BuildSystem/BuildSystem.cpp
+++ b/lib/BuildSystem/BuildSystem.cpp
@@ -664,12 +664,8 @@ class ProducedNodeTask : public Task {
     }
 
     // We currently do not support building nodes which have multiple producers.
-    auto producerA = node.getProducers()[0];
-    auto producerB = node.getProducers()[1];
-    getBuildSystem(engine).error(
-        "", "unable to build node: '" + node.getName() + "' (node is produced "
-        "by multiple commands; e.g., '" + producerA->getName() + "' and '" +
-        producerB->getName() + "')");
+    getBuildSystem(engine).getDelegate().
+        cannotBuildNodeDueToMultipleProducers(&node, node.getProducers());
     isInvalid = true;
   }
 

--- a/lib/BuildSystem/ExternalCommand.cpp
+++ b/lib/BuildSystem/ExternalCommand.cpp
@@ -347,19 +347,8 @@ BuildValue ExternalCommand::execute(BuildSystemCommandInterface& bsci,
   if (skipValue.hasValue()) {
     // If this command had a failed input, treat it as having failed.
     if (!missingInputNodes.empty()) {
-      std::string inputs;
-      llvm::raw_string_ostream inputsStream(inputs);
-      for (Node* missingInputNode : missingInputNodes) {
-        if (missingInputNode != *missingInputNodes.begin()) {
-          inputsStream << ", ";
-        }
-        inputsStream << "'" << missingInputNode->getName() << "'";
-      }
-      inputsStream.flush();
-
-      // FIXME: Design the logging and status output APIs.
-      bsci.getDelegate().commandHadError(this, "cannot build '" + outputs[0]->getName().str() +
-                                         "' due to missing inputs: " + inputs);
+      bsci.getDelegate().commandCannotBuildOutputDueToMissingInputs(this,
+                         outputs[0], missingInputNodes);
 
       // Report the command failure.
       bsci.getDelegate().hadCommandFailure();

--- a/products/libllbuild/include/llbuild/buildsystem.h
+++ b/products/libllbuild/include/llbuild/buildsystem.h
@@ -361,6 +361,20 @@ typedef struct llb_buildsystem_delegate_t_ {
                            llb_buildsystem_command_t* command,
                            const llb_data_t* data);
 
+  /// Called to report a command could not build due to missing inputs.
+  void (*command_cannot_build_output_due_to_missing_inputs)(void *context,
+                           llb_buildsystem_command_t* command,
+                           llb_build_key_t* output,
+                           llb_build_key_t* inputs,
+                           uint64_t input_count);
+
+  /// Called by the build system to report a node could not be built
+  /// because multiple commands are producing it.
+  void (*cannot_build_node_due_to_multiple_producers)(void *context,
+                           llb_build_key_t* output,
+                           llb_buildsystem_command_t** commands,
+                           uint64_t command_count);
+
   /// Called when a command's job has started executing an external process.
   ///
   /// The system guarantees that any commandProcessStarted() call will be paired

--- a/products/libllbuild/include/llbuild/llbuild.h
+++ b/products/libllbuild/include/llbuild/llbuild.h
@@ -38,6 +38,8 @@
 ///
 /// Version History:
 ///
+/// 6: Added delegate methods for specific diagnostics.
+///
 /// 5: Added `llb_buildsystem_command_extended_result_t`, changed command_process_finished signature.
 ///
 /// 4: Added llb_buildsystem_build_node.

--- a/products/libllbuild/include/llbuild/version.h
+++ b/products/libllbuild/include/llbuild/version.h
@@ -15,5 +15,5 @@
 //
 //===----------------------------------------------------------------------===//
 
-#define LLBUILD_C_API_VERSION 5
+#define LLBUILD_C_API_VERSION 6
 


### PR DESCRIPTION
This adds new delegate methods for "missing inputs" and "multiple producers for a single node" errors. These provide context to the client now instead of constructing strings.

See <rdar://problem/34333034>