### PR TITLE
Fix use-after-free in some helper methods

### DIFF
--- a/include/llbuild/BuildSystem/BuildDescription.h
+++ b/include/llbuild/BuildSystem/BuildDescription.h
@@ -181,23 +181,9 @@ public:
   
   /// Get a short description of the command, for use in status reporting.
   virtual void getShortDescription(SmallVectorImpl<char> &result) = 0;
-
-  /// Get a short description of the command, for use in status reporting.
-  llvm::StringRef getShortDescription() {
-    llvm::SmallString<64> description;
-    getShortDescription(description);
-    return description.str();
-  }
   
   /// Get a verbose description of the command, for use in status reporting.
   virtual void getVerboseDescription(SmallVectorImpl<char> &result) = 0;
-  
-  /// Get a verbose description of the command, for use in status reporting.
-  llvm::StringRef getVerboseDescription() {
-    llvm::SmallString<64> description;
-    getVerboseDescription(description);
-    return description.str();
-  }
   
   /// @}
 

--- a/lib/BuildSystem/LaneBasedExecutionQueue.cpp
+++ b/lib/BuildSystem/LaneBasedExecutionQueue.cpp
@@ -194,7 +194,10 @@ class LaneBasedExecutionQueue : public BuildExecutionQueue {
       LaneBasedExecutionQueueJobContext context{ laneNumber, job };
       {
         TracingExecutionQueueDepth(readyJobsCount);
-        TracingExecutionQueueJob t(context.laneNumber, job.getForCommand()->getShortDescription());
+
+        llvm::SmallString<64> description;
+        job.getForCommand()->getShortDescription(description);
+        TracingExecutionQueueJob t(context.laneNumber, description.str());
         
         getDelegate().commandJobStarted(job.getForCommand());
         job.execute(reinterpret_cast<QueueJobContext*>(&context));
@@ -309,7 +312,10 @@ public:
                  bool canSafelyInterrupt) override {
     LaneBasedExecutionQueueJobContext& context =
       *reinterpret_cast<LaneBasedExecutionQueueJobContext*>(opaqueContext);
-    TracingExecutionQueueSubprocess subprocessInterval(context.laneNumber, context.job.getForCommand()->getShortDescription());
+
+    llvm::SmallString<64> description;
+    context.job.getForCommand()->getShortDescription(description);
+    TracingExecutionQueueSubprocess subprocessInterval(context.laneNumber, description.str());
 
     {
       std::unique_lock<std::mutex> lock(readyJobsMutex);


### PR DESCRIPTION
llvm::SmallString's str() method returns an llvm::StringRef, which does
not copy the string data. When getShortDescription/getVerboseDescription
return, the SmallString is deallocated and the underlying memory freed,
causing the returned StringRef to be pointing to deallocated memory.

Remove these functions and require the caller to provide their own
string data instance, which the Command can then populate with data.