### PR TITLE
Revert "[BuildSystem] Enable fast cancellation."

### DIFF
--- a/lib/BuildSystem/BuildSystem.cpp
+++ b/lib/BuildSystem/BuildSystem.cpp
@@ -347,13 +347,8 @@ public:
 
     isCancelled_ = true;
     // Cancel jobs if we actually have a queue.
-    if (executionQueue.get() != nullptr) {
-      // Ask the engine to cancel all pending work.
-      getBuildEngine().cancelBuild();
-
-      // Ask the execution queue to cancel currently running jobs.
+    if (executionQueue.get() != nullptr)
       getExecutionQueue().cancelAllJobs();
-    }
   }
 
   /// Check if the build has been cancelled.


### PR DESCRIPTION
 - This turned out to not be completely safe yet... reveritng for now.

This reverts commit 265448e02eed33b9e92b006bc1d29800430de58d.