### PR TITLE
[Xcode] Stop shipping Version.xcconfig with the framework

### DIFF
--- a/llbuild.xcodeproj/project.pbxproj
+++ b/llbuild.xcodeproj/project.pbxproj
@@ -76,8 +76,6 @@
 /* End PBXAggregateTarget section */
 
 /* Begin PBXBuildFile section */
-		14124EAD207C49BF00E2AB56 /* libcurses.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = E15B6EC61B546A2C00643066 /* libcurses.tbd */; };
-		14124EAE207C49D400E2AB56 /* libsqlite3.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = E1E221081A00B82100957481 /* libsqlite3.tbd */; };
 		402614272087B10B005BD956 /* Tracing.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 402614262087B10B005BD956 /* Tracing.cpp */; };
 		403B1A492053123B0018A322 /* version.h in Headers */ = {isa = PBXBuildFile; fileRef = 403B1A48205312000018A322 /* version.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		40B3C91020D3AEC9007C5847 /* libcurses.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = E15B6EC61B546A2C00643066 /* libcurses.tbd */; };
@@ -98,16 +96,6 @@
 		9DDD8BE11DDCAB9A00FB62D2 /* SQLiteBuildDBTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 9DDD8BDF1DDCAB9A00FB62D2 /* SQLiteBuildDBTest.cpp */; };
 		BC669C54205A2C2000942C3B /* BuildSystemBindings.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC8DEF0620300AAF00E9EF0C /* BuildSystemBindings.swift */; };
 		BC669C55205A2C2000942C3B /* CoreBindings.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC8DEF0720300AAF00E9EF0C /* CoreBindings.swift */; };
-		BC8DEF0820300AAF00E9EF0C /* BuildSystemBindings.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC8DEF0620300AAF00E9EF0C /* BuildSystemBindings.swift */; };
-		BC8DEF0920300AAF00E9EF0C /* CoreBindings.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC8DEF0720300AAF00E9EF0C /* CoreBindings.swift */; };
-		BC8DEF1420300BBE00E9EF0C /* libllbuildBasic.a in Frameworks */ = {isa = PBXBuildFile; fileRef = E1A2242519F991B40059043E /* libllbuildBasic.a */; };
-		BC8DEF1520300BBE00E9EF0C /* libllbuildCommands.a in Frameworks */ = {isa = PBXBuildFile; fileRef = E1A2242E19F997050059043E /* libllbuildCommands.a */; };
-		BC8DEF1620300BBE00E9EF0C /* libllbuildCore.a in Frameworks */ = {isa = PBXBuildFile; fileRef = E1A2243E19F997150059043E /* libllbuildCore.a */; };
-		BC8DEF1720300BBE00E9EF0C /* libllvmSupport.a in Frameworks */ = {isa = PBXBuildFile; fileRef = E1B838A21B52E7DE00DB876B /* libllvmSupport.a */; };
-		BC8DEF1820300BC600E9EF0C /* libllbuildBuildSystem.a in Frameworks */ = {isa = PBXBuildFile; fileRef = E1B839571B541BFD00DB876B /* libllbuildBuildSystem.a */; };
-		BC8DEF2220300D7B00E9EF0C /* BuildSystem-C-API.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E1DD22761C472A3F00555A5D /* BuildSystem-C-API.cpp */; };
-		BC8DEF2320300D7B00E9EF0C /* C-API.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E1ADC2311A85922F00D5387C /* C-API.cpp */; };
-		BC8DEF2420300D7B00E9EF0C /* Core-C-API.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E1DD22741C47259900555A5D /* Core-C-API.cpp */; };
 		C5740D091E03523100567DD8 /* BuildSystemFrontendTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C5740D081E03523100567DD8 /* BuildSystemFrontendTest.cpp */; };
 		C5740D0A1E03527B00567DD8 /* libllbuildCore.a in Frameworks */ = {isa = PBXBuildFile; fileRef = E1A2243E19F997150059043E /* libllbuildCore.a */; };
 		C5740D0B1E03528600567DD8 /* libllbuildBasic.a in Frameworks */ = {isa = PBXBuildFile; fileRef = E1A2242519F991B40059043E /* libllbuildBasic.a */; };
@@ -357,41 +345,6 @@
 			proxyType = 1;
 			remoteGlobalIDString = 9DB047A71DF9D43D006CDF52;
 			remoteInfo = BuildSystemTests;
