### PR TITLE
Install libllbuild next to libllbuildSwift

### DIFF
--- a/cmake/modules/Utility.cmake
+++ b/cmake/modules/Utility.cmake
@@ -198,6 +198,15 @@ function(add_swift_module target name deps sources additional_args)
   foreach(arg ${additional_args})
     list(APPEND DYLYB_ARGS ${arg})
   endforeach()
+
+  # Add rpath to lookup the linked dylibs adjacent to itself.
+  if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+    list(APPEND DYLYB_ARGS -Xlinker -rpath -Xlinker @loader_path)
+    list(APPEND DYLYB_ARGS -Xlinker -install_name -Xlinker @rpath/${target}.${DYLIB_EXT})
+  else()
+    list(APPEND DYLYB_ARGS -Xlinker "-rpath=$ORIGIN")
+  endif()
+
   list(APPEND DYLYB_ARGS -L ${LLBUILD_LIBRARY_OUTPUT_INTDIR})
   
   add_custom_command(

--- a/products/llbuildSwift/CMakeLists.txt
+++ b/products/llbuildSwift/CMakeLists.txt
@@ -43,8 +43,11 @@ if (SWIFTC_FOUND)
   else()
     set(DYLIB_EXT so)
   endif()
+
+  # Install both libllbuild and libllbuildSwift.
+  list(APPEND LLBUILD_LIBRARIES "${LLBUILD_LIBRARY_OUTPUT_INTDIR}/libllbuildSwift.${DYLIB_EXT}" "${LLBUILD_LIBRARY_OUTPUT_INTDIR}/libllbuild.${DYLIB_EXT}")
   
-  install(FILES "${LLBUILD_LIBRARY_OUTPUT_INTDIR}/libllbuildSwift.${DYLIB_EXT}"
+  install(FILES "${LLBUILD_LIBRARIES}"
     DESTINATION lib/swift/pm/llbuild
     COMPONENT libllbuildSwift)
   


### PR DESCRIPTION
libllbuildSwift only contains the Swift bindings, so we need to install
libllbuild as well. It would be nice if libllbuildSwift contained the
entire thing but this should be ok as well.