### PR TITLE
[BuildSystem] Fix tests and comments due to #328 and #329

### DIFF
--- a/tests/BuildSystem/Build/directory-contents-filtered.llbuild
+++ b/tests/BuildSystem/Build/directory-contents-filtered.llbuild
@@ -1,9 +1,6 @@
 # Check that directory contents are rebuilt *only* when appropriate.
 # Makes use of exclusion filters
 #
-# Failure tracked by rdar://problem/41182818
-# XFAIL: *
-#
 # RUN: rm -rf %t.build
 # RUN: mkdir -p %t.build
 # RUN: cp %s %t.build/build.llbuild
@@ -23,14 +20,15 @@
 # CHECK-REBUILD: { "new-rule", "[[RULE_NAME:R[0-9]+]]", "Ddirexcludedfile" },
 # CHECK-REBUILD: { "rule-does-not-need-to-run", "[[RULE_NAME]]" },
 
-# A rebuild shouldn't rebuild the directory for excluded files.
+# A rebuild unfortunately rebuilds with even with excluded files.
+# rdar://41142590
 #
 # RUN: touch %t.build/dir/excludedfile
 # RUN: %{llbuild} buildsystem build --serial --trace %t.rebuild.trace --chdir %t.build
 # RUN: %{FileCheck} --check-prefix=CHECK-REBUILD2 --input-file=%t.rebuild.trace %s
 #
 # CHECK-REBUILD2: { "new-rule", "[[RULE_NAME:R[0-9]+]]", "Ddirexcludedfile" },
-# CHECK-REBUILD2: { "rule-does-not-need-to-run", "[[RULE_NAME]]" },
+# CHECK-REBUILD2: { "rule-needs-to-run", "[[RULE_NAME]]", "input-rebuilt", "[[RULE_NAME2:R[0-9]+]]" },
 
 
 # A rebuild after adding a new file should rebuild the directory.

--- a/tests/BuildSystem/Build/directory-contents-ordering.llbuild
+++ b/tests/BuildSystem/Build/directory-contents-ordering.llbuild
@@ -1,0 +1,76 @@
+# Check that directory contents that are actually files correctly trigger the
+# production of the file.
+# rdar://problem/41142590
+#
+#
+# First pass we set up the database such that a directory contents node points
+# to a 'missing' file/directory.
+#
+# RUN: rm -rf %t.build
+# RUN: mkdir -p %t.build
+# RUN: grep -A1000 "VERSION-BEGIN-[1]" %s | grep -B10000 "VERSION-END-1" | grep -ve '^--$' > %t.build/build-1.llbuild
+# RUN: %{llbuild} buildsystem build --serial --trace %t.initial.trace --chdir %t.build -f build-1.llbuild
+# RUN: %{FileCheck} --check-prefix=CHECK-INITIAL --input-file=%t.initial.trace %s
+#
+# CHECK-INITIAL: { "new-rule", "[[RULE_NAME:R[0-9]+]]", "Dfile" },
+# CHECK-INITIAL: { "rule-needs-to-run", "[[RULE_NAME]]", "never-built" },
+
+
+# Second pass we add a rule that may now produce that file. As exposed in
+# rdar://problem/41142590, clients rely on the explicit dependency on the basal
+# node created by 'taskNeedsInput' for this to trigger the production of 'file'
+# before execution of the directory contents dependency.
+#
+# RUN: grep -A1000 "VERSION-BEGIN-[2]" %s | grep -B10000 "VERSION-END-2" | grep -ve '^--$' > %t.build/build-2.llbuild
+# RUN: %{llbuild} buildsystem build --serial --trace %t.rebuild.trace --chdir %t.build -f build-2.llbuild
+# RUN: %{FileCheck} --check-prefix=CHECK-REBUILD --input-file=%t.rebuild.trace %s
+#
+# CHECK-REBUILD: { "new-rule", "[[RULE_NAME:R[0-9]+]]", "Dfile" },
+# CHECK-REBUILD: { "rule-needs-to-run", "[[RULE_NAME]]", "input-rebuilt", "[[RULE_NAME2:R[0-9]+]]" },
+
+##### VERSION-BEGIN-1 #####
+
+client:
+  name: basic
+
+targets:
+  "": ["<all>"]
+
+commands:
+  a:
+    tool: phony
+    inputs: ["file/"]
+    outputs: ["<afile>"]
+  build:
+    tool: phony
+    inputs: ["<afile>"]
+    outputs: ["<all>"]
+
+##### VERSION-END-1 #####
+
+##### VERSION-BEGIN-2 #####
+
+client:
+  name: basic
+
+targets:
+  "": ["<all>"]
+
+commands:
+  a:
+    tool: shell
+    args: stat file
+    inputs: ["file/"]
+    outputs: ["<afile>"]
+
+  z:
+    tool: shell
+    args: touch file
+    outputs: ["file"]
+
+  build:
+    tool: phony
+    inputs: ["<afile>"]
+    outputs: ["<all>"]
+
+##### VERSION-END-2 #####

--- a/tests/BuildSystem/Build/directory-contents.llbuild
+++ b/tests/BuildSystem/Build/directory-contents.llbuild
@@ -1,8 +1,5 @@
 # Check that directory contents are rebuilt *only* when appropriate.
 #
-# Failure tracked by rdar://problem/41182818
-# XFAIL: *
-#
 # RUN: rm -rf %t.build
 # RUN: mkdir -p %t.build
 # RUN: cp %s %t.build/build.llbuild
@@ -22,14 +19,15 @@
 # CHECK-REBUILD: { "new-rule", "[[RULE_NAME:R[0-9]+]]", "Ddir" },
 # CHECK-REBUILD: { "rule-does-not-need-to-run", "[[RULE_NAME]]" },
 
-# A null rebuild where the directory itself has been touch shouldn't rebuild.
+# A null rebuild where the directory itself has been touched unfortunately
+# rebuilds (due to rdar://41142590).
 #
 # RUN: touch %t.build/dir
 # RUN: %{llbuild} buildsystem build --serial --trace %t.touch.trace --chdir %t.build
 # RUN: %{FileCheck} --check-prefix=CHECK-TOUCH --input-file=%t.touch.trace %s
 #
-# CHECK-TOUCH: { "new-rule", "[[RULE_NAME:R[0-9]+]]", "Ddir" },
-# CHECK-TOUCH: { "rule-does-not-need-to-run", "[[RULE_NAME]]" },
+# CHECK-TOUCH: { "new-rule", "[[RULE_NAME:R[0-9]+]]", "Ndir" },
+# CHECK-TOUCH: { "rule-needs-to-run", "[[RULE_NAME]]", "invalid-value" },
 
 
 # A rebuild after adding a new file should rebuild the directory.


### PR DESCRIPTION
Reverting directory contents behavior broke tests expecting the new
behavior. This change adds a test that directly exposes the bug that was
fixed in #328, and fixes the tests that were XFAIL'd in #329. It also
adds commentary explaining the problem in BuildSystem.cpp, as the
full solution is non-trivial.

rdar://problem/41182818