### PR TITLE
[BuildSystem] Add support for content exclusion patterns

### DIFF
--- a/include/llbuild/Basic/BinaryCoding.h
+++ b/include/llbuild/Basic/BinaryCoding.h
@@ -83,7 +83,7 @@ public:
 
   /// Encode a value to the stream.
   template<typename T>
-  void write(T value) {
+  void write(const T& value) {
     BinaryCodingTraits<T>::encode(value, *this);
   }
 
@@ -182,6 +182,13 @@ public:
   /// Finish decoding and clean up.
   void finish() {
     assert(isEmpty());
+  }
+};
+
+template<>
+struct BinaryCodingTraits<StringRef> {
+  static inline void encode(const StringRef& value, BinaryEncoder& coder) {
+    coder.writeBytes(value);
   }
 };
 

--- a/include/llbuild/Basic/StringList.h
+++ b/include/llbuild/Basic/StringList.h
@@ -1,0 +1,123 @@
+//===- StringList.h ---------------------------------------------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2018 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLBUILD_BASIC_STRINGLIST_H
+#define LLBUILD_BASIC_STRINGLIST_H
+
+#include "llbuild/Basic/BinaryCoding.h"
+
+#include <vector>
+
+namespace llbuild {
+namespace basic {
+
+/// A list of strings particularly suited for use in binary coding
+class StringList {
+private:
+  /// The values are packed as a sequence of C strings.
+  char* contents = nullptr;
+
+  /// The total length of the contents.
+  uint64_t size = 0;
+
+public:
+  StringList() {}
+  StringList(basic::BinaryDecoder& decoder) {
+    decoder.read(size);
+    StringRef contents;
+    decoder.readBytes(size, contents);
+    this->contents = new char[size];
+    memcpy(this->contents, contents.data(), contents.size());
+  }
+  ~StringList() {
+    if (contents != nullptr)
+      delete [] contents;
+  }
+
+  explicit StringList(StringRef value) {
+    size = value.size() + 1;
+    contents = new char[size];
+    assert(value.find('\0') == StringRef::npos);
+    memcpy(contents, value.data(), value.size());
+    contents[size - 1] = '\0';
+  }
+
+  template<class StringType>
+  explicit StringList(const ArrayRef<StringType> values) {
+    // Construct the concatenated data.
+    for (auto value: values) {
+      size += value.size() + 1;
+    }
+    // Make sure to allocate at least 1 byte.
+    char* p = nullptr;
+    contents = p = new char[size + 1];
+    for (auto value: values) {
+      assert(value.find('\0') == StringRef::npos);
+      memcpy(p, value.data(), value.size());
+      p += value.size();
+      *p++ = '\0';
+    }
+    *p = '\0';
+  }
+
+  // StringList can only be moved, not copied
+  StringList(StringList&& rhs) : size(rhs.size), contents(rhs.contents) {
+    rhs.size = 0;
+    rhs.contents = nullptr;
+  }
+
+  StringList& operator=(StringList&& rhs) {
+    if (this != &rhs) {
+      size = rhs.size;
+      if (contents != nullptr)
+        delete [] contents;
+      contents = rhs.contents;
+      rhs.contents = nullptr;
+    }
+    return *this;
+  }
+
+  std::vector<StringRef> getValues() const {
+    std::vector<StringRef> result;
+    for (uint64_t i = 0; i < size;) {
+      auto value = StringRef(&contents[i]);
+      assert(i + value.size() <= size);
+      result.push_back(value);
+      i += value.size() + 1;
+    }
+    return result;
+  }
+
+  bool isEmpty() const { return size == 0; }
+
+  void encode(BinaryEncoder& coder) const {
+    coder.write(size);
+    coder.writeBytes(StringRef(contents, size));
+  }
+};
+
+template<>
+struct BinaryCodingTraits<StringList> {
+  static inline void encode(const StringList& value, BinaryEncoder& coder) {
+    value.encode(coder);
+  }
+
+  static inline void decode(StringList& value, BinaryDecoder& coder) {
+    value = StringList(coder);
+  }
+};
+
+}
+}
+
+#endif /* StringList_h */
+

