### PR TITLE
[CMake] Enable autolinking when compiling llbuildSwift

### DIFF
--- a/cmake/modules/Utility.cmake
+++ b/cmake/modules/Utility.cmake
@@ -167,6 +167,10 @@ function(add_swift_module target name deps sources additional_args)
   foreach(arg ${additional_args})
     list(APPEND ARGS ${arg})
   endforeach()
+
+  # Enable autolinking so clients that import this library automatically get the
+  # -l<library-name> flag.
+  list(APPEND ARGS -module-link-name ${name})
   
   if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
     list(APPEND ARGS -sdk ${CMAKE_OSX_SYSROOT})


### PR DESCRIPTION
This will let clients avoid passing -l flag when they import
llbuildSwift.