### PR TITLE
Added process identifier to command_extended_result

### DIFF
--- a/include/llbuild/Basic/CrossPlatformCompatibility.h
+++ b/include/llbuild/Basic/CrossPlatformCompatibility.h
@@ -1,0 +1,33 @@
+//===- PlatformUtility.h ----------------------------------------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2015 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// This file defines cross platform definitions.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef CrossPlatformCompatibility_h
+#define CrossPlatformCompatibility_h
+
+#ifdef _MSC_VER
+typedef int llbuild_pid_t;
+#else
+
+#if defined(__linux__) || defined(__GNU__)
+#include <termios.h>
+#else
+#include <sys/types.h>
+#endif
+
+typedef pid_t llbuild_pid_t;
+#endif
+
+#endif /* CrossPlatformCompatibility_h */

--- a/include/llbuild/BuildSystem/CommandResult.h
+++ b/include/llbuild/BuildSystem/CommandResult.h
@@ -13,6 +13,7 @@
 #ifndef LLBUILD_BUILDSYSTEM_COMMAND_RESULT_H
 #define LLBUILD_BUILDSYSTEM_COMMAND_RESULT_H
 
+#include "llbuild/Basic/CrossPlatformCompatibility.h"
 #include <inttypes.h>
 
 namespace llbuild {
@@ -31,23 +32,23 @@ struct CommandExtendedResult {
   CommandResult result; /// The final status of the command
   int exitStatus;       /// The exit code
 
-  uint64_t utime;       /// User time (in us)
-  uint64_t stime;       /// Sys time (in us)
-  uint64_t maxrss;      /// Max RSS (in bytes)
+  uint64_t utime;     /// User time (in us)
+  uint64_t stime;     /// Sys time (in us)
+  uint64_t maxrss;    /// Max RSS (in bytes)
+  llbuild_pid_t pid;  /// Process identifier (can be -1 for failure reasons)
 
-
-  CommandExtendedResult(CommandResult result, int exitStatus, uint64_t utime = 0,
+  CommandExtendedResult(CommandResult result, int exitStatus, llbuild_pid_t pid, uint64_t utime = 0,
                 uint64_t stime = 0, uint64_t maxrss = 0)
-    : result(result), exitStatus(exitStatus)
-    , utime(utime), stime(stime), maxrss(maxrss)
+    : result(result), exitStatus(exitStatus), utime(utime)
+    , stime(stime), maxrss(maxrss), pid(pid)
   {}
 
   static CommandExtendedResult makeFailed(int exitStatus = -1) {
-    return CommandExtendedResult(CommandResult::Failed, exitStatus);
+    return CommandExtendedResult(CommandResult::Failed, exitStatus, -1);
   }
 
   static CommandExtendedResult makeCancelled(int exitStatus = -1) {
-    return CommandExtendedResult(CommandResult::Cancelled, exitStatus);
+    return CommandExtendedResult(CommandResult::Cancelled, exitStatus, -1);
   }
 
 };

--- a/lib/BuildSystem/LaneBasedExecutionQueue.cpp
+++ b/lib/BuildSystem/LaneBasedExecutionQueue.cpp
@@ -14,6 +14,7 @@
 
 #include "POSIXEnvironment.h"
 
+#include "llbuild/Basic/CrossPlatformCompatibility.h"
 #include "llbuild/Basic/LLVM.h"
 #include "llbuild/Basic/PlatformUtility.h"
 #include "llbuild/Basic/Tracing.h"
@@ -133,7 +134,7 @@ class LaneBasedExecutionQueue : public BuildExecutionQueue {
   bool shutdown { false };
   
   /// The set of spawned processes to terminate if we get cancelled.
-  std::unordered_map<pid_t, ProcessInfo> spawnedProcesses;
+  std::unordered_map<llbuild_pid_t, ProcessInfo> spawnedProcesses;
   std::mutex spawnedProcessesMutex;
 
   /// Management of cancellation and SIGKILL escalation
@@ -460,7 +461,7 @@ public:
     }
       
     // Spawn the command.
-    pid_t pid = -1;
+    llbuild_pid_t pid = -1;
     bool wasCancelled;
     {
       // We need to hold the spawn processes lock when we spawn, to ensure that
@@ -568,7 +569,7 @@ public:
     // Notify of the process completion.
     bool cancelled = WIFSIGNALED(status) && (WTERMSIG(status) == SIGINT || WTERMSIG(status) == SIGKILL);
     CommandResult commandResult = cancelled ? CommandResult::Cancelled : (status == 0) ? CommandResult::Succeeded : CommandResult::Failed;
-    CommandExtendedResult extendedResult(commandResult, status, utime, stime,
+    CommandExtendedResult extendedResult(commandResult, status, pid, utime, stime,
                                          usage.ru_maxrss);
     getDelegate().commandProcessFinished(context.job.getForCommand(), handle,
                                          extendedResult);

--- a/llbuild.xcodeproj/project.pbxproj
+++ b/llbuild.xcodeproj/project.pbxproj
@@ -868,6 +868,7 @@
 		9DB0478B1DF9D3E2006CDF52 /* LaneBasedExecutionQueueTest.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = LaneBasedExecutionQueueTest.cpp; sourceTree = "<group>"; };
 		9DB047A81DF9D43D006CDF52 /* BuildSystemTests */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = BuildSystemTests; sourceTree = BUILT_PRODUCTS_DIR; };
 		9DDD8BDF1DDCAB9A00FB62D2 /* SQLiteBuildDBTest.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = SQLiteBuildDBTest.cpp; sourceTree = "<group>"; };
+		B563CEA620A6252500276198 /* CrossPlatformCompatibility.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CrossPlatformCompatibility.h; sourceTree = "<group>"; };
 		BC8DEEFF2030088600E9EF0C /* libllbuildSwift.dylib */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.dylib"; includeInIndex = 0; path = libllbuildSwift.dylib; sourceTree = BUILT_PRODUCTS_DIR; };
 		BC8DEF0520300AAF00E9EF0C /* CMakeLists.txt */ = {isa = PBXFileReference; fileEncoding = 4; indentWidth = 2; lastKnownFileType = text; path = CMakeLists.txt; sourceTree = "<group>"; tabWidth = 2; };
 		BC8DEF0620300AAF00E9EF0C /* BuildSystemBindings.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BuildSystemBindings.swift; sourceTree = "<group>"; };
@@ -1829,6 +1830,7 @@
 			children = (
 				E120B9EF1E4E65FC00B28469 /* BinaryCoding.h */,
 				E182BE111ABA2B8D001840AD /* Compiler.h */,
+				B563CEA620A6252500276198 /* CrossPlatformCompatibility.h */,
 				E11470901B75160400ED84CF /* FileInfo.h */,
 				E138129C1C536CFC000092C0 /* FileSystem.h */,
 				E147DEFD1BA81D0E0032D08E /* Hashing.h */,

--- a/products/libllbuild/BuildSystem-C-API.cpp
+++ b/products/libllbuild/BuildSystem-C-API.cpp
@@ -378,6 +378,7 @@ public:
       llb_buildsystem_command_extended_result_t result;
       result.result = get_command_result(commandResult.result);
       result.exit_status = commandResult.exitStatus;
+      result.pid = commandResult.pid;
       result.utime = commandResult.utime;
       result.stime = commandResult.stime;
       result.maxrss = commandResult.maxrss;

--- a/products/libllbuild/include/llbuild/buildsystem.h
+++ b/products/libllbuild/include/llbuild/buildsystem.h
@@ -24,6 +24,19 @@
 #include <stdbool.h>
 #include <stdint.h>
 
+#ifdef _MSC_VER
+typedef int llbuild_pid_t;
+#else
+
+#if defined(__linux__) || defined(__GNU__)
+#include <termios.h>
+#else
+#include <sys/types.h>
+#endif
+
+typedef pid_t llbuild_pid_t;
+#endif
+
 /// @name File System Behaviors
 /// @{
 
@@ -102,6 +115,7 @@ typedef struct llb_buildsystem_command_extended_result_t_ {
   uint64_t utime;                           /// User time (in us)
   uint64_t stime;                           /// Sys time (in us)
   uint64_t maxrss;                          /// Max RSS (in bytes)
+  llbuild_pid_t pid;                        /// The process identifier (-1 if process creation failed)
 } llb_buildsystem_command_extended_result_t;
 
 /// Status change event kinds.


### PR DESCRIPTION
The command extended result struct contains information about the spawned subprocesses. It should also contain the process identifier of the spawned child process.
I chose to take int32 as the type and use -1 for the case that the process creation has failed.

rdar://39798231