### PR TITLE
[Tracing] Introduce os_signpost/os_log

### DIFF
--- a/include/llbuild/BuildSystem/BuildDescription.h
+++ b/include/llbuild/BuildSystem/BuildDescription.h
@@ -16,6 +16,7 @@
 #include "llbuild/Basic/Compiler.h"
 #include "llbuild/Basic/LLVM.h"
 
+#include "llvm/ADT/SmallString.h"
 #include "llvm/ADT/StringMap.h"
 #include "llvm/ADT/StringRef.h"
 
@@ -181,8 +182,22 @@ public:
   /// Get a short description of the command, for use in status reporting.
   virtual void getShortDescription(SmallVectorImpl<char> &result) = 0;
 
+  /// Get a short description of the command, for use in status reporting.
+  llvm::StringRef getShortDescription() {
+    llvm::SmallString<64> description;
+    getShortDescription(description);
+    return description.str();
+  }
+  
   /// Get a verbose description of the command, for use in status reporting.
   virtual void getVerboseDescription(SmallVectorImpl<char> &result) = 0;
+  
+  /// Get a verbose description of the command, for use in status reporting.
+  llvm::StringRef getVerboseDescription() {
+    llvm::SmallString<64> description;
+    getVerboseDescription(description);
+    return description.str();
+  }
   
   /// @}
 


### PR DESCRIPTION
This commit introduces the usage of os_signpost and os_log to implement tracing in llbuild. os_signpost is part of macOS 10.14 and gives the ability to add more and structured information to tracing intervals.
We adopt this in llbuild to get a better understanding about the build system if tracing as a feature has been enabled. If tracing is disabled this should result in no-ops to not influence the performance of the system.

rdar://problem/40310911