### PR TITLE
Set APPLICATION_EXTENSION_API_ONLY = YES

### DIFF
--- a/Xcode/Configs/Common.xcconfig
+++ b/Xcode/Configs/Common.xcconfig
@@ -20,6 +20,9 @@ CURRENT_PROJECT_VERSION = 1
 // Do not always search user paths.
 ALWAYS_SEARCH_USER_PATHS = NO
 
+// Only use API safe for use in app extensions.
+APPLICATION_EXTENSION_API_ONLY = YES
+
 // Headermaps are disabled.
 USE_HEADERMAP = NO
 


### PR DESCRIPTION
We don't use any APIs that are not app-extension-safe, so this is just
general best practice.