### PR TITLE
[llvmSupport] Undefine the DEBUG macro added by SwiftPM

### DIFF
--- a/include/llvm/Support/COFF.h
+++ b/include/llvm/Support/COFF.h
@@ -27,6 +27,12 @@
 #include <cassert>
 #include <cstring>
 
+// Undefine the DEBUG macro which is added by SwiftPM to avoid
+// conflict with another "DEBUG" symbol in this file.
+#ifdef SWIFT_PACKAGE
+#undef DEBUG
+#endif
+
 namespace llvm {
 namespace COFF {
 

--- a/include/llvm/Support/Debug.h
+++ b/include/llvm/Support/Debug.h
@@ -30,6 +30,12 @@
 
 #include "llvm/Support/raw_ostream.h"
 
+// Undefine the DEBUG macro which is added by SwiftPM to avoid
+// conflict with another "DEBUG" symbol in this file.
+#ifdef SWIFT_PACKAGE
+#undef DEBUG
+#endif
+
 namespace llvm {
 
 #ifndef NDEBUG


### PR DESCRIPTION
This avoids the conflict between the DEBUG macro added by SwiftPM and
the other "DEBUG" define in the file.