### PR TITLE
[BuildSystem] Produced nodes should build when prior value was missing

### DIFF
--- a/lib/BuildSystem/BuildSystem.cpp
+++ b/lib/BuildSystem/BuildSystem.cpp
@@ -709,6 +709,12 @@ public:
     if (value.isFailedInput())
       return false;
 
+    // If the result was previously a missing input, it may have been because
+    // we did not previously know how to produce this node. We do now, so
+    // attempt to build it now.
+    if (value.isMissingInput())
+      return false;
+
     // The produced node result itself doesn't need any synchronization.
     return true;
   }


### PR DESCRIPTION
In situations where a node was previously a missing input, that fact may
be recorded in the build database. If subsequent builds add a rule that
may now produce that node, the system could get into a situation such
that 'missing input' errors are triggered even though we can
successfully build it. This changes produced nodes to cause their rule
to be built.

rdar://problem/40376404