### PR TITLE
Fix initializer order warning

### DIFF
--- a/Xcode/Configs/Common.xcconfig
+++ b/Xcode/Configs/Common.xcconfig
@@ -35,7 +35,7 @@ CLANG_CXX_LIBRARY = libc++
 #include "Version.xcconfig"
 
 COMMON_PREPROCESSOR_DEFINITIONS = $(LLBUILD_VERSION_DEFINITIONS)
-OTHER_CPLUSPLUSFLAGS = $(OTHER_CFLAGS) -Wimplicit-fallthrough
+OTHER_CPLUSPLUSFLAGS = $(OTHER_CFLAGS) -Wimplicit-fallthrough -Wall
 
 // MARK: Signing Support
 

--- a/include/llbuild/Basic/StringList.h
+++ b/include/llbuild/Basic/StringList.h
@@ -70,7 +70,7 @@ public:
   }
 
   // StringList can only be moved, not copied
-  StringList(StringList&& rhs) : size(rhs.size), contents(rhs.contents) {
+  StringList(StringList&& rhs) : contents(rhs.contents), size(rhs.size) {
     rhs.size = 0;
     rhs.contents = nullptr;
   }


### PR DESCRIPTION
- Also, enable -Wall in Xcode so that this warning is triggered there