### PR TITLE
Adhere to CMake LIB_SUFFIX if set

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,7 +69,7 @@ set(LLBUILD_SRC_DIR ${CMAKE_CURRENT_SOURCE_DIR})
 set(LLBUILD_OBJ_DIR ${CMAKE_CURRENT_BINARY_DIR})
 
 # Shared output directories for executables and libraries.
-set(LLBUILD_LIBDIR_SUFFIX "" CACHE STRING "Set default library folder suffix. Ex: set it to 64 and it will use lib64")
+set(LLBUILD_LIBDIR_SUFFIX "${LIB_SUFFIX}" CACHE STRING "Set default library folder suffix. Ex: set it to 64 and it will use lib64")
 set(LLBUILD_EXECUTABLE_OUTPUT_INTDIR ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_CFG_INTDIR}/bin)
 set(LLBUILD_LIBRARY_OUTPUT_INTDIR ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_CFG_INTDIR}/lib${LLBUILD_LIBDIR_SUFFIX})
 

--- a/products/libllbuild/CMakeLists.txt
+++ b/products/libllbuild/CMakeLists.txt
@@ -48,8 +48,8 @@ install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/include/
   PATTERN "*.h")
 
 install(TARGETS libllbuild
-        DESTINATION lib
-        COMPONENT libllbuild)
+  DESTINATION lib${LLBUILD_LIBDIR_SUFFIX}
+  COMPONENT libllbuild)
 
 add_custom_target(install-libllbuild
                   DEPENDS libllbuild


### PR DESCRIPTION
CMake cache variables need to be changed manually in CMakeCache.txt,
which is annoying at best. Instead, default to LIB_SUFFIX, which is
commonly used in many other projects and in Linux packaging macros.