-		};
-		BC8DEF0A20300B9300E9EF0C /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = E1A223E919F98F1C0059043E /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = E1B838981B52E7DE00DB876B;
-			remoteInfo = llvmSupport;
-		};
-		BC8DEF0C20300B9300E9EF0C /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = E1A223E919F98F1C0059043E /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = E1A2242419F991B40059043E;
-			remoteInfo = llbuildBasic;
-		};
-		BC8DEF0E20300B9300E9EF0C /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = E1A223E919F98F1C0059043E /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = E1A2242D19F997050059043E;
-			remoteInfo = llbuildCommands;
-		};
-		BC8DEF1020300B9300E9EF0C /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = E1A223E919F98F1C0059043E /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = E1A2243D19F997150059043E;
-			remoteInfo = llbuildCore;
-		};
-		BC8DEF1220300B9300E9EF0C /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = E1A223E919F98F1C0059043E /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = E1B839481B541BFD00DB876B;
-			remoteInfo = llbuildBuildSystem;
 		};
 		E104FAF81B655BB2005C68A0 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -911,7 +864,6 @@
 		9DB047A81DF9D43D006CDF52 /* BuildSystemTests */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = BuildSystemTests; sourceTree = BUILT_PRODUCTS_DIR; };
 		9DDD8BDF1DDCAB9A00FB62D2 /* SQLiteBuildDBTest.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = SQLiteBuildDBTest.cpp; sourceTree = "<group>"; };
 		B563CEA620A6252500276198 /* CrossPlatformCompatibility.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CrossPlatformCompatibility.h; sourceTree = "<group>"; };
-		BC8DEEFF2030088600E9EF0C /* libllbuildSwift.dylib */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.dylib"; includeInIndex = 0; path = libllbuildSwift.dylib; sourceTree = BUILT_PRODUCTS_DIR; };
 		BC8DEF0520300AAF00E9EF0C /* CMakeLists.txt */ = {isa = PBXFileReference; fileEncoding = 4; indentWidth = 2; lastKnownFileType = text; path = CMakeLists.txt; sourceTree = "<group>"; tabWidth = 2; };
 		BC8DEF0620300AAF00E9EF0C /* BuildSystemBindings.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BuildSystemBindings.swift; sourceTree = "<group>"; };
 		BC8DEF0720300AAF00E9EF0C /* CoreBindings.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CoreBindings.swift; sourceTree = "<group>"; };
@@ -1238,20 +1190,6 @@
 				9DB047BC1DF9D4AA006CDF52 /* libllvmSupport.a in Frameworks */,
 				9DB047BA1DF9D4A4006CDF52 /* libgtest_main.a in Frameworks */,
 				9DB047BB1DF9D4A4006CDF52 /* libgtest.a in Frameworks */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		BC8DEEFC2030088600E9EF0C /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				BC8DEF1820300BC600E9EF0C /* libllbuildBuildSystem.a in Frameworks */,
-				BC8DEF1420300BBE00E9EF0C /* libllbuildBasic.a in Frameworks */,
-				BC8DEF1520300BBE00E9EF0C /* libllbuildCommands.a in Frameworks */,
-				14124EAD207C49BF00E2AB56 /* libcurses.tbd in Frameworks */,
-				BC8DEF1620300BBE00E9EF0C /* libllbuildCore.a in Frameworks */,
-				14124EAE207C49D400E2AB56 /* libsqlite3.tbd in Frameworks */,
-				BC8DEF1720300BBE00E9EF0C /* libllvmSupport.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1780,7 +1718,6 @@
 				E147DF161BA81D330032D08E /* BasicTests */,
 				E1604CB11BB9E01D001153A1 /* swift-build-tool */,
 				9DB047A81DF9D43D006CDF52 /* BuildSystemTests */,
-				BC8DEEFF2030088600E9EF0C /* libllbuildSwift.dylib */,
 				40B3C91A20D3AEC9007C5847 /* CAPITests */,
 			);
 			name = Products;
@@ -2414,13 +2351,6 @@
 /* End PBXGroup section */
 
 /* Begin PBXHeadersBuildPhase section */
-		BC8DEEFD2030088600E9EF0C /* Headers */ = {
-			isa = PBXHeadersBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
 		E1A2242319F991B40059043E /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
@@ -2543,28 +2473,6 @@
 			productName = BuildSystemTests;
 			productReference = 9DB047A81DF9D43D006CDF52 /* BuildSystemTests */;
 			productType = "com.apple.product-type.tool";
-		};
-		BC8DEEFE2030088600E9EF0C /* llbuildSwift */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = BC8DEF002030088600E9EF0C /* Build configuration list for PBXNativeTarget "llbuildSwift" */;
-			buildPhases = (
-				BC8DEEFB2030088600E9EF0C /* Sources */,
-				BC8DEEFC2030088600E9EF0C /* Frameworks */,
-				BC8DEEFD2030088600E9EF0C /* Headers */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-				BC8DEF0B20300B9300E9EF0C /* PBXTargetDependency */,
-				BC8DEF0D20300B9300E9EF0C /* PBXTargetDependency */,
-				BC8DEF0F20300B9300E9EF0C /* PBXTargetDependency */,
-				BC8DEF1120300B9300E9EF0C /* PBXTargetDependency */,
-				BC8DEF1320300B9300E9EF0C /* PBXTargetDependency */,
-			);
-			name = llbuildSwift;
-			productName = llbuildSwift;
-			productReference = BC8DEEFF2030088600E9EF0C /* libllbuildSwift.dylib */;
-			productType = "com.apple.product-type.library.dynamic";
 		};
 		E10D5CD919FEBF6A00211ED4 /* LitXCTestAdaptor */ = {
 			isa = PBXNativeTarget;
@@ -2923,10 +2831,6 @@
 						CreatedOnToolsVersion = 8.3;
 						ProvisioningStyle = Automatic;
 					};