--- a/include/llbuild/BuildSystem/BuildNode.h
+++ b/include/llbuild/BuildSystem/BuildNode.h
@@ -16,6 +16,7 @@
 #include "BuildDescription.h"
 
 #include "llbuild/Basic/LLVM.h"
+#include "llbuild/Basic/StringList.h"
 #include "llbuild/BuildSystem/BuildFile.h"
 
 #include "llvm/ADT/StringRef.h"
@@ -57,6 +58,12 @@ class BuildNode : public Node {
   /// cannot be safely used to track *output* file state.
   bool mutated;
 
+  /// Exclusion filters for directory listings
+  ///
+  /// Items matching these filter strings are not considered as part of the
+  /// signature for directory and directory structure nodes.
+  basic::StringList directoryFilters;
+
 public:
   explicit BuildNode(StringRef name, bool isDirectory,
                      bool isDirectoryStructure, bool isVirtual,
@@ -79,6 +86,10 @@ public:
   bool isCommandTimestamp() const { return commandTimestamp; }
 
   bool isMutated() const { return mutated; }
+
+  const basic::StringList& directoryExclusionFilters() const {
+    return directoryFilters;
+  }
 
   virtual bool configureAttribute(const ConfigureContext& ctx, StringRef name,
                                   StringRef value) override;

--- a/include/llbuild/BuildSystem/BuildValue.h
+++ b/include/llbuild/BuildSystem/BuildValue.h
@@ -398,7 +398,7 @@ template<>
 struct basic::BinaryCodingTraits<buildsystem::BuildValue::Kind> {
   typedef buildsystem::BuildValue::Kind Kind;
   
-  static inline void encode(Kind& value, BinaryEncoder& coder) {
+  static inline void encode(const Kind& value, BinaryEncoder& coder) {
     uint8_t tmp = uint8_t(value);
     assert(value == Kind(tmp));
     coder.write(tmp);

--- a/lib/BuildSystem/BuildKey.cpp
+++ b/lib/BuildSystem/BuildKey.cpp
@@ -48,16 +48,11 @@ void BuildKey::dump(raw_ostream& os) const {
     os << ", dataSize='" << getCustomTaskData().size() << "'";
     break;
   }
-  case Kind::DirectoryContents: {
-    os << ", path='" << getDirectoryContentsPath() << "'";
-    break;
-  }
-  case Kind::DirectoryTreeSignature: {
-    os << ", path='" << getDirectoryTreeSignaturePath() << "'";
-    break;
-  }
+  case Kind::DirectoryContents:
+  case Kind::DirectoryTreeSignature:
   case Kind::DirectoryTreeStructureSignature: {
-    os << ", path='" << getDirectoryTreeStructureSignaturePath() << "'";
+    os << ", path='" << getDirectoryPath() << "'";
+    // FIXME: should probably dump filters here too
     break;
   }
   case Kind::Node: {

--- a/lib/BuildSystem/BuildNode.cpp
+++ b/lib/BuildSystem/BuildNode.cpp
@@ -86,6 +86,9 @@ bool BuildNode::configureAttribute(const ConfigureContext& ctx, StringRef name,
       return false;
     }
     return true;
+  } else if (name == "directory-filters") {
+    directoryFilters = basic::StringList(value);
+    return true;
   }
     
   // We don't support any other custom attributes.
@@ -95,6 +98,11 @@ bool BuildNode::configureAttribute(const ConfigureContext& ctx, StringRef name,
 
 bool BuildNode::configureAttribute(const ConfigureContext& ctx, StringRef name,
                                    ArrayRef<StringRef> values) {
+  if (name == "directory-filters") {
+    directoryFilters = basic::StringList(values);
+    return true;
+  }
+
   // We don't support any other custom attributes.
   ctx.error("unexpected attribute: '" + name + "'");
   return false;

--- a/lib/BuildSystem/BuildSystemFrontend.cpp
+++ b/lib/BuildSystem/BuildSystemFrontend.cpp
@@ -172,15 +172,15 @@ std::string BuildSystemInvocation::formatDetectedCycle(const std::vector<core::R
         os << "custom task '" << key.getCustomTaskName() << "'";
         break;
       case BuildKey::Kind::DirectoryContents:
-        os << "directory-contents '" << key.getDirectoryContentsPath() << "'";
+        os << "directory-contents '" << key.getDirectoryPath() << "'";
         break;
       case BuildKey::Kind::DirectoryTreeSignature:
         os << "directory-tree-signature '"
-        << key.getDirectoryTreeSignaturePath() << "'";
+        << key.getDirectoryPath() << "'";
         break;
       case BuildKey::Kind::DirectoryTreeStructureSignature:
         os << "directory-tree-structure-signature '"
-        << key.getDirectoryTreeStructureSignaturePath() << "'";
+        << key.getDirectoryPath() << "'";
         break;
       case BuildKey::Kind::Node:
         os << "node '" << key.getNodeName() << "'";

--- a/lib/Core/BuildEngineTrace.cpp
+++ b/lib/Core/BuildEngineTrace.cpp
@@ -100,7 +100,15 @@ const char* BuildEngineTrace::getRuleName(const Rule* rule) {
   auto result = ruleNames.emplace(rule, name);
 
   // Report the newly seen rule.
-  fprintf(fp, "{ \"new-rule\", \"%s\", \"%s\" },\n", name, rule->key.c_str());
+  // FIXME: This is currently encoding the key by merely stripping the
+  // non-printable characters. Should probably encode this into a real encoding.
+  std::string encoded = rule->key;
+  encoded.erase(
+                std::remove_if(encoded.begin(), encoded.end(),
+                               [](char c) -> bool {
+                                 return c < 32 || c > 127; }),
+                encoded.end());
+  fprintf(fp, "{ \"new-rule\", \"%s\", \"%s\" },\n", name, encoded.c_str());
 
   return result.first->second.c_str();
 }

--- a/llbuild.xcodeproj/project.pbxproj
+++ b/llbuild.xcodeproj/project.pbxproj
@@ -838,6 +838,7 @@
 		40377C7C2061D24200C0FD4D /* Package.swift */ = {isa = PBXFileReference; indentWidth = 4; lastKnownFileType = sourcecode.swift; path = Package.swift; sourceTree = "<group>"; tabWidth = 4; };
 		403B1A48205312000018A322 /* version.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = version.h; sourceTree = "<group>"; };
 		404C888E20924BF8000C201A /* DenseMapInfo.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DenseMapInfo.h; sourceTree = "<group>"; };
+		4062058120C7263C00B28281 /* StringList.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = StringList.h; sourceTree = "<group>"; };
 		40F4F4F220531D8A00170EE1 /* version.h.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = version.h.in; sourceTree = "<group>"; };
 		40F638CE2051EDC800A1CFBE /* count-lines-2 */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = "count-lines-2"; sourceTree = "<group>"; };
 		40F638CF2051EDC800A1CFBE /* count-lines-4 */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = "count-lines-4"; sourceTree = "<group>"; };
@@ -1842,6 +1843,7 @@
 				E147DEFC1BA81D0E0032D08E /* SerialQueue.h */,
 				E17440C11CE192E30070A30C /* ShellUtility.h */,
 				E181D1441F7D90AC0015286C /* Stat.h */,
+				4062058120C7263C00B28281 /* StringList.h */,
 				E181D1451F7D90AC0015286C /* Tracing.h */,
 				E1A2245119F997D40059043E /* Version.h */,
 			);

--- a/products/libllbuild/BuildSystem-C-API.cpp
+++ b/products/libllbuild/BuildSystem-C-API.cpp
@@ -411,17 +411,17 @@ public:
         break;
       case BuildKey::Kind::DirectoryContents:
         buildKey.kind = llb_build_key_kind_directory_contents;
-        buildKey.key = strdup(key.getDirectoryContentsPath().str().c_str());
+        buildKey.key = strdup(key.getDirectoryPath().str().c_str());
         break;
       case BuildKey::Kind::DirectoryTreeSignature:
         buildKey.kind = llb_build_key_kind_directory_tree_signature;
         buildKey.key = strdup(
-                              key.getDirectoryTreeSignaturePath().str().c_str());
+                              key.getDirectoryPath().str().c_str());
         break;
       case BuildKey::Kind::DirectoryTreeStructureSignature:
         buildKey.kind = llb_build_key_kind_directory_tree_structure_signature;
         buildKey.key = strdup(
-                              key.getDirectoryTreeStructureSignaturePath().str().c_str());
+                              key.getDirectoryPath().str().c_str());
         break;
       case BuildKey::Kind::Node:
         buildKey.kind = llb_build_key_kind_node;

--- a/tests/BuildSystem/Build/directory-contents-filtered-produced.llbuild
+++ b/tests/BuildSystem/Build/directory-contents-filtered-produced.llbuild
@@ -1,0 +1,60 @@
+# Check that directory contents are rebuilt *only* when appropriate.
+# Makes use of exclusion filters. This tests that this works properly when the
+# directory in question is produced by another rule in the manifest.
+#
+# RUN: rm -rf %t.build
+# RUN: mkdir -p %t.build
+# RUN: cp %s %t.build/build.llbuild
+# RUN: %{llbuild} buildsystem build --serial --trace %t.initial.trace --chdir %t.build
+# RUN: %{FileCheck} --check-prefix=CHECK-INITIAL --input-file=%t.initial.trace %s
+#
+# CHECK-INITIAL: { "new-rule", "[[RULE_NAME:R[0-9]+]]", "Ddirexcludedfile" },
+# CHECK-INITIAL: { "rule-needs-to-run", "[[RULE_NAME]]", "never-built" },
+
+
+# A null rebuild shouldn't rebuild the directory.
+#
+# RUN: %{llbuild} buildsystem build --serial --trace %t.rebuild.trace --chdir %t.build
+# RUN: %{FileCheck} --check-prefix=CHECK-REBUILD --input-file=%t.rebuild.trace %s
+#
+# CHECK-REBUILD: { "new-rule", "[[RULE_NAME:R[0-9]+]]", "Ddirexcludedfile" },
+# CHECK-REBUILD: { "rule-does-not-need-to-run", "[[RULE_NAME]]" },
+
+# A rebuild shouldn't rebuild the directory for excluded files.
+#
+# RUN: touch %t.build/dir/excludedfile
+# RUN: %{llbuild} buildsystem build --serial --trace %t.rebuild.trace --chdir %t.build
+# RUN: %{FileCheck} --check-prefix=CHECK-REBUILD2 --input-file=%t.rebuild.trace %s
+#
+# CHECK-REBUILD2: { "new-rule", "[[RULE_NAME:R[0-9]+]]", "Ddirexcludedfile" },
+# CHECK-REBUILD2: { "rule-does-not-need-to-run", "[[RULE_NAME]]" },
+
+
+# A rebuild after adding a new file should rebuild the directory.
+#
+# RUN: touch %t.build/dir/file
+# RUN: %{llbuild} buildsystem build --serial --trace %t.modified.trace --chdir %t.build
+# RUN: %{FileCheck} --check-prefix=CHECK-MODIFIED --input-file=%t.modified.trace %s
+#
+# CHECK-MODIFIED: { "new-rule", "[[RULE_NAME:R[0-9]+]]", "Ddirexcludedfile" },
+# CHECK-MODIFIED: { "rule-needs-to-run", "[[RULE_NAME]]", "invalid-value" },
+
+client:
+  name: basic
+
+targets:
+  "": ["<all>"]
+
+nodes:
+  "dir/":
+    directory-filters: ["excludedfile"]
+
+commands:
+  C.all:
+    tool: shell
+    inputs: ["dir/"]
+    args: stat dir
+    outputs: ["<all>"]
+  C.mkdir:
+    tool: mkdir
+    outputs: ["dir"]

--- a/tests/BuildSystem/Build/directory-contents-filtered.llbuild
+++ b/tests/BuildSystem/Build/directory-contents-filtered.llbuild
@@ -1,0 +1,57 @@
+# Check that directory contents are rebuilt *only* when appropriate.
+# Makes use of exclusion filters
+#
+# RUN: rm -rf %t.build
+# RUN: mkdir -p %t.build
+# RUN: cp %s %t.build/build.llbuild
+# RUN: mkdir -p %t.build/dir
+# RUN: %{llbuild} buildsystem build --serial --trace %t.initial.trace --chdir %t.build
+# RUN: %{FileCheck} --check-prefix=CHECK-INITIAL --input-file=%t.initial.trace %s
+#
+# CHECK-INITIAL: { "new-rule", "[[RULE_NAME:R[0-9]+]]", "Ddirexcludedfile" },
+# CHECK-INITIAL: { "rule-needs-to-run", "[[RULE_NAME]]", "never-built" },
+
+
+# A null rebuild shouldn't rebuild the directory.
+#
+# RUN: %{llbuild} buildsystem build --serial --trace %t.rebuild.trace --chdir %t.build
+# RUN: %{FileCheck} --check-prefix=CHECK-REBUILD --input-file=%t.rebuild.trace %s
+#
+# CHECK-REBUILD: { "new-rule", "[[RULE_NAME:R[0-9]+]]", "Ddirexcludedfile" },
+# CHECK-REBUILD: { "rule-does-not-need-to-run", "[[RULE_NAME]]" },
+
+# A rebuild shouldn't rebuild the directory for excluded files.
+#
+# RUN: touch %t.build/dir/excludedfile
+# RUN: %{llbuild} buildsystem build --serial --trace %t.rebuild.trace --chdir %t.build
+# RUN: %{FileCheck} --check-prefix=CHECK-REBUILD2 --input-file=%t.rebuild.trace %s
+#
+# CHECK-REBUILD2: { "new-rule", "[[RULE_NAME:R[0-9]+]]", "Ddirexcludedfile" },
+# CHECK-REBUILD2: { "rule-does-not-need-to-run", "[[RULE_NAME]]" },
+
+
+# A rebuild after adding a new file should rebuild the directory.
+#
+# RUN: touch %t.build/dir/file
+# RUN: %{llbuild} buildsystem build --serial --trace %t.modified.trace --chdir %t.build
+# RUN: %{FileCheck} --check-prefix=CHECK-MODIFIED --input-file=%t.modified.trace %s
+#
+# CHECK-MODIFIED: { "new-rule", "[[RULE_NAME:R[0-9]+]]", "Ddirexcludedfile" },
+# CHECK-MODIFIED: { "rule-needs-to-run", "[[RULE_NAME]]", "invalid-value" },
+
+client:
+  name: basic
+
+targets:
+  "": ["<all>"]
+
+nodes:
+  "dir/":
+    directory-filters: ["excludedfile"]
+
+commands:
+  C.all:
+    tool: phony
+    inputs: ["dir/"]
+    outputs: ["<all>"]
+

--- a/unittests/BuildSystem/BuildSystemTaskTests.cpp
+++ b/unittests/BuildSystem/BuildSystemTaskTests.cpp
@@ -197,7 +197,8 @@ TEST(BuildSystemTaskTests, directoryContents) {
 
   // Build a specific key.
   {
-    auto result = system.build(BuildKey::makeDirectoryContents(tempDir.str()));
+    auto result = system.build(BuildKey::makeDirectoryContents(tempDir.str(),
+                                                               StringList()));
     ASSERT_TRUE(result.hasValue());
     ASSERT_TRUE(result->isDirectoryContents());
     ASSERT_EQ(result->getDirectoryContents(), std::vector<StringRef>({
@@ -207,7 +208,8 @@ TEST(BuildSystemTaskTests, directoryContents) {
   // Check that a missing directory behaves properly.
   {
     auto result = system.build(BuildKey::makeDirectoryContents(
-                                   tempDir.str() + "/missing-subpath"));
+                                   tempDir.str() + "/missing-subpath",
+                                                               StringList()));
     ASSERT_TRUE(result.hasValue());
     ASSERT_TRUE(result->isMissingInput());
   }
@@ -308,7 +310,8 @@ TEST(BuildSystemTaskTests, directorySignature) {
   }
   
   // Create the build system.
-  auto keyToBuild = BuildKey::makeDirectoryTreeSignature(tempDir.str());
+  auto keyToBuild = BuildKey::makeDirectoryTreeSignature(tempDir.str(),
+                                                         StringList());
   auto description = llvm::make_unique<BuildDescription>();
   MockBuildSystemDelegate delegate;
   BuildSystem system(delegate, createLocalFileSystem());


### PR DESCRIPTION
- Moves BuildValue string list into a reusable data structure 
- Adds support for 'content-exclusion-patterns' in the manifest for directory nodes
- Filters exclude items from consideration when calculating directory signatures
- Implements generic binary coding support for BuildKeys