### PR TITLE
[BuildSystem] Disable defaulting to UTILITY QOS for tasks.

### DIFF
--- a/lib/BuildSystem/LaneBasedExecutionQueue.cpp
+++ b/lib/BuildSystem/LaneBasedExecutionQueue.cpp
@@ -351,11 +351,6 @@ public:
     flags |= POSIX_SPAWN_CLOEXEC_DEFAULT;
 #endif
 
-    // On Darwin, set the QOS of launched processes to UTILITY.
-#ifdef __APPLE__
-    posix_spawnattr_set_qos_class_np(&attributes, QOS_CLASS_UTILITY);
-#endif
-
     posix_spawnattr_setflags(&attributes, flags);
 
     // Setup the file actions.


### PR DESCRIPTION
 - This turns out to have a pretty substantial impact on some build scenarios,
   so I am going to reland this but exposed as an API so that clients can try to
   choose more intelligently what class is appropriate.

 - <rdar://problem/39825229> llbuild should use default QOS class for subprocess, by default