### PR TITLE
<rdar://35326105> Rethink the args-for-signature manifest property

### DIFF
--- a/docs/buildsystem.rst
+++ b/docs/buildsystem.rst
@@ -499,18 +499,11 @@ attributes on commands, and not at the tool level.
      - A string or string list indicating the command line to be executed. If a
        single string is provided, it will be executed using ``/bin/sh -c``.
 
-   * - args-for-signature
-     - A string or string list indicating the canonical form of the command line
-       to be executed. This should be the same as args, but without the
-       output-agnostic arguments that should be ignored for the purposes of
-       dependency tracking.
-
-       For example, args might be ``cp -v a b`` while args-for-signature might
-       be ``cp a b``, as the -v argument is irrelevant to dependency tracking
-       and its presence or absence should not trigger an execution of the
-       associated task on the next build.
-
-       The default is the same as `args`.
+   * - signature
+     - An arbitrary string used to compute the task signature. If defined, this
+       will be used instead of the built-in signature computation strategy,
+       which takes into account `args`, `env`, `deps`, `deps-style`,
+       `inherit-env` and `can-safely-interrupt`.
 
    * - env
      - A mapping of keys and values defining the environment to pass to the

--- a/tests/BuildSystem/Build/changed-output-agnostic-commands.llbuild
+++ b/tests/BuildSystem/Build/changed-output-agnostic-commands.llbuild
@@ -52,6 +52,7 @@ commands:
     outputs: ["<C.output-2.timestamp>"]
     description: C.output-2
     args: cp input output-2
+    signature: cp input output-2
 
 ##### VERSION-END-1 #####
 
@@ -81,6 +82,6 @@ commands:
     outputs: ["<C.output-2.timestamp>"]
     description: C.output-2
     args: cp -v input output-2
-    args-for-signature: cp input output-2
+    signature: cp input output-2
 
 ##### VERSION-END-2 #####


### PR DESCRIPTION
Instead of adding a domain-specific "args-for-signature" property, we
instead now have "additional-signature-data" which allows to add
arbitrary string data that will contribute to the task signature, and
ignore-args-in-signature, that will allow to remove existing args data
from the task signature. This is a more flexible design and also allows
us to ADD arbitrary data to the signature as well.