### PR TITLE
[BuildSystem] Don't pass -num-threads for non-wmo invocations

### DIFF
--- a/lib/BuildSystem/BuildSystem.cpp
+++ b/lib/BuildSystem/BuildSystem.cpp
@@ -2373,6 +2373,8 @@ class SwiftCompilerShellCommand : public ExternalCommand {
   bool enableWholeModuleOptimization = false;
 
   /// Enables multi-threading with the thread count if > 0.
+  ///
+  /// Note: This is only used when whole module optimization is enabled.
   std::string numThreads = "0";
 
   virtual CommandSignature getSignature() override {
@@ -2413,9 +2415,9 @@ class SwiftCompilerShellCommand : public ExternalCommand {
     }
     if (enableWholeModuleOptimization) {
       result.push_back("-whole-module-optimization");
+      result.push_back("-num-threads");
+      result.push_back(numThreads);
     }
-    result.push_back("-num-threads");
-    result.push_back(numThreads);
     result.push_back("-c");
     for (const auto& source: sourcesList) {
       result.push_back(source);

--- a/tests/SwiftBuildTool/swift-compiler.swift-build
+++ b/tests/SwiftBuildTool/swift-compiler.swift-build
@@ -10,7 +10,7 @@
 #
 # CHECK: Compile Swift Module 'Foo'
 # FIXME: This should quote output paths.
-# CHECK-VERBOSE: swiftc -module-name Foo -incremental -emit-dependencies -emit-module -emit-module-path Foo.swiftmodule -output-file-map temps/output-file-map.json -parse-as-library -num-threads 0 -c "s 1.swift" "s 2.swift" -I "import A" -I "import B" -Onone -I "path with spaces"
+# CHECK-VERBOSE: swiftc -module-name Foo -incremental -emit-dependencies -emit-module -emit-module-path Foo.swiftmodule -output-file-map temps/output-file-map.json -parse-as-library -c "s 1.swift" "s 2.swift" -I "import A" -I "import B" -Onone -I "path with spaces"
 
 # Sanity check the output file map.
 #


### PR DESCRIPTION
<rdar://problem/40178238> llbuild should not pass -num-threads to swiftc for non-wmo invocations