### PR TITLE
Alter directory-contents test to be more reliable in CI

### DIFF
--- a/tests/BuildSystem/Build/directory-contents.llbuild
+++ b/tests/BuildSystem/Build/directory-contents.llbuild
@@ -39,9 +39,9 @@
 # CHECK-MODIFIED: { "new-rule", "[[RULE_NAME:R[0-9]+]]", "Ddir" },
 # CHECK-MODIFIED: { "rule-needs-to-run", "[[RULE_NAME]]", "invalid-value" },
 
-# A rebuild after touching a file should rebuild the directory.
+# A rebuild after modifying a file should rebuild the directory.
 #
-# RUN: touch %t.build/dir/file
+# RUN: echo diff > %t.build/dir/file
 # RUN: %{llbuild} buildsystem build --serial --trace %t.modified2.trace --chdir %t.build
 # RUN: %{FileCheck} --check-prefix=CHECK-MODIFIED2 --input-file=%t.modified2.trace %s
 #


### PR DESCRIPTION
The second modification test failed in internal CI. The likely
explanation I can think of is that the system must still be HFS, thus
two close together touch commands did not alter the stat info. Change to
a file content change instead.

rdar://problem/41352819