### PR TITLE
Revert "Install libllbuild next to libllbuildSwift"

### DIFF
--- a/cmake/modules/Utility.cmake
+++ b/cmake/modules/Utility.cmake
@@ -198,15 +198,6 @@ function(add_swift_module target name deps sources additional_args)
   foreach(arg ${additional_args})
     list(APPEND DYLYB_ARGS ${arg})
   endforeach()
-
-  # Add rpath to lookup the linked dylibs adjacent to itself.
-  if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
-    list(APPEND DYLYB_ARGS -Xlinker -rpath -Xlinker @loader_path)
-    list(APPEND DYLYB_ARGS -Xlinker -install_name -Xlinker @rpath/${target}.${DYLIB_EXT})
-  else()
-    list(APPEND DYLYB_ARGS -Xlinker "-rpath=$ORIGIN")
-  endif()
-
   list(APPEND DYLYB_ARGS -L ${LLBUILD_LIBRARY_OUTPUT_INTDIR})
   
   add_custom_command(

--- a/products/llbuildSwift/CMakeLists.txt
+++ b/products/llbuildSwift/CMakeLists.txt
@@ -43,11 +43,8 @@ if (SWIFTC_FOUND)
   else()
     set(DYLIB_EXT so)
   endif()
-
-  # Install both libllbuild and libllbuildSwift.
-  list(APPEND LLBUILD_LIBRARIES "${LLBUILD_LIBRARY_OUTPUT_INTDIR}/libllbuildSwift.${DYLIB_EXT}" "${LLBUILD_LIBRARY_OUTPUT_INTDIR}/libllbuild.${DYLIB_EXT}")
   
-  install(FILES "${LLBUILD_LIBRARIES}"
+  install(FILES "${LLBUILD_LIBRARY_OUTPUT_INTDIR}/libllbuildSwift.${DYLIB_EXT}"
     DESTINATION lib/swift/pm/llbuild
     COMPONENT libllbuildSwift)
   


### PR DESCRIPTION
Reverts apple/swift-llbuild#344

This broke for some reason:
https://ci.swift.org/job/swift-PR-Linux-smoke-test/8139/console

```
18:55:46 -- Install configuration: "Release"
18:55:46 CMake Error at cmake_install.cmake:36 (file):
18:55:46   file INSTALL cannot find
18:55:46   "/home/buildnode/jenkins/workspace/swift-PR-Linux-smoke-test/branch-master/buildbot_linux/llbuild-linux-x86_64/./lib/libllbuildSwift.so;/home/buildnode/jenkins/workspace/swift-PR-Linux-smoke-test/branch-master/buildbot_linux/llbuild-linux-x86_64/./lib/libllbuild.so".
18:55:46 Call Stack (most recent call first):
18:55:46   /home/buildnode/jenkins/workspace/swift-PR-Linux-smoke-test/branch-master/buildbot_linux/llbuild-linux-x86_64/products/cmake_install.cmake:40 (include)
18:55:46   /home/buildnode/jenkins/workspace/swift-PR-Linux-smoke-test/branch-master/buildbot_linux/llbuild-linux-x86_64/cmake_install.cmake:39 
```