### PR TITLE
Support swift bindings on Linux

### DIFF
--- a/products/llbuildSwift/BuildSystemBindings.swift
+++ b/products/llbuildSwift/BuildSystemBindings.swift
@@ -685,8 +685,13 @@ public final class BuildSystem {
         info.pointee.inode = UInt64(s.st_ino)
         info.pointee.mode = UInt64(s.st_mode)
         info.pointee.size = UInt64(s.st_size)
-        info.pointee.mod_time.seconds = UInt64(s.st_mtimespec.tv_sec)
-        info.pointee.mod_time.nanoseconds = UInt64(s.st_mtimespec.tv_nsec)
+        #if os(Darwin)
+            info.pointee.mod_time.seconds = UInt64(s.st_mtimespec.tv_sec)
+            info.pointee.mod_time.nanoseconds = UInt64(s.st_mtimespec.tv_nsec)
+        #else
+            info.pointee.mod_time.seconds = UInt64(s.st_mtim.tv_sec)
+            info.pointee.mod_time.nanoseconds = UInt64(s.st_mtim.tv_nsec)
+        #endif
     }
 
     private func fsGetLinkInfo(_ path: String, _ info: UnsafeMutablePointer<llb_fs_file_info_t>) {

--- a/products/llbuildSwift/CMakeLists.txt
+++ b/products/llbuildSwift/CMakeLists.txt
@@ -17,6 +17,20 @@ list(APPEND additional_args -DLLBUILD_C_API_VERSION_${LLBUILD_C_API_VERSION} -I 
  
 if(APPLE)
   list(APPEND additional_args -target x86_64-apple-macosx10.10)
+else()
+  # On Linux, use Foundation and Dispatch libraries built and provided by swift's build-script.
+  if(FOUNDATION_BUILD_DIR)
+    list(APPEND additional_args
+      -L${FOUNDATION_BUILD_DIR}/Foundation
+      -I${FOUNDATION_BUILD_DIR}/Foundation
+      -I${FOUNDATION_BUILD_DIR}/Foundation/usr/lib/swift)
+  endif()
+  if(LIBDISPATCH_BUILD_DIR)
+    list(APPEND additional_args -L${LIBDISPATCH_BUILD_DIR}/src/.libs)
+  endif()
+  if(LIBDISPATCH_SOURCE_DIR)
+    list(APPEND additional_args -I${LIBDISPATCH_SOURCE_DIR})
+  endif()
 endif()
 
 # Add swift bindings target if swift compiler is present.


### PR DESCRIPTION
To support building the Swift bindings on Linux, `BuildSystemBindings.swift` had to updated to use `stat.st_mtim` on Linux as `stat.s.st_mtimespec` is not available, and CMake was modified to use custom foundation and dispatch libraries on Linux (for building through CI).