### PR TITLE
[Core] Set a busy timeout on the database

### DIFF
--- a/lib/Core/SQLiteBuildDB.cpp
+++ b/lib/Core/SQLiteBuildDB.cpp
@@ -128,6 +128,7 @@ class SQLiteBuildDB : public BuildDB {
       return false;
     }
 
+    sqlite3_busy_timeout(db, 20000);
     // Create the database schema, if necessary.
     char *cError;
     int version;

--- a/lib/Core/SQLiteBuildDB.cpp
+++ b/lib/Core/SQLiteBuildDB.cpp
@@ -128,7 +128,7 @@ class SQLiteBuildDB : public BuildDB {
       return false;
     }
 
-    sqlite3_busy_timeout(db, 20000);
+    sqlite3_busy_timeout(db, 5000);
     // Create the database schema, if necessary.
     char *cError;
     int version;


### PR DESCRIPTION
This adds a timeout for sqlite to wait before giving up because the
database is already busy. This happens if you have 2 concurrent builds
happening at once. Previously it would error out immediately, now it
will wait for up to 20 seconds before erroring out.