### PR TITLE
[libllbuild] Add linker flags in the modulemap file

### DIFF
--- a/products/libllbuild/include/module.modulemap
+++ b/products/libllbuild/include/module.modulemap
@@ -1,3 +1,9 @@
 module "llbuild" {
   umbrella header "llbuild/llbuild.h"
+
+  // Hack: This allows the clients to autolink these system libraries when
+  // building using SwiftPM. We should declare this in the Package.swift
+  // manifest file once SwiftPM exposes an API for it.
+  link "sqlite3"
+  link "ncurses"
 }


### PR DESCRIPTION
This will allow autolinking some required system libraries when building
with SwiftPM. We should be able to move this to the manifest file once
SwiftPM gains support for declaring such things.