-					BC8DEEFE2030088600E9EF0C = {
-						CreatedOnToolsVersion = 9.3;
-						ProvisioningStyle = Automatic;
-					};
 					E10D5CD919FEBF6A00211ED4 = {
 						CreatedOnToolsVersion = 6.3;
 						ProvisioningStyle = Manual;
@@ -3033,7 +2937,6 @@
 				E1A2243D19F997150059043E /* llbuildCore */,
 				E1B839481B541BFD00DB876B /* llbuildBuildSystem */,
 				E1A2243519F9970D0059043E /* llbuildNinja */,
-				BC8DEEFE2030088600E9EF0C /* llbuildSwift */,
 				E1A224DC19F99B0E0059043E /* gtest */,
 				E1A224E519F99C580059043E /* gtest_main */,
 				E147DEFE1BA81D330032D08E /* BasicTests */,
@@ -3266,18 +3169,6 @@
 				9D0A6D811E1FFEA800BE636F /* TempDir.cpp in Sources */,
 				E1075ED71E4EA417007D52C6 /* BuildSystemTaskTests.cpp in Sources */,
 				E1B3B9DC1E4D5A7A00DF1FBC /* MockBuildSystemDelegate.cpp in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		BC8DEEFB2030088600E9EF0C /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				BC8DEF2220300D7B00E9EF0C /* BuildSystem-C-API.cpp in Sources */,
-				BC8DEF2320300D7B00E9EF0C /* C-API.cpp in Sources */,
-				BC8DEF2420300D7B00E9EF0C /* Core-C-API.cpp in Sources */,
-				BC8DEF0920300AAF00E9EF0C /* CoreBindings.swift in Sources */,
-				BC8DEF0820300AAF00E9EF0C /* BuildSystemBindings.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -3564,31 +3455,6 @@
 			isa = PBXTargetDependency;
 			target = 9DB047A71DF9D43D006CDF52 /* BuildSystemTests */;
 			targetProxy = 9DB047BE1DF9D4B8006CDF52 /* PBXContainerItemProxy */;
-		};
-		BC8DEF0B20300B9300E9EF0C /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = E1B838981B52E7DE00DB876B /* llvmSupport */;
-			targetProxy = BC8DEF0A20300B9300E9EF0C /* PBXContainerItemProxy */;
-		};
-		BC8DEF0D20300B9300E9EF0C /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = E1A2242419F991B40059043E /* llbuildBasic */;
-			targetProxy = BC8DEF0C20300B9300E9EF0C /* PBXContainerItemProxy */;
-		};
-		BC8DEF0F20300B9300E9EF0C /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = E1A2242D19F997050059043E /* llbuildCommands */;
-			targetProxy = BC8DEF0E20300B9300E9EF0C /* PBXContainerItemProxy */;
-		};
-		BC8DEF1120300B9300E9EF0C /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = E1A2243D19F997150059043E /* llbuildCore */;
-			targetProxy = BC8DEF1020300B9300E9EF0C /* PBXContainerItemProxy */;
-		};
-		BC8DEF1320300B9300E9EF0C /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = E1B839481B541BFD00DB876B /* llbuildBuildSystem */;
-			targetProxy = BC8DEF1220300B9300E9EF0C /* PBXContainerItemProxy */;
 		};
 		E104FAF91B655BB2005C68A0 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
