### PR TITLE
Refactor Engine/DB Key/KeyID handling

### DIFF
--- a/include/llbuild/Basic/BinaryCoding.h
+++ b/include/llbuild/Basic/BinaryCoding.h
@@ -47,7 +47,7 @@ private:
   /// The encoded data.
   //
   // FIXME: Parameterize this size?
-  llvm::SmallVector<uint8_t, 256> data;
+  llvm::SmallVector<uint8_t, 256> encdata;
 
 public:
   /// Construct a new binary encoder.
@@ -55,7 +55,7 @@ public:
 
   /// Encode a value to the stream.
   void write(uint8_t value) {
-    data.push_back(value);
+    encdata.push_back(value);
   }
 
   /// Encode a value to the stream.
@@ -78,7 +78,7 @@ public:
 
   /// Encode a sequence of bytes to the stream.
   void writeBytes(StringRef bytes) {
-    data.insert(data.end(), bytes.begin(), bytes.end());
+    encdata.insert(encdata.end(), bytes.begin(), bytes.end());
   }
 
   /// Encode a value to the stream.
@@ -89,7 +89,17 @@ public:
 
   /// Get the encoded binary data.
   std::vector<uint8_t> contents() {
-    return std::vector<uint8_t>(data.begin(), data.end());
+    return std::vector<uint8_t>(encdata.begin(), encdata.end());
+  }
+
+  /// Get the encoded binary data (in place)
+  const uint8_t* data() const {
+    return encdata.data();
+  }
+
+  /// Get the size of the encoded binary data
+  const size_t size() const {
+    return encdata.size();
   }
 };
   

--- a/include/llbuild/Core/BuildDB.h
+++ b/include/llbuild/Core/BuildDB.h
@@ -28,22 +28,34 @@ namespace core {
 struct Result;
 class Rule;
 
-class BuildDB {
+/// Delegate interface for use with the build database
+class BuildDBDelegate {
 public:
-  virtual ~BuildDB();
+  virtual ~BuildDBDelegate();
 
   /// Get a unique ID for the given key.
   ///
   /// This method is thread safe.
   ///
   /// \param key [out] The key whose unique ID is being returned.
-  /// \param error_out [out] Error string if return value is 0.
-  virtual KeyID getKeyID(const KeyType& key, std::string *error_out) = 0;
+  virtual KeyID getKeyID(const KeyType& key) = 0;
 
   /// Get the key corresponding to a key ID.
   ///
   /// This method is thread safe, and cannot fail.
   virtual KeyType getKeyForID(KeyID key) = 0;
+};
+
+
+class BuildDB {
+public:
+  virtual ~BuildDB();
+
+  /// Set the delegate for key/id mapping
+  ///
+  /// \param delegate The delegate pointer (does not take ownership)
+  virtual void attachDelegate(BuildDBDelegate* delegate) = 0;
+
   
   /// Get the current build iteration.
   ///

--- a/lib/Core/BuildDB.cpp
+++ b/lib/Core/BuildDB.cpp
@@ -15,4 +15,6 @@
 using namespace llbuild;
 using namespace llbuild::core;
 
+BuildDBDelegate::~BuildDBDelegate() { }
+
 BuildDB::~BuildDB() { }

--- a/unittests/Core/BuildEngineTest.cpp
+++ b/unittests/Core/BuildEngineTest.cpp
@@ -431,16 +431,8 @@ TEST(BuildEngineTest, incrementalDependency) {
     
     std::unordered_map<KeyType, Result> ruleResults;
 
-    virtual KeyID getKeyID(const KeyType& key, std::string *error_out) override {
-      auto it = keyTable.insert(std::make_pair(key, false)).first;
-      return (KeyID)(uintptr_t)it->getKey().data();
-    }
+    virtual void attachDelegate(BuildDBDelegate* delegate) override { ; }
 
-    virtual KeyType getKeyForID(KeyID keyID) override {
-      return llvm::StringMapEntry<bool>::GetStringMapEntryFromKeyData(
-          (const char*)(uintptr_t)keyID).getKey();
-    }
-    
     virtual uint64_t getCurrentIteration(bool* success_out, std::string* error_out) override {
       return 0;
     }


### PR DESCRIPTION
- Separate database key IDs from engine keys to reduce database queries
while holding the engine key table lock
- Add support for directly accessing the byte array of BinaryEncoding