### PR TITLE
Add -Wimplicit-fallthrough to most C++ targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -194,6 +194,7 @@ else ()
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wnewline-eof -Wdeprecated-declarations")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Winvalid-offsetof")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wnon-virtual-dtor")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wimplicit-fallthrough")
 endif ()
 
 if (${CMAKE_SYSTEM_NAME} STREQUAL "Windows")

--- a/Xcode/Configs/Common.xcconfig
+++ b/Xcode/Configs/Common.xcconfig
@@ -25,6 +25,7 @@ USE_HEADERMAP = NO
 #include "Version.xcconfig"
 
 COMMON_PREPROCESSOR_DEFINITIONS = $(LLBUILD_VERSION_DEFINITIONS)
+OTHER_CPLUSPLUSFLAGS = $(OTHER_CFLAGS) -Wimplicit-fallthrough
 
 // MARK: Signing Support
 

--- a/lib/llvm/Support/Path.cpp
+++ b/lib/llvm/Support/Path.cpp
@@ -1019,6 +1019,7 @@ file_magic identify_magic(StringRef Magic) {
     case 0xc4: // ARMNT Windows
       if (Magic[1] == 0x01)
         return file_magic::coff_object;
+      [[clang::fallthrough]];
 
     case 0x90: // PA-RISC Windows
     case 0x68: // mc68K Windows

--- a/lib/llvm/Support/YAMLParser.cpp
+++ b/lib/llvm/Support/YAMLParser.cpp
@@ -1894,6 +1894,7 @@ void MappingNode::increment() {
       break;
     default:
       setError("Unexpected token. Expected Key or Block End", T);
+      [[clang::fallthrough]];
     case Token::TK_Error:
       IsAtEnd = true;
       CurrentEntry = nullptr;
@@ -1906,6 +1907,7 @@ void MappingNode::increment() {
       return increment();
     case Token::TK_FlowMappingEnd:
       getNext();
+      [[clang::fallthrough]];
     case Token::TK_Error:
       // Set this to end iterator.
       IsAtEnd = true;
@@ -1946,8 +1948,8 @@ void SequenceNode::increment() {
       CurrentEntry = nullptr;
       break;
     default:
-      setError( "Unexpected token. Expected Block Entry or Block End."
-              , T);
+      setError("Unexpected token. Expected Block Entry or Block End.", T);
+      [[clang::fallthrough]];
     case Token::TK_Error:
       IsAtEnd = true;
       CurrentEntry = nullptr;
@@ -1976,6 +1978,7 @@ void SequenceNode::increment() {
       return increment();
     case Token::TK_FlowSequenceEnd:
       getNext();
+      [[clang::fallthrough]];
     case Token::TK_Error:
       // Set this to end iterator.
       IsAtEnd = true;

--- a/lib/llvm/Support/raw_ostream.cpp
+++ b/lib/llvm/Support/raw_ostream.cpp
@@ -342,10 +342,10 @@ void raw_ostream::copy_to_buffer(const char *Ptr, size_t Size) {
   // Handle short strings specially, memcpy isn't very good at very short
   // strings.
   switch (Size) {
-  case 4: OutBufCur[3] = Ptr[3]; // FALL THROUGH
-  case 3: OutBufCur[2] = Ptr[2]; // FALL THROUGH
-  case 2: OutBufCur[1] = Ptr[1]; // FALL THROUGH
-  case 1: OutBufCur[0] = Ptr[0]; // FALL THROUGH
+  case 4: OutBufCur[3] = Ptr[3]; [[clang::fallthrough]];
+  case 3: OutBufCur[2] = Ptr[2]; [[clang::fallthrough]];
+  case 2: OutBufCur[1] = Ptr[1]; [[clang::fallthrough]];
+  case 1: OutBufCur[0] = Ptr[0]; [[clang::fallthrough]];
   case 0: break;
   default:
     memcpy(OutBufCur, Ptr, Size);


### PR DESCRIPTION
- Explicitly not used in llvmSupport, which has intentional use of
implicit fallthrough