@@ -3894,57 +3760,6 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				USER_HEADER_SEARCH_PATHS = "$(SRCROOT)/include $(SRCROOT)/utils/unittest/googletest/include";
-			};
-			name = Release;
-		};
-		BC8DEF012030088600E9EF0C /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				CLANG_ANALYZER_NONNULL = YES;
-				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
-				CLANG_ENABLE_OBJC_WEAK = YES;
-				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
-				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
-				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
-				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
-				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
-				CODE_SIGN_IDENTITY = "-";
-				DEBUG_INFORMATION_FORMAT = dwarf;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				EXECUTABLE_PREFIX = lib;
-				GCC_PREPROCESSOR_DEFINITIONS = (
-					"DEBUG=1",
-					"$(inherited)",
-				);
-				GCC_WARN_64_TO_32_BIT_CONVERSION = NO;
-				HEADER_SEARCH_PATHS = "$(SRCROOT)/products/libllbuild/include";
-				INSTALL_PATH = "";
-				MTL_ENABLE_DEBUG_INFO = YES;
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(LLBUILD_SWIFT_VERSION_DEFINITIONS)";
-			};
-			name = Debug;
-		};
-		BC8DEF022030088600E9EF0C /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				CLANG_ANALYZER_NONNULL = YES;
-				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
-				CLANG_ENABLE_OBJC_WEAK = YES;
-				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
-				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
-				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
-				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
-				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
-				CODE_SIGN_IDENTITY = "-";
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				EXECUTABLE_PREFIX = lib;
-				GCC_WARN_64_TO_32_BIT_CONVERSION = NO;
-				HEADER_SEARCH_PATHS = "$(SRCROOT)/products/libllbuild/include";
-				INSTALL_PATH = "";
-				MTL_ENABLE_DEBUG_INFO = NO;
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(LLBUILD_SWIFT_VERSION_DEFINITIONS)";
 			};
 			name = Release;
 		};
@@ -4452,15 +4267,6 @@
 			buildConfigurations = (
 				9DB047AD1DF9D43D006CDF52 /* Debug */,
 				9DB047AE1DF9D43D006CDF52 /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
-		BC8DEF002030088600E9EF0C /* Build configuration list for PBXNativeTarget "llbuildSwift" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				BC8DEF012030088600E9EF0C /* Debug */,
-				BC8DEF022030088600E9EF0C /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/llbuild.xcodeproj/project.pbxproj
+++ b/llbuild.xcodeproj/project.pbxproj
@@ -85,7 +85,6 @@
 		40B3C91220D3AEC9007C5847 /* libgtest_main.a in Frameworks */ = {isa = PBXBuildFile; fileRef = E1A224E619F99C580059043E /* libgtest_main.a */; };
 		40B3C91C20D3B075007C5847 /* C-API.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 40B3C91B20D3AF9B007C5847 /* C-API.cpp */; };
 		40B3C92720D3B24D007C5847 /* libllbuild.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = E1ADC23A1A85936400D5387C /* libllbuild.dylib */; };
-		40F638ED205306AB00A1CFBE /* Version.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 40F638EC2053043D00A1CFBE /* Version.xcconfig */; };
 		9ADD8B2320D7009F0066BE9A /* BuildSystem-C-API.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 9ADD8B2220D7009A0066BE9A /* BuildSystem-C-API.cpp */; };
 		9D0A6D811E1FFEA800BE636F /* TempDir.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 9D0A6D7F1E1FFEA800BE636F /* TempDir.cpp */; };
 		9D2107C61DFADDFA00BE26FF /* libcurses.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = E15B6EC61B546A2C00643066 /* libcurses.tbd */; };
@@ -2891,7 +2890,6 @@
 				E1D191B91B47232B000C4E95 /* Sources */,
 				E1D191BA1B47232B000C4E95 /* Frameworks */,
 				E1D191BB1B47232B000C4E95 /* Headers */,
-				E1D191BC1B47232B000C4E95 /* Resources */,
 			);
 			buildRules = (
 			);
@@ -3065,14 +3063,6 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		E1D191BC1B47232B000C4E95 /* Resources */ = {
-			isa = PBXResourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				40F638ED205306AB00A1CFBE /* Version.xcconfig in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/llbuild.xcodeproj/xcshareddata/xcschemes/llbuild.xcscheme
+++ b/llbuild.xcodeproj/xcshareddata/xcschemes/llbuild.xcscheme
@@ -79,20 +79,6 @@
          <BuildActionEntry
             buildForTesting = "YES"
             buildForRunning = "YES"
-            buildForProfiling = "YES"
-            buildForArchiving = "YES"
-            buildForAnalyzing = "YES">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "BC8DEEFE2030088600E9EF0C"
-               BuildableName = "libllbuildSwift.dylib"
-               BlueprintName = "llbuildSwift"
-               ReferencedContainer = "container:llbuild.xcodeproj">
-            </BuildableReference>
-         </BuildActionEntry>
-         <BuildActionEntry
-            buildForTesting = "YES"
-            buildForRunning = "YES"
             buildForProfiling = "NO"
             buildForArchiving = "NO"
             buildForAnalyzing = "YES">


### PR DESCRIPTION
Downstream swift clients may now use the bindings in the framework
directly, thus do not need to rely on build system trickery to set the
version information.