### PR TITLE
[BuildSystem] Enable fast cancellation.

### DIFF
--- a/lib/BuildSystem/BuildSystem.cpp
+++ b/lib/BuildSystem/BuildSystem.cpp
@@ -347,8 +347,13 @@ public:
 
     isCancelled_ = true;
     // Cancel jobs if we actually have a queue.
-    if (executionQueue.get() != nullptr)
+    if (executionQueue.get() != nullptr) {
+      // Ask the engine to cancel all pending work.
+      getBuildEngine().cancelBuild();
+
+      // Ask the execution queue to cancel currently running jobs.
       getExecutionQueue().cancelAllJobs();
+    }
   }
 
   /// Check if the build has been cancelled.


### PR DESCRIPTION
 - This uses the new engine support for immediately cancelling, rather than
   waiting for all tasks to be processed and marked as cancelled.