### PR TITLE
[BuildSystem] Allow processes to release lanes

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,7 +251,7 @@ discovered on the fly.
 License
 -------
 
-Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors.
+Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors.
 Licensed under Apache License v2.0 with Runtime Library Exception.
 
 See http://swift.org/LICENSE.txt for license information.

--- a/docs/buildsystem.rst
+++ b/docs/buildsystem.rst
@@ -611,6 +611,40 @@ the output file -- even if the output file was just regenerated. This is under
 the assumption that the build system can only truly know that a file was
 produced correctly if it produces it directly.
 
+The build system exposes several environment variables and a file descriptor
+that may be used by subprocesses to communicate information back to the build
+system while executing.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 80
+
+   * - Variable
+     - Description
+
+   * - LLBUILD_LANE_ID
+     - An identifier string representing the execution lane the task is running
+       under.
+
+   * - LLBUILD_TASK_ID
+     - A (reasonably) identifier string for this individual task.
+
+   * - LLBUILD_CONTROL_FD
+     - The file descriptor passed to the subprocess that may be written to with
+       the build system control protocol.
+
+The build system control protocol version 1 is currently limited to a single
+function that allows a subprocess to release its exclusive control of an
+execution lane while continuing to run. This may be accomplished by writing the
+newline delimted version string 'llbuild.1' followed by a newline delimited echo
+of the contents of LLBUILD_TASK_ID. For example:
+
+
+.. code-block:: shell
+
+   bash -c "printf 'llbuild.1\n${LLBUILD_TASK_ID}\n' >&${LLBUILD_CONTROL_FD}"
+
+
 .. note::
 
    One useful behavior not currently supported is the ability to modify and

--- a/include/llbuild/Basic/Tracing.h
+++ b/include/llbuild/Basic/Tracing.h
@@ -89,6 +89,12 @@ struct TracingExecutionQueueSubprocess {
     if (!TracingEnabled) return;
     LLBUILD_TRACE_INTERVAL_BEGIN("execution_queue_subprocess", "lane:%d;command:%s", laneNumber, commandName.str().c_str());
   }
+
+  TracingExecutionQueueSubprocess(const TracingExecutionQueueSubprocess&) = delete;
+  TracingExecutionQueueSubprocess(TracingExecutionQueueSubprocess&& t)
+    : laneNumber(t.laneNumber), pid(t.pid), utime(t.utime), stime(t.stime), maxrss(t.maxrss) {
+    t.active = false;
+  }
   
   void update(pid_t pid, uint64_t utime, uint64_t stime, long maxrss) {
     this->pid = pid;
@@ -98,11 +104,12 @@ struct TracingExecutionQueueSubprocess {
   }
   
   ~TracingExecutionQueueSubprocess() {
-    if (!TracingEnabled) return;
+    if (!TracingEnabled || !active) return;
     LLBUILD_TRACE_INTERVAL_END("execution_queue_subprocess", "lane:%d;pid:%d;utime:%llu;stime:%llu;maxrss:%ld", laneNumber, pid, utime, stime, maxrss);
   }
   
 private:
+  bool active = true;
   uint32_t laneNumber;
   pid_t pid;
   uint64_t utime;

--- a/include/llbuild/BuildSystem/BuildDescription.h
+++ b/include/llbuild/BuildSystem/BuildDescription.h
@@ -20,6 +20,7 @@
 #include "llvm/ADT/StringMap.h"
 #include "llvm/ADT/StringRef.h"
 
+#include <functional>
 #include <memory>
 #include <string>
 #include <utility>
@@ -252,11 +253,16 @@ public:
   virtual void provideValue(BuildSystemCommandInterface&, core::Task*,
                             uintptr_t inputID, const BuildValue& value) = 0;
 
+
+  typedef std::function<void (BuildValue&&)> ResultFn;
+
   /// Execute the command, and return the value.
   ///
   /// This method will always be executed on the build execution queue.
-  virtual BuildValue execute(BuildSystemCommandInterface&, core::Task*,
-                             QueueJobContext* context) = 0;
+  ///
+  /// Note that resultFn may be executed asynchronously on a separate thread.
+  virtual void execute(BuildSystemCommandInterface&, core::Task*,
+                       QueueJobContext* context, ResultFn resultFn) = 0;
   
   /// @}
 };

