### PR TITLE
Don’t install headers for llbuildSwift

### DIFF
--- a/cmake/modules/Utility.cmake
+++ b/cmake/modules/Utility.cmake
@@ -181,7 +181,12 @@ function(add_swift_module target name deps sources additional_args)
   )
   
   # Link and create dynamic framework.
-  set(DYLIB_OUTPUT ${LLBUILD_LIBRARY_OUTPUT_INTDIR}/${target}.dylib)
+  if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+    set(DYLIB_EXT dylib)
+  else()
+    set(DYLIB_EXT so)
+  endif()
+  set(DYLIB_OUTPUT ${LLBUILD_LIBRARY_OUTPUT_INTDIR}/${target}.${DYLIB_EXT})
   
   if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
     list(APPEND DYLYB_ARGS -sdk ${CMAKE_OSX_SYSROOT})

--- a/products/llbuildSwift/CMakeLists.txt
+++ b/products/llbuildSwift/CMakeLists.txt
@@ -36,13 +36,6 @@ endif()
 # Add swift bindings target if swift compiler is present.
 if (SWIFTC_FOUND)
   add_swift_module(libllbuildSwift llbuildSwift libllbuild "${SOURCES}" "${additional_args}")
-  
-  # Install the swift headers.
-  install(FILES 
-      ${CMAKE_CURRENT_BINARY_DIR}/llbuildSwift.swiftmodule
-      ${CMAKE_CURRENT_BINARY_DIR}/llbuildSwift.swiftdoc
-    DESTINATION lib/swift/pm/llbuild/include
-    COMPONENT libllbuildSwift)
 
   # Install the library.
   install(FILES "${LLBUILD_LIBRARY_OUTPUT_INTDIR}/libllbuildSwift.dylib"

--- a/products/llbuildSwift/CMakeLists.txt
+++ b/products/llbuildSwift/CMakeLists.txt
@@ -38,7 +38,13 @@ if (SWIFTC_FOUND)
   add_swift_module(libllbuildSwift llbuildSwift libllbuild "${SOURCES}" "${additional_args}")
 
   # Install the library.
-  install(FILES "${LLBUILD_LIBRARY_OUTPUT_INTDIR}/libllbuildSwift.dylib"
+  if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+    set(DYLIB_EXT dylib)
+  else()
+    set(DYLIB_EXT so)
+  endif()
+  
+  install(FILES "${LLBUILD_LIBRARY_OUTPUT_INTDIR}/libllbuildSwift.${DYLIB_EXT}"
     DESTINATION lib/swift/pm/llbuild
     COMPONENT libllbuildSwift)
   

--- a/products/llbuildSwift/CMakeLists.txt
+++ b/products/llbuildSwift/CMakeLists.txt
@@ -36,14 +36,6 @@ endif()
 # Add swift bindings target if swift compiler is present.
 if (SWIFTC_FOUND)
   add_swift_module(libllbuildSwift llbuildSwift libllbuild "${SOURCES}" "${additional_args}")
-
-  # Install libllbuild.
-  install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/../libllbuild/include
-    DESTINATION lib/swift/pm/llbuild
-    COMPONENT libllbuildSwift
-    FILES_MATCHING
-    PATTERN "*.h"
-    PATTERN "module.modulemap")
   
   # Install the swift headers.
   install(FILES 


### PR DESCRIPTION
Needed for the https://github.com/apple/swift/pull/17829 PR so that we don't install headers in the toolchain.