### PR TITLE
Install llbuild binary

### DIFF
--- a/products/llbuild/CMakeLists.txt
+++ b/products/llbuild/CMakeLists.txt
@@ -13,3 +13,7 @@ target_link_libraries(llbuild
 if(NOT ${CMAKE_SYSTEM_NAME} STREQUAL "Windows")
   target_link_libraries(llbuild curses)
 endif()
+
+install(TARGETS llbuild
+        COMPONENT llbuild
+        DESTINATION bin)


### PR DESCRIPTION
Otherwise needs to be copied manually into the install-dir of a
successful CMake build.