--- a/include/llbuild/BuildSystem/CommandResult.h
+++ b/include/llbuild/BuildSystem/CommandResult.h
@@ -16,6 +16,8 @@
 #include "llbuild/Basic/CrossPlatformCompatibility.h"
 #include <inttypes.h>
 
+#include <functional>
+
 namespace llbuild {
 namespace buildsystem {
 
@@ -26,6 +28,9 @@ enum class CommandResult {
   Cancelled,
   Skipped,
 };
+
+typedef std::function<void(CommandResult)> CommandCompletionFn;
+
 
 /// Extended result of a command execution.
 struct CommandExtendedResult {

--- a/include/llbuild/BuildSystem/ExternalCommand.h
+++ b/include/llbuild/BuildSystem/ExternalCommand.h
@@ -100,9 +100,11 @@ protected:
   virtual basic::CommandSignature getSignature();
 
   /// Extension point for subclasses, to actually execute the command.
-  virtual CommandResult executeExternalCommand(BuildSystemCommandInterface& bsci,
-                                               core::Task* task,
-                                               QueueJobContext* context) = 0;
+  virtual void executeExternalCommand(
+      BuildSystemCommandInterface& bsci,
+      core::Task* task,
+      QueueJobContext* context,
+      llvm::Optional<CommandCompletionFn> completionFn = {llvm::None}) = 0;
   
 public:
   using Command::Command;
@@ -139,9 +141,10 @@ public:
                             uintptr_t inputID,
                             const BuildValue& value) override;
 
-  virtual BuildValue execute(BuildSystemCommandInterface& bsci,
-                             core::Task* task,
-                             QueueJobContext* context) override;
+  virtual void execute(BuildSystemCommandInterface& bsci,
+                       core::Task* task,
+                       QueueJobContext* context,
+                       ResultFn resultFn) override;
 };
 
 }

--- a/include/llvm/ADT/Optional.h
+++ b/include/llvm/ADT/Optional.h
@@ -20,6 +20,7 @@
 #include "llvm/Support/AlignOf.h"
 #include "llvm/Support/Compiler.h"
 #include <cassert>
+#include <functional>
 #include <new>
 #include <utility>
 
@@ -131,6 +132,15 @@ public:
   template <typename U>
   LLVM_CONSTEXPR T getValueOr(U &&value) const LLVM_LVALUE_FUNCTION {
     return hasValue() ? getValue() : std::forward<U>(value);
+  }
+
+  void unwrapIn(std::function<void(T&)> fn) {
+    if (hasValue())
+      fn(getValue());
+  }
+  void unwrapIn(std::function<void(const T&)> fn) const {
+    if (hasValue())
+      fn(getValue());
   }
 
 #if LLVM_HAS_RVALUE_REFERENCE_THIS

--- a/lib/BuildSystem/BuildExecutionQueue.cpp
+++ b/lib/BuildSystem/BuildExecutionQueue.cpp
@@ -17,6 +17,7 @@
 #include "llvm/ADT/SmallString.h"
 #include "llvm/ADT/StringRef.h"
 
+#include <future>
 #include <vector>
 
 using namespace llbuild;
