### PR TITLE
Add support for configuring the build system scheduler

### DIFF
--- a/include/llbuild/BuildSystem/BuildSystem.h
+++ b/include/llbuild/BuildSystem/BuildSystem.h
@@ -295,6 +295,22 @@ enum class QualityOfService {
 QualityOfService getDefaultQualityOfService();
 void setDefaultQualityOfService(QualityOfService level);
 
+// MARK: Execution Queue Scheduler Control
+
+enum class SchedulerAlgorithm {
+  /// Command name priority queue based scheduling [default]
+  commandNamePriority = 0,
+
+  /// First in, first out
+  fifo = 1
+};
+
+SchedulerAlgorithm getSchedulerAlgorithm();
+void setSchedulerAlgorithm(SchedulerAlgorithm algorithm);
+
+uint32_t getSchedulerLaneWidth();
+void setSchedulerLaneWidth(uint32_t width);
+
 }
 }
 

--- a/products/libllbuild/BuildSystem-C-API.cpp
+++ b/products/libllbuild/BuildSystem-C-API.cpp
@@ -811,7 +811,7 @@ char* llb_buildsystem_command_get_verbose_description(
   return strdup(result.c_str());
 }
 
-llb_quality_of_service_t llb_get_quality_of_servicellb_enable_tracing() {
+llb_quality_of_service_t llb_get_quality_of_service() {
   switch (llbuild::buildsystem::getDefaultQualityOfService()) {
   case llbuild::buildsystem::QualityOfService::normal:
     return llb_quality_of_service_default;
@@ -822,7 +822,7 @@ llb_quality_of_service_t llb_get_quality_of_servicellb_enable_tracing() {
   case llbuild::buildsystem::QualityOfService::background:
     return llb_quality_of_service_background;
   default:
-    assert(0 && "unknown command result");
+    assert(0 && "unknown quality service level");
     return llb_quality_of_service_default;
   }
 }
@@ -846,6 +846,40 @@ void llb_set_quality_of_service(llb_quality_of_service_t level) {
         llbuild::buildsystem::QualityOfService::background);
     break;
   default:
-    assert(0 && "unknown command result");
+    assert(0 && "unknown quality service level");
   }
+}
+
+
+llb_scheduler_algorithm_t llb_get_scheduler_algorithm() {
+  switch (llbuild::buildsystem::getSchedulerAlgorithm()) {
+    case llbuild::buildsystem::SchedulerAlgorithm::commandNamePriority:
+      return llb_scheduler_algorithm_command_name_priority;
+    case llbuild::buildsystem::SchedulerAlgorithm::fifo:
+      return llb_scheduler_algorithm_fifo;
+    default:
+      assert(0 && "unknown scheduler algorithm");
+      return llb_scheduler_algorithm_command_name_priority;
+  }
+}
+
+void llb_set_scheduler_algorithm(llb_scheduler_algorithm_t algorithm) {
+  switch (algorithm) {
+    case llb_scheduler_algorithm_command_name_priority:
+      llbuild::buildsystem::setSchedulerAlgorithm(
+          llbuild::buildsystem::SchedulerAlgorithm::commandNamePriority);
+    case llb_scheduler_algorithm_fifo:
+      llbuild::buildsystem::setSchedulerAlgorithm(
+          llbuild::buildsystem::SchedulerAlgorithm::fifo);
+    default:
+      assert(0 && "unknown scheduler algorithm");
+  }
+}
+
+uint32_t llb_get_scheduler_lane_width() {
+  return llbuild::buildsystem::getSchedulerLaneWidth();
+}
+
+void llb_set_scheduler_lane_width(uint32_t width) {
+  llbuild::buildsystem::setSchedulerLaneWidth(width);
 }

--- a/products/libllbuild/include/llbuild/buildsystem.h
+++ b/products/libllbuild/include/llbuild/buildsystem.h
@@ -674,6 +674,39 @@ llb_get_quality_of_service();
 LLBUILD_EXPORT void
 llb_set_quality_of_service(llb_quality_of_service_t level);
 
+// MARK: Execution Queue Scheduler Control
+
+/// Scheduler algorithms
+typedef enum {
+  /// Command name priority queue based scheduling [default]
+  llb_scheduler_algorithm_command_name_priority = 0,
+
+  /// First in, first out
+  llb_scheduler_algorithm_fifo = 1
+} llb_scheduler_algorithm_t;
+
+/// Get the global scheduler algorithm setting.
+LLBUILD_EXPORT llb_scheduler_algorithm_t
+llb_get_scheduler_algorithm();
+
+/// Set the global scheduler algorthm used for the execution queue. This will
+/// only take effect when constructing a new execution queue (i.e. for a build
+/// operation).
+LLBUILD_EXPORT void
+llb_set_scheduler_algorithm(llb_scheduler_algorithm_t algorithm);
+
+/// Get the global scheduler lane width setting.
+LLBUILD_EXPORT uint32_t
+llb_get_scheduler_lane_width();
+
+/// Set the global scheduler lane width. This will only take effect when
+/// constructing a new execution queue (i.e. for a build operation).
+///
+/// \param width The number of lanes to schedule. A value of 0 [default] will
+/// be automatically translated into the number of cores detected on the host.
+LLBUILD_EXPORT void
+llb_set_scheduler_lane_width(uint32_t width);
+
 /// @}
 
 #endif

--- a/tests/BuildSystem/Build/missing-inputs.llbuild
+++ b/tests/BuildSystem/Build/missing-inputs.llbuild
@@ -6,7 +6,7 @@
 # RUN: rm -rf %t.build
 # RUN: mkdir -p %t.build
 # RUN: cp %s %t.build/build.llbuild
-# RUN: %{llbuild} buildsystem build --serial --chdir %t.build &> %t.out || true
+# RUN: %{llbuild} buildsystem build --serial --scheduler fifo --chdir %t.build &> %t.out || true
 # RUN: cat %t.out
 # RUN: %{FileCheck} %s --input-file %t.out --check-prefix=CHECK-FAILURE
 #


### PR DESCRIPTION
- Add methods for changing the scheduler algorithm. Supports:
-- commandNamePriority: priority queue ordered by command name [default]
-- fifo: first in/first out queue - previous behavior
- Add methods for setting the lane width of the scheduler
- Add command line option for llbuild debug tool for selecting the scheduler