### PR TITLE
[BuildSystem] Move Swift compiler's aux files next to the object file

### DIFF
--- a/lib/BuildSystem/BuildSystem.cpp
+++ b/lib/BuildSystem/BuildSystem.cpp
@@ -2609,18 +2609,19 @@ public:
     for (unsigned i = 0; i != sourcesList.size(); ++i) {
       auto source = sourcesList[i];
       auto object = objectsList[i];
+      auto objectDir = llvm::sys::path::parent_path(object);
       auto sourceStem = llvm::sys::path::stem(source);
       SmallString<16> partialModulePath;
-      llvm::sys::path::append(partialModulePath, tempsPath,
+      llvm::sys::path::append(partialModulePath, objectDir,
                               sourceStem + "~partial.swiftmodule");
       SmallString<16> swiftDepsPath;
-      llvm::sys::path::append(swiftDepsPath, tempsPath,
+      llvm::sys::path::append(swiftDepsPath, objectDir,
                               sourceStem + ".swiftdeps");
       
       os << "  \"" << source << "\": {\n";
       if (!enableWholeModuleOptimization) {
         SmallString<16> depsPath;
-        llvm::sys::path::append(depsPath, tempsPath, sourceStem + ".d");
+        llvm::sys::path::append(depsPath, objectDir, sourceStem + ".d");
         os << "    \"dependencies\": \"" << depsPath << "\",\n";
         depsFiles_out.push_back(depsPath.str());
       }

--- a/tests/SwiftBuildTool/swift-compiler.swift-build
+++ b/tests/SwiftBuildTool/swift-compiler.swift-build
@@ -1,7 +1,7 @@
 # Check that we communicate properly with the Swift compiler.
 #
 # RUN: rm -rf %t.build
-# RUN: mkdir -p %t.build
+# RUN: mkdir -p %t.build/temps/nested
 # RUN: sed -e "s#SOURCEDIR#%S#g" -e "s#TMPDIR#%t#g" < %s > %t.build/build.swift-build
 # RUN: %{swift-build-tool} --no-db --chdir %t.build > %t.out
 # RUN: %{swift-build-tool} --no-db -v --chdir %t.build > %t-verbose.out
@@ -17,6 +17,8 @@
 # RUN: %{FileCheck} --check-prefix=CHECK-OUTPUT-FILE-MAP --input-file=%t.build/temps/output-file-map.json %s
 # CHECK-OUTPUT-FILE-MAP: "s 1.swift": {
 # CHECK-OUTPUT-FILE-MAP-NEXT: "dependencies": "temps/s 1.d"
+# CHECK-OUTPUT-FILE-MAP: "s 2.swift": {
+# CHECK-OUTPUT-FILE-MAP-NEXT: "dependencies": "temps/nested/s 2.d"
 
 client:
   name: swift-build
@@ -34,7 +36,7 @@ commands:
     sources: ["s 1.swift", "s 2.swift"]
     import-paths: ["import A", "import B"]
     # FIXME: We can't use spaces in filenames here yet, because of a Swift compiler bug.
-    objects: ["s1.o", "s2.o"]
+    objects: ["temps/s1.o", "temps/nested/s2.o"]
     other-args: ["-Onone", "-I", "path with spaces"]
     temps-path: temps
     is-library: true


### PR DESCRIPTION
This is important for performing correct builds when there are two source files
with the same name in a Swift target.

<rdar://problem/41060279> Nest all swift auxiliary files similar to the object files