@@ -32,7 +33,16 @@ BuildExecutionQueue::~BuildExecutionQueue() {
 
 CommandResult BuildExecutionQueue::executeProcess(
     QueueJobContext* context, ArrayRef<StringRef> commandLine) {
-  return executeProcess(context, commandLine, {});
+  // Promises are move constructible only, thus cannot be put into std::function
+  // objects that themselves get copied around. So we must create a shared_ptr
+  // here to allow it to go along with the labmda.
+  std::shared_ptr<std::promise<CommandResult>> p{new std::promise<CommandResult>};
+  auto result = p->get_future();
+  executeProcess(context, commandLine, {}, true, true,
+                 {[p](CommandResult result) mutable {
+    p->set_value(result);
+  }});
+  return result.get();
 }
 
 bool BuildExecutionQueue::executeShellCommand(QueueJobContext* context,

--- a/lib/BuildSystem/LaneBasedExecutionQueue.cpp
+++ b/lib/BuildSystem/LaneBasedExecutionQueue.cpp
@@ -33,16 +33,19 @@
 
 #include <atomic>
 #include <condition_variable>
+#include <cstdlib>
 #include <deque>
 #include <memory>
 #include <mutex>
 #include <queue>
+#include <random>
 #include <string>
 #include <thread>
 #include <unordered_map>
 #include <vector>
 
 #include <fcntl.h>
+#include <poll.h>
 #include <pthread.h>
 #include <unistd.h>
 #include <signal.h>
@@ -93,7 +96,8 @@ qos_class_t _getDarwinQOSClass(QualityOfService level) {
 #endif
 
 struct LaneBasedExecutionQueueJobContext {
-  uint32_t laneNumber;
+  uint64_t jobID;
+  uint64_t laneNumber;
   
   QueueJob& job;
 };
@@ -120,6 +124,9 @@ public:
 //
 // FIXME: Consider trying to share this with the Ninja implementation.
 class LaneBasedExecutionQueue : public BuildExecutionQueue {
+  /// (Random) build identifier
+  uint32_t buildID;
+
   /// The number of lanes the queue was configured with.
   unsigned numLanes;
 
@@ -147,7 +154,7 @@ class LaneBasedExecutionQueue : public BuildExecutionQueue {
   /// The base environment.
   const char* const* environment;
   
-  void executeLane(unsigned laneNumber) {
+  void executeLane(uint32_t buildID, uint32_t laneNumber) {
     // Set the thread name, if available.
 #if defined(__APPLE__)
     pthread_setname_np(
@@ -165,7 +172,14 @@ class LaneBasedExecutionQueue : public BuildExecutionQueue {
     pthread_set_qos_class_self_np(
         _getDarwinQOSClass(defaultQualityOfService), 0);
 #endif
-    
+
+    // Lane ID, used in creating reasonably unique task IDs, stores the buildID
+    // in the top 32 bits.  The laneID is stored in bits 16:31, and the job
+    // count is placed in the lower order 16 bits. These are not strictly
+    // guaranteed to be unique, but should be close enough for common use cases.
+    uint32_t jobCount = 0;
+    uint64_t laneID = (((uint64_t)buildID & 0xFFFF) << 32) + (((uint64_t)laneNumber & 0xFFFF) << 16);
+
     // Execute items from the queue until shutdown.
     while (true) {
       // Take a job from the ready queue.
@@ -191,7 +205,9 @@ class LaneBasedExecutionQueue : public BuildExecutionQueue {
         break;
 
       // Process the job.
-      LaneBasedExecutionQueueJobContext context{ laneNumber, job };
+      jobCount++;
+      uint64_t jobID = laneID + jobCount;
+      LaneBasedExecutionQueueJobContext context{ jobID, laneNumber, job };
       {
         TracingExecutionQueueDepth(readyJobsCount);
 
@@ -240,13 +256,13 @@ public:
   LaneBasedExecutionQueue(BuildExecutionQueueDelegate& delegate,
                           unsigned numLanes,
                           const char* const* environment)
-      : BuildExecutionQueue(delegate), numLanes(numLanes),
+  : BuildExecutionQueue(delegate), buildID(std::random_device()()), numLanes(numLanes),
         readyJobs(Scheduler::make()), environment(environment)
   {
     for (unsigned i = 0; i != numLanes; ++i) {
       lanes.push_back(std::unique_ptr<std::thread>(
                           new std::thread(
-                              &LaneBasedExecutionQueue::executeLane, this, i)));
+                              &LaneBasedExecutionQueue::executeLane, this, buildID, i)));
     }
   }
   
@@ -303,25 +319,30 @@ public:
     }
   }
 
-  virtual CommandResult
-  executeProcess(QueueJobContext* opaqueContext,
-                 ArrayRef<StringRef> commandLine,
-                 ArrayRef<std::pair<StringRef,
-                                    StringRef>> environment,
-                 bool inheritEnvironment,
-                 bool canSafelyInterrupt) override {
+  virtual void executeProcess(
+      QueueJobContext* opaqueContext,
+      ArrayRef<StringRef> commandLine,
+      ArrayRef<std::pair<StringRef, StringRef>> environment,
+      bool inheritEnvironment,
+      bool canSafelyInterrupt,
+      llvm::Optional<std::function<void(CommandResult)>> completionFn) override {
+
     LaneBasedExecutionQueueJobContext& context =
       *reinterpret_cast<LaneBasedExecutionQueueJobContext*>(opaqueContext);
 
     llvm::SmallString<64> description;
     context.job.getForCommand()->getShortDescription(description);
-    TracingExecutionQueueSubprocess subprocessInterval(context.laneNumber, description.str());
+    TracingExecutionQueueSubprocess subprocessInterval(context.laneNumber,
+                                                       description.str());
 
     {
       std::unique_lock<std::mutex> lock(readyJobsMutex);
       // Do not execute new processes anymore after cancellation.
       if (cancelled) {
-        return CommandResult::Cancelled;
+        completionFn.unwrapIn([](CommandCompletionFn fn){
+          fn(CommandResult::Cancelled);
+        });
+        return;
       }
     }
 
@@ -335,6 +356,18 @@ public:
 
     getDelegate().commandProcessStarted(context.job.getForCommand(), handle);
     
+    if (commandLine.size() == 0) {
+      getDelegate().commandProcessHadError(context.job.getForCommand(), handle,
+                                           Twine("no arguments for command"));
+      getDelegate().commandProcessFinished(context.job.getForCommand(),
+                                           handle,
+                                           CommandExtendedResult::makeFailed());
+      completionFn.unwrapIn([](CommandCompletionFn fn){
+        fn(CommandResult::Failed);
+      });
+      return;
+    }
+
     // Initialize the spawn attributes.
     posix_spawnattr_t attributes;
     posix_spawnattr_init(&attributes);
@@ -396,6 +429,29 @@ public:
     posix_spawn_file_actions_addopen(
         &fileActions, 0, "/dev/null", O_RDONLY, 0);
 
+
+    // Create a pipe for the process to (potentially) release the lane while
+    // still running.
+    int releasePipe[2]{ -1, -1 };
+    if (basic::sys::pipe(releasePipe) < 0) {
+      getDelegate().commandProcessHadError(
+          context.job.getForCommand(), handle,
+          Twine("unable to open lane release pipe (") + strerror(errno) + ")");
+      getDelegate().commandProcessFinished(context.job.getForCommand(),
+                                           handle,
+                                           CommandExtendedResult::makeFailed());
+      completionFn.unwrapIn([](CommandCompletionFn fn){
+        fn(CommandResult::Failed);
+      });
+      return;
+    }
+#ifdef __APPLE__
+    posix_spawn_file_actions_addinherit_np(&fileActions, releasePipe[1]);
+#else
+    posix_spawn_file_actions_adddup2(&fileActions, releasePipe[1], releasePipe[1]);
+#endif
+    posix_spawn_file_actions_addclose(&fileActions, releasePipe[0]);
+
     // If we are capturing output, create a pipe and appropriate spawn actions.
     int outputPipe[2]{ -1, -1 };
     if (shouldCaptureOutput) {
@@ -404,8 +460,12 @@ public:
             context.job.getForCommand(), handle,
             Twine("unable to open output pipe (") + strerror(errno) + ")");
         getDelegate().commandProcessFinished(context.job.getForCommand(),
-                                             handle, CommandExtendedResult::makeFailed());
-        return CommandResult::Failed;
+                                             handle,
+                                             CommandExtendedResult::makeFailed());
+        completionFn.unwrapIn([](CommandCompletionFn fn){
+          fn(CommandResult::Failed);
+        });
+        return;
       }
 
       // Open the write end of the pipe as stdout and stderr.
@@ -437,11 +497,11 @@ public:
     POSIXEnvironment posixEnv;
 
     // Export a task ID to subprocesses.
-    //
-    // We currently only export the lane ID, but eventually will export a unique
-    // task ID for SR-6053.
-    posixEnv.setIfMissing("LLBUILD_TASK_ID", Twine(context.laneNumber).str());
-                          
+    auto taskID = Twine::utohexstr(context.jobID);
+    posixEnv.setIfMissing("LLBUILD_LANE_ID", Twine(context.laneNumber).str());
+    posixEnv.setIfMissing("LLBUILD_TASK_ID", taskID.str());
+    posixEnv.setIfMissing("LLBUILD_CONTROL_FD", Twine(releasePipe[1]).str());
+
     // Add the requested environment.
     for (const auto& entry: environment) {
       posixEnv.setIfMissing(entry.first, entry.second);
@@ -499,45 +559,235 @@ public:
 
     posix_spawn_file_actions_destroy(&fileActions);
     posix_spawnattr_destroy(&attributes);
-    
+
+    // Close the write end of the release pipe
+    ::close(releasePipe[1]);
+
+
     // If we failed to launch a process, clean up and abort.
     if (pid == -1) {
+      ::close(releasePipe[0]);
+
       if (shouldCaptureOutput) {
         ::close(outputPipe[1]);
         ::close(outputPipe[0]);
       }
-      return wasCancelled ? CommandResult::Cancelled : CommandResult::Failed;
+      auto result = wasCancelled ? CommandResult::Cancelled : CommandResult::Failed;
+      completionFn.unwrapIn([result](CommandCompletionFn fn){fn(result);});
+      return;
     }
+
+    // Set up our select() structures
+    pollfd readfds[] = {
+      { releasePipe[0], POLLIN, 0 },
+      { outputPipe[0], 0, 0 }
+    };
+    ControlProtocolState control(taskID.str());
+    std::function<bool (StringRef)> readCbs[] = {
+      // control callback handle
+      [this, &control, context, handle](StringRef buf) mutable -> bool {
+        std::string errstr;
+        int ret = control.read(buf, &errstr);
+        if (ret < 0) {
+          getDelegate().commandProcessHadError(
+              context.job.getForCommand(), handle,
+              Twine("control protocol error" + errstr));
+        }
+        return (ret == 0);
+      },
+      // output capture callback
+      [this, context, handle](StringRef buf) -> bool {
+        // Notify the client of the output.
+        getDelegate().commandProcessHadOutput(
+            context.job.getForCommand(), handle, buf);
+        return true;
+      }
+    };
+
+    int nfds = 1;
+    int activefds = 1;
 
     // Read the command output, if capturing.
     if (shouldCaptureOutput) {
+      readfds[1].events = POLLIN;
+      nfds = 2;
+      activefds = 2;
+
       // Close the write end of the output pipe.
       ::close(outputPipe[1]);
+    }
 
-      // Read all the data from the output pipe.
-      while (true) {
-        char buf[4096];
-        ssize_t numBytes = read(outputPipe[0], buf, sizeof(buf));
-        if (numBytes < 0) {
-          getDelegate().commandProcessHadError(
-              context.job.getForCommand(), handle,
-              Twine("unable to read process output (") + strerror(errno) + ")");
-          break;
-        }
+    while (activefds) {
+      char buf[4096];
 
-        if (numBytes == 0)
-          break;
-
-        // Notify the client of the output.
-        getDelegate().commandProcessHadOutput(
-            context.job.getForCommand(), handle,
-            StringRef(buf, numBytes));
+      if (poll(readfds, nfds, -1) == -1) {
+        int err = errno;
+        getDelegate().commandProcessHadError(
+             context.job.getForCommand(), handle,
+             Twine("failed to poll (") + strerror(err) + ")");
+        break;
       }
 
-      // Close the read end of the pipe.
+
+      for (int i = 0; i < nfds; i++) {
+        if (readfds[i].revents & (POLLIN | POLLERR | POLLHUP)) {
+          ssize_t numBytes = read(readfds[i].fd, buf, sizeof(buf));
+          if (numBytes < 0) {
+            int err = errno;
+            getDelegate().commandProcessHadError(
+                context.job.getForCommand(), handle,
+                Twine("unable to read process output (") + strerror(err) + ")");
+          }
+          if (numBytes <= 0 || !readCbs[i](StringRef(buf, numBytes))) {
+            readfds[i].events = 0;
+            activefds--;
+            break;
+          }
+
+          if (control.shouldRelease()) {
+            // Close the read end of the release pipe.
+            ::close(releasePipe[0]);
+
+            std::thread([
+                this, pid, handle, command=context.job.getForCommand(),
+                outputFd{outputPipe[0]},
+                completionFn, subprocessInterval{std::move(subprocessInterval)}
+            ]() mutable {
+              if (shouldCaptureOutput)
+                captureExecutedProcessOutput(outputFd, handle, command);
+
+              cleanUpExecutedProcess(pid, handle, command, completionFn,
+                                     std::move(subprocessInterval));
+            }).detach();
+            return;
+          }
+        }
+      }
+    }
+
+    // Close the read end of the release pipe.
+    ::close(releasePipe[0]);
+
+    if (shouldCaptureOutput) {
+      // Close the read end of the output pipe.
       ::close(outputPipe[0]);
     }
-    
+
+    cleanUpExecutedProcess(pid, handle, context.job.getForCommand(), completionFn,
+                           std::move(subprocessInterval));
+  }
+
+
+private:
+
+  class ControlProtocolState {
+    std::string controlID;
+
+    bool negotiated = false;
+    std::string partialMsg;
+    bool releaseSeen = false;
+
+    const size_t maxLength = 16;
+
+  public:
+    ControlProtocolState(const std::string& controlID) : controlID(controlID) {}
+
+    /// Reads incoming control message buffer
+    ///
+    /// \return 0 on success, 1 on completion, -1 on error.
+    int read(StringRef buf, std::string* errstr = nullptr) {
+      while (buf.size()) {
+        size_t nl = buf.find('\n');
+        if (nl == StringRef::npos) {
+          if (partialMsg.size() + buf.size() > maxLength) {
+            // protocol fault, msg length exceeded maximum
+            partialMsg.clear();
+            if (errstr) {
+              *errstr = "excessive message length";
+            }
+            return -1;
+          }
+
+          // incomplete msg, store and continue
+          partialMsg += buf.str();
+          return 0;
+        }
+
+        partialMsg += buf.slice(0, nl);
+
+        if (!negotiated) {
+          // negotiate protocol version
+          if (partialMsg != "llbuild.1") {
+            // incompatible protocol version
+            if (errstr) {
+              *errstr = "unsupported protocol: " + partialMsg;
+            }
+            partialMsg.clear();
+            return -1;
+          }
+          negotiated = true;
+        } else {
+          // check for supported control message
+          if (partialMsg == controlID) {
+            releaseSeen = true;
+          }
+
+          // We halt receiving anything after the first control message
+          if (errstr) {
+            *errstr = "bad ID";
+          }
+          partialMsg.clear();
+          return 1;
+        }
+
+        partialMsg.clear();
+        buf = buf.drop_front(nl + 1);
+      }
+      return 0;
+    }
+
+    bool shouldRelease() const { return releaseSeen; }
+  };
+
+
+  // Helper function to collect subprocess output
+  void captureExecutedProcessOutput(
+      int outputPipe,
+      struct BuildExecutionQueueDelegate::ProcessHandle handle,
+      Command* command
+  ) {
+    // Read all the data from the output pipe.
+    while (true) {
+      char buf[4096];
+      ssize_t numBytes = read(outputPipe, buf, sizeof(buf));
+      if (numBytes < 0) {
+        int err = errno;
+        getDelegate().commandProcessHadError(
+            command, handle,
+            Twine("unable to read process output (") + strerror(err) + ")");
+        break;
+      }
+
+      if (numBytes == 0)
+        break;
+
+      // Notify the client of the output.
+      getDelegate().commandProcessHadOutput(command, handle,
+                                            StringRef(buf, numBytes));
+    }
+
+    ::close(outputPipe);
+  }
+
+  // Helper function for cleaning up after a process has finished in
+  // executeProcess
+  void cleanUpExecutedProcess(
+      llbuild_pid_t pid,
+      struct BuildExecutionQueueDelegate::ProcessHandle handle,
+      Command* command,
+      llvm::Optional<std::function<void(CommandResult)>> completionFn,
+      TracingExecutionQueueSubprocess&& subprocessInterval
+  ) {
     // Wait for the command to complete.
     struct rusage usage;
     int status, result = wait4(pid, &status, 0, &usage);
@@ -552,11 +802,14 @@ public:
 
     if (result == -1) {
       getDelegate().commandProcessHadError(
-          context.job.getForCommand(), handle,
+          command, handle,
           Twine("unable to wait for process (") + strerror(errno) + ")");
-      getDelegate().commandProcessFinished(context.job.getForCommand(), handle,
+      getDelegate().commandProcessFinished(command, handle,
                                            CommandExtendedResult::makeFailed(status));
-      return CommandResult::Failed;
+      completionFn.unwrapIn([](CommandCompletionFn fn){
+        fn(CommandResult::Failed);
+      });
+      return;
     }
 
     // We report additional info in the tracing interval
@@ -578,9 +831,12 @@ public:
     CommandResult commandResult = cancelled ? CommandResult::Cancelled : (status == 0) ? CommandResult::Succeeded : CommandResult::Failed;
     CommandExtendedResult extendedResult(commandResult, status, pid, utime, stime,
                                          usage.ru_maxrss);
-    getDelegate().commandProcessFinished(context.job.getForCommand(), handle,
+    getDelegate().commandProcessFinished(command, handle,
                                          extendedResult);
-    return commandResult;
+
+    completionFn.unwrapIn([commandResult](CommandCompletionFn fn){
+      fn(commandResult);
+    });
   }
 };
 

--- a/lib/Commands/BuildSystemCommand.cpp
+++ b/lib/Commands/BuildSystemCommand.cpp
@@ -226,9 +226,9 @@ public:
   virtual void provideValue(BuildSystemCommandInterface&, Task*,
                                  uintptr_t inputID,
                                  const BuildValue&) override {}
-  virtual BuildValue execute(BuildSystemCommandInterface&, Task*,
-                             QueueJobContext*) override {
-    return BuildValue::makeFailedCommand();
+  virtual void execute(BuildSystemCommandInterface&, Task*,
+                       QueueJobContext*, ResultFn resultFn) override {
+    resultFn(BuildValue::makeFailedCommand());
   }
 };
 

--- a/llbuild.xcodeproj/xcshareddata/xcschemes/BuildSystemTests.xcscheme
+++ b/llbuild.xcodeproj/xcshareddata/xcschemes/BuildSystemTests.xcscheme
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1000"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "9DB047A71DF9D43D006CDF52"
+               BuildableName = "BuildSystemTests"
+               BlueprintName = "BuildSystemTests"
+               ReferencedContainer = "container:llbuild.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "9DB047A71DF9D43D006CDF52"
+            BuildableName = "BuildSystemTests"
+            BlueprintName = "BuildSystemTests"
+            ReferencedContainer = "container:llbuild.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "9DB047A71DF9D43D006CDF52"
+            BuildableName = "BuildSystemTests"
+            BlueprintName = "BuildSystemTests"
+            ReferencedContainer = "container:llbuild.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+      <CommandLineArguments>
+         <CommandLineArgument
+            argument = "--gtest_filter=BuildSystemTaskTests.directoryContents"
+            isEnabled = "NO">
+         </CommandLineArgument>
+      </CommandLineArguments>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "9DB047A71DF9D43D006CDF52"
+            BuildableName = "BuildSystemTests"
+            BlueprintName = "BuildSystemTests"
+            ReferencedContainer = "container:llbuild.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/llbuild.xcodeproj/xcshareddata/xcschemes/llbuild.xcscheme
+++ b/llbuild.xcodeproj/xcshareddata/xcschemes/llbuild.xcscheme
@@ -142,7 +142,8 @@
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference
-            skipped = "NO">
+            skipped = "NO"
+            parallelizable = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "E10D5CD919FEBF6A00211ED4"

--- a/tests/BuildSystem/Build/basic.llbuild
+++ b/tests/BuildSystem/Build/basic.llbuild
@@ -13,7 +13,7 @@
 # CHECK-NOT: PATH=
 # CHECK-NEXT: /usr/bin/env
 # CHECK: ENV_KEY=ENV_VALUE_2
-# CHECK: LLBUILD_TASK_ID=0
+# CHECK: LLBUILD_TASK_ID={{[a-f0-9]+}}
 # CHECK: PATH=random-overridden-path
 # CHECK: cp 'input A' output
 

--- a/tests/BuildSystem/Build/command-dependencies.llbuild
+++ b/tests/BuildSystem/Build/command-dependencies.llbuild
@@ -26,7 +26,6 @@
 #
 # RUN: echo modified >> %t.build/input
 # RUN: %{llbuild} buildsystem build --serial --chdir %t.build > %t.rebuild.out
-# RUN: cat %t.rebuild.out
 # RUN: %{FileCheck} --check-prefix CHECK-REBUILD --input-file %t.rebuild.out %s
 # RUN: diff %t.build/output-1 %t.build/output-2
 #

--- a/tests/BuildSystem/Build/file-system-opts.llbuild
+++ b/tests/BuildSystem/Build/file-system-opts.llbuild
@@ -13,7 +13,7 @@
 # CHECK-NOT: PATH=
 # CHECK-NEXT: /usr/bin/env
 # CHECK: ENV_KEY=ENV_VALUE_2
-# CHECK: LLBUILD_TASK_ID=0
+# CHECK: LLBUILD_TASK_ID={{[a-f0-9]+}}
 # CHECK: PATH=random-overridden-path
 # CHECK: cp 'input A' output
 

--- a/tests/BuildSystem/Build/lane-release.llbuild
+++ b/tests/BuildSystem/Build/lane-release.llbuild
@@ -1,0 +1,34 @@
+# Test that a command can release a lane
+#
+# RUN: rm -rf %t.build
+# RUN: mkdir -p %t.build
+# RUN: cp %s %t.build/build.llbuild
+# RUN: cp %S/Inputs/wait-for-file %t.build
+# RUN: %{llbuild} buildsystem build --serial --scheduler fifo --chdir %t.build >%t.out
+# RUN: %{FileCheck} --input-file=%t.out %s
+
+# CHECK: release
+# CHECK: other
+# CHECK: done
+
+client:
+  name: basic
+
+targets:
+  "": ["<all>"]
+
+commands:
+  "<echo-wait-echo>":
+    tool: shell
+    outputs: ["<echo-wait-echo>"]
+    args: bash -c "echo release && command echo -e 'llbuild.1\n${LLBUILD_TASK_ID}\n' >&${LLBUILD_CONTROL_FD} && ./wait-for-file ./semaphore && echo done"
+
+  "<echo-other>":
+    tool: shell
+    outputs: ["<echo-other>"]
+    args: echo other && touch ./semaphore
+
+  "<all>":
+    tool: phony
+    inputs: ["<echo-wait-echo>", "<echo-other>"]
+    outputs: ["<all>"]

--- a/tests/BuildSystem/Build/missing-inputs.llbuild
+++ b/tests/BuildSystem/Build/missing-inputs.llbuild
@@ -7,7 +7,6 @@
 # RUN: mkdir -p %t.build
 # RUN: cp %s %t.build/build.llbuild
 # RUN: %{llbuild} buildsystem build --serial --scheduler fifo --chdir %t.build &> %t.out || true
-# RUN: cat %t.out
 # RUN: %{FileCheck} %s --input-file %t.out --check-prefix=CHECK-FAILURE
 #
 # CHECK-FAILURE: cannot build 'output-1' due to missing inputs: 'input'
@@ -15,7 +14,6 @@
 
 # RUN: touch %t.build/input
 # RUN: %{llbuild} buildsystem build --serial --chdir %t.build &> %t2.out || true
-# RUN: cat %t2.out
 # RUN: %{FileCheck} %s --input-file %t2.out --check-prefix=CHECK-FAILURE-2
 #
 # At this point, we have unblocked the commands, and commands are allowed to run

--- a/tests/Examples/buildsystem-capi.llbuild
+++ b/tests/Examples/buildsystem-capi.llbuild
@@ -2,7 +2,6 @@
 #
 # RUN: cc -o %t.exe %{srcroot}/examples/c-api/buildsystem/main.c -I %{srcroot}/products/libllbuild/include -lllbuild -L %{llbuild-lib-dir} -Werror
 # RUN: env LD_LIBRARY_PATH=%{llbuild-lib-dir} %t.exe %s > %t.out
-# RUN: cat %t.out
 # RUN: %{FileCheck} %s --input-file %t.out
 #
 # CHECK: -- read file contents: {{.*}}/buildsystem-capi.llbuild

--- a/unittests/BuildSystem/LaneBasedExecutionQueueTest.cpp
+++ b/unittests/BuildSystem/LaneBasedExecutionQueueTest.cpp
@@ -87,9 +87,9 @@ namespace {
                                    const BuildValue& value) {}
     virtual void provideValue(BuildSystemCommandInterface&, core::Task*,
                               uintptr_t inputID, const BuildValue& value) {}
-    virtual BuildValue execute(BuildSystemCommandInterface&, core::Task*,
-                               QueueJobContext* context) {
-      return BuildValue::makeInvalid();
+    virtual void execute(BuildSystemCommandInterface&, core::Task*,
+                         QueueJobContext* context, ResultFn resultFn) {
+      resultFn(BuildValue::makeInvalid());
     }
   };
 


### PR DESCRIPTION
The general approach here is that LaneBasedExecutionQueue::executeProcess()
exposes a pipe file descriptor to the launched process. If that process
sends the value of LLBUILD_TASK_ID over that pipe, the process will
release the lane on which it is executing and asynchronously wait for
completion.

This initial implementation spawns a new thread for each process that
triggers the release. Longer term, more sophisticated handling of async
IO and process wait may be preferred.

Since any process may opt in to use this functionality, the chain of
methods that lead into the executeProcess call have all been modified
to take completion/result reporting callbacks.

rdar://problem/44683736