### PR TITLE
[Core] Fix MakeFileDepsParser handling of filenames with ':'

### DIFF
--- a/lib/BuildSystem/BuildSystem.cpp
+++ b/lib/BuildSystem/BuildSystem.cpp
@@ -48,6 +48,7 @@
 #include <memory>
 #include <mutex>
 #include <set>
+#include <sstream>
 
 #include <fnmatch.h>
 #include <unistd.h>
@@ -1827,9 +1828,11 @@ class ShellCommand : public ExternalCommand {
           : bsci(bsci), task(task), command(command), depsPath(depsPath) {}
 
       virtual void error(const char* message, uint64_t position) override {
-        getBuildSystem(bsci.getBuildEngine()).getDelegate().commandHadError(command,
-                        "error reading dependency file '" + depsPath.str() +
-                        "': " + std::string(message));
+        std::stringstream msg;
+        msg << "error reading dependency file '" << depsPath.str() << "': "
+            << message << " at position " << position;
+        getBuildSystem(bsci.getBuildEngine()).getDelegate().commandHadError(
+            command, msg.str());
         ++numErrors;
       }
 

--- a/unittests/Core/MakefileDepsParserTest.cpp
+++ b/unittests/Core/MakefileDepsParserTest.cpp
@@ -144,6 +144,14 @@ TEST(MakefileDepsParserTest, basic) {
   EXPECT_EQ(1U, actions.records.size());
   EXPECT_EQ(RuleRecord("/=> ;|%.o", { "/=> ;|%.swift" }), actions.records[0]);
   
+  // Check that we can parse filenames with colons.
+  actions.errors.clear();
+  actions.records.clear();
+  input = "a: b:c";
+  MakefileDepsParser(input.data(), input.size(), actions).parse();
+  EXPECT_EQ(0U, actions.errors.size());
+  EXPECT_EQ(1U, actions.records.size());
+  EXPECT_EQ(RuleRecord("a", { "b:c" }), actions.records[0]);
 }
 
 }


### PR DESCRIPTION
Filenames may contain ':'. The deps file 'format' does minimal escaping,
thus may contain such characters unescaped past the rule name. Fix this
by continuing lexing for colons in post rule paths.

rdar://problem/40827063