### PR TITLE
[BuildSystem] Split out filtered directory nodes

### DIFF
--- a/include/llbuild/BuildSystem/BuildNode.h
+++ b/include/llbuild/BuildSystem/BuildNode.h
@@ -103,6 +103,20 @@ public:
   basic::FileInfo getLinkInfo(basic::FileSystem&) const;
 };
 
+
+class StatNode {
+  std::string name;
+
+public:
+  explicit StatNode(StringRef name) : name(name) {}
+
+  const std::string& getName() { return name; }
+
+  basic::FileInfo getFileInfo(basic::FileSystem&) const;
+  basic::FileInfo getLinkInfo(basic::FileSystem&) const;
+};
+
+
 }
 }
 

--- a/include/llbuild/BuildSystem/BuildValue.h
+++ b/include/llbuild/BuildSystem/BuildValue.h
@@ -90,6 +90,10 @@ class BuildValue {
 
     /// Sentinel value representing the result of "building" a top-level target.
     Target,
+
+    /// The filtered contents of a directory.
+    FilteredDirectoryContents,
+
   };
   static StringRef stringForKind(Kind);
 
@@ -121,12 +125,12 @@ class BuildValue {
   basic::StringList stringValues;
 
   bool kindHasCommandSignature() const {
-    return isSuccessfulCommand() || isDirectoryTreeSignature() ||
-      isDirectoryTreeStructureSignature();
+    return isSuccessfulCommand() ||
+        isDirectoryTreeSignature() || isDirectoryTreeStructureSignature();
   }
 
   bool kindHasStringList() const {
-    return isDirectoryContents() || isStaleFileRemoval();
+    return isDirectoryContents() || isFilteredDirectoryContents() || isStaleFileRemoval();
   }
 
   bool kindHasOutputInfo() const {
@@ -172,7 +176,6 @@ private:
     assert(kindHasStringList());
   }
 
-  
   std::vector<StringRef> getStringListValues() const {
     assert(kindHasStringList());
     return stringValues.getValues();
@@ -287,6 +290,9 @@ public:
   static BuildValue makeStaleFileRemoval(ArrayRef<std::string> values) {
     return BuildValue(Kind::StaleFileRemoval, values);
   }
+  static BuildValue makeFilteredDirectoryContents(ArrayRef<std::string> values) {
+    return BuildValue(Kind::FilteredDirectoryContents, values);
+  }
 
   /// @}
 
@@ -317,9 +323,12 @@ public:
   bool isCancelledCommand() const { return kind == Kind::CancelledCommand; }
   bool isSkippedCommand() const { return kind == Kind::SkippedCommand; }
   bool isTarget() const { return kind == Kind::Target; }
+  bool isFilteredDirectoryContents() const {
+    return kind == Kind::FilteredDirectoryContents;
+  }
 
   std::vector<StringRef> getDirectoryContents() const {
-    assert(isDirectoryContents() && "invalid call for value kind");
+    assert((isDirectoryContents() || isFilteredDirectoryContents()) && "invalid call for value kind");
     return getStringListValues();
   }
 

--- a/lib/BuildSystem/BuildKey.cpp
+++ b/lib/BuildSystem/BuildKey.cpp
@@ -26,9 +26,11 @@ StringRef BuildKey::stringForKind(BuildKey::Kind kind) {
     CASE(Command);
     CASE(CustomTask);
     CASE(DirectoryContents);
+    CASE(FilteredDirectoryContents);
     CASE(DirectoryTreeSignature);
     CASE(DirectoryTreeStructureSignature);
     CASE(Node);
+    CASE(Stat);
     CASE(Target);
     CASE(Unknown);
 #undef CASE
@@ -49,6 +51,7 @@ void BuildKey::dump(raw_ostream& os) const {
     break;
   }
   case Kind::DirectoryContents:
+  case Kind::FilteredDirectoryContents:
   case Kind::DirectoryTreeSignature:
   case Kind::DirectoryTreeStructureSignature: {
     os << ", path='" << getDirectoryPath() << "'";
@@ -57,6 +60,10 @@ void BuildKey::dump(raw_ostream& os) const {
   }
   case Kind::Node: {
     os << ", name='" << getNodeName() << "'";
+    break;
+  }
+  case Kind::Stat: {
+    os << ", name='" << getStatName() << "'";
     break;
   }
   case Kind::Target: {

--- a/lib/BuildSystem/BuildNode.cpp
+++ b/lib/BuildSystem/BuildNode.cpp
@@ -125,3 +125,12 @@ FileInfo BuildNode::getLinkInfo(basic::FileSystem& fileSystem) const {
   assert(!isVirtual());
   return fileSystem.getLinkInfo(getName());
 }
+
+
+FileInfo StatNode::getFileInfo(basic::FileSystem& fileSystem) const {
+  return fileSystem.getFileInfo(name);
+}
+
+FileInfo StatNode::getLinkInfo(basic::FileSystem& fileSystem) const {
+  return fileSystem.getLinkInfo(name);
+}

--- a/lib/BuildSystem/BuildSystemFrontend.cpp
+++ b/lib/BuildSystem/BuildSystemFrontend.cpp
@@ -174,6 +174,9 @@ std::string BuildSystemInvocation::formatDetectedCycle(const std::vector<core::R
       case BuildKey::Kind::DirectoryContents:
         os << "directory-contents '" << key.getDirectoryPath() << "'";
         break;
+      case BuildKey::Kind::FilteredDirectoryContents:
+        os << "filtered-directory-contents '" << key.getDirectoryPath() << "'";
+        break;
       case BuildKey::Kind::DirectoryTreeSignature:
         os << "directory-tree-signature '"
         << key.getDirectoryPath() << "'";
@@ -184,6 +187,9 @@ std::string BuildSystemInvocation::formatDetectedCycle(const std::vector<core::R
         break;
       case BuildKey::Kind::Node:
         os << "node '" << key.getNodeName() << "'";
+        break;
+      case BuildKey::Kind::Stat:
+        os << "stat '" << key.getStatName() << "'";
         break;
       case BuildKey::Kind::Target:
         os << "target '" << key.getTargetName() << "'";

--- a/lib/BuildSystem/BuildValue.cpp
+++ b/lib/BuildSystem/BuildValue.cpp
@@ -29,6 +29,7 @@ StringRef BuildValue::stringForKind(BuildValue::Kind kind) {
     CASE(ExistingInput);
     CASE(MissingInput);
     CASE(DirectoryContents);
+    CASE(FilteredDirectoryContents);
     CASE(DirectoryTreeSignature);
     CASE(DirectoryTreeStructureSignature);
     CASE(MissingOutput);

--- a/lib/BuildSystem/ExternalCommand.cpp
+++ b/lib/BuildSystem/ExternalCommand.cpp
@@ -250,7 +250,8 @@ void ExternalCommand::provideValue(BuildSystemCommandInterface& bsci,
     // If the value is an signature, existing, or virtual input, we are always
     // good.
     if (value.isDirectoryTreeSignature() ||
-        value.isDirectoryTreeStructureSignature() || value.isExistingInput() ||
+        value.isDirectoryTreeStructureSignature() ||
+        value.isExistingInput() ||
         value.isVirtualInput() || value.isStaleFileRemoval())
       return llvm::None;
 

--- a/products/libllbuild/BuildSystem-C-API.cpp
+++ b/products/libllbuild/BuildSystem-C-API.cpp
@@ -414,19 +414,25 @@ public:
         buildKey.kind = llb_build_key_kind_directory_contents;
         buildKey.key = strdup(key.getDirectoryPath().str().c_str());
         break;
+      case BuildKey::Kind::FilteredDirectoryContents:
+        buildKey.kind = llb_build_key_kind_filtered_directory_contents;
+        buildKey.key = strdup(key.getDirectoryPath().str().c_str());
+        break;
       case BuildKey::Kind::DirectoryTreeSignature:
         buildKey.kind = llb_build_key_kind_directory_tree_signature;
-        buildKey.key = strdup(
-                              key.getDirectoryPath().str().c_str());
+        buildKey.key = strdup(key.getDirectoryPath().str().c_str());
         break;
       case BuildKey::Kind::DirectoryTreeStructureSignature:
         buildKey.kind = llb_build_key_kind_directory_tree_structure_signature;
-        buildKey.key = strdup(
-                              key.getDirectoryPath().str().c_str());
+        buildKey.key = strdup(key.getDirectoryPath().str().c_str());
         break;
       case BuildKey::Kind::Node:
         buildKey.kind = llb_build_key_kind_node;
         buildKey.key = strdup(key.getNodeName().str().c_str());
+        break;
+      case BuildKey::Kind::Stat:
+        buildKey.kind = llb_build_key_kind_stat;
+        buildKey.key = strdup(key.getStatName().str().c_str());
         break;
       case BuildKey::Kind::Target:
         buildKey.kind = llb_build_key_kind_target;

--- a/products/libllbuild/include/llbuild/buildsystem.h
+++ b/products/libllbuild/include/llbuild/buildsystem.h
@@ -161,6 +161,12 @@ typedef enum {
 
   /// A key used to identify the signature of a complete directory tree.
   llb_build_key_kind_directory_tree_structure_signature = 7,
+
+  /// A key used to identify filtered directory contents.
+  llb_build_key_kind_filtered_directory_contents = 8,
+
+  /// A key used to identify a node.
+  llb_build_key_kind_stat = 10,
 } llb_build_key_kind_t;
 
 typedef enum {

--- a/tests/BuildSystem/Build/directory-contents-filtered-produced.llbuild
+++ b/tests/BuildSystem/Build/directory-contents-filtered-produced.llbuild
@@ -8,7 +8,7 @@
 # RUN: %{llbuild} buildsystem build --serial --trace %t.initial.trace --chdir %t.build
 # RUN: %{FileCheck} --check-prefix=CHECK-INITIAL --input-file=%t.initial.trace %s
 #
-# CHECK-INITIAL: { "new-rule", "[[RULE_NAME:R[0-9]+]]", "Ddirexcludedfile" },
+# CHECK-INITIAL: { "new-rule", "[[RULE_NAME:R[0-9]+]]", "Sdirexcludedfile" },
 # CHECK-INITIAL: { "rule-needs-to-run", "[[RULE_NAME]]", "never-built" },
 
 
@@ -17,7 +17,7 @@
 # RUN: %{llbuild} buildsystem build --serial --trace %t.rebuild.trace --chdir %t.build
 # RUN: %{FileCheck} --check-prefix=CHECK-REBUILD --input-file=%t.rebuild.trace %s
 #
-# CHECK-REBUILD: { "new-rule", "[[RULE_NAME:R[0-9]+]]", "Ddirexcludedfile" },
+# CHECK-REBUILD: { "new-rule", "[[RULE_NAME:R[0-9]+]]", "Sdirexcludedfile" },
 # CHECK-REBUILD: { "rule-does-not-need-to-run", "[[RULE_NAME]]" },
 
 # A rebuild shouldn't rebuild the directory for excluded files.
@@ -26,7 +26,7 @@
 # RUN: %{llbuild} buildsystem build --serial --trace %t.rebuild.trace --chdir %t.build
 # RUN: %{FileCheck} --check-prefix=CHECK-REBUILD2 --input-file=%t.rebuild.trace %s
 #
-# CHECK-REBUILD2: { "new-rule", "[[RULE_NAME:R[0-9]+]]", "Ddirexcludedfile" },
+# CHECK-REBUILD2: { "new-rule", "[[RULE_NAME:R[0-9]+]]", "Sdirexcludedfile" },
 # CHECK-REBUILD2: { "rule-does-not-need-to-run", "[[RULE_NAME]]" },
 
 
@@ -36,8 +36,9 @@
 # RUN: %{llbuild} buildsystem build --serial --trace %t.modified.trace --chdir %t.build
 # RUN: %{FileCheck} --check-prefix=CHECK-MODIFIED --input-file=%t.modified.trace %s
 #
-# CHECK-MODIFIED: { "new-rule", "[[RULE_NAME:R[0-9]+]]", "Ddirexcludedfile" },
-# CHECK-MODIFIED: { "rule-needs-to-run", "[[RULE_NAME]]", "invalid-value" },
+# CHECK-MODIFIED: { "new-rule", "[[RULE_NAME:R[0-9]+]]", "Sdirexcludedfile" },
+# CHECK-MODIFIED: { "new-rule", "[[RULE2_NAME:R[0-9]+]]", "ddirexcludedfile" },
+# CHECK-MODIFIED: { "rule-needs-to-run", "[[RULE_NAME]]", "input-rebuilt", "[[RULE2_NAME]]" },
 
 client:
   name: basic

--- a/tests/BuildSystem/Build/directory-contents-filtered.llbuild
+++ b/tests/BuildSystem/Build/directory-contents-filtered.llbuild
@@ -8,7 +8,7 @@
 # RUN: %{llbuild} buildsystem build --serial --trace %t.initial.trace --chdir %t.build
 # RUN: %{FileCheck} --check-prefix=CHECK-INITIAL --input-file=%t.initial.trace %s
 #
-# CHECK-INITIAL: { "new-rule", "[[RULE_NAME:R[0-9]+]]", "Ddirexcludedfile" },
+# CHECK-INITIAL: { "new-rule", "[[RULE_NAME:R[0-9]+]]", "Sdirexcludedfile" },
 # CHECK-INITIAL: { "rule-needs-to-run", "[[RULE_NAME]]", "never-built" },
 
 
@@ -17,18 +17,17 @@
 # RUN: %{llbuild} buildsystem build --serial --trace %t.rebuild.trace --chdir %t.build
 # RUN: %{FileCheck} --check-prefix=CHECK-REBUILD --input-file=%t.rebuild.trace %s
 #
-# CHECK-REBUILD: { "new-rule", "[[RULE_NAME:R[0-9]+]]", "Ddirexcludedfile" },
+# CHECK-REBUILD: { "new-rule", "[[RULE_NAME:R[0-9]+]]", "Sdirexcludedfile" },
 # CHECK-REBUILD: { "rule-does-not-need-to-run", "[[RULE_NAME]]" },
 
-# A rebuild unfortunately rebuilds with even with excluded files.
-# rdar://41142590
+# A rebuild shouldn't rebuild the directory for excluded files.
 #
 # RUN: touch %t.build/dir/excludedfile
 # RUN: %{llbuild} buildsystem build --serial --trace %t.rebuild.trace --chdir %t.build
 # RUN: %{FileCheck} --check-prefix=CHECK-REBUILD2 --input-file=%t.rebuild.trace %s
 #
-# CHECK-REBUILD2: { "new-rule", "[[RULE_NAME:R[0-9]+]]", "Ddirexcludedfile" },
-# CHECK-REBUILD2: { "rule-needs-to-run", "[[RULE_NAME]]", "input-rebuilt", "[[RULE_NAME2:R[0-9]+]]" },
+# CHECK-REBUILD2: { "new-rule", "[[RULE_NAME:R[0-9]+]]", "Sdirexcludedfile" },
+# CHECK-REBUILD2: { "rule-does-not-need-to-run", "[[RULE_NAME]]" },
 
 
 # A rebuild after adding a new file should rebuild the directory.
@@ -37,8 +36,9 @@
 # RUN: %{llbuild} buildsystem build --serial --trace %t.modified.trace --chdir %t.build
 # RUN: %{FileCheck} --check-prefix=CHECK-MODIFIED --input-file=%t.modified.trace %s
 #
-# CHECK-MODIFIED: { "new-rule", "[[RULE_NAME:R[0-9]+]]", "Ddirexcludedfile" },
-# CHECK-MODIFIED: { "rule-needs-to-run", "[[RULE_NAME]]", "invalid-value" },
+# CHECK-MODIFIED: { "new-rule", "[[RULE_NAME:R[0-9]+]]", "Sdirexcludedfile" },
+# CHECK-MODIFIED: { "new-rule", "[[RULE2_NAME:R[0-9]+]]", "ddirexcludedfile" },
+# CHECK-MODIFIED: { "rule-needs-to-run", "[[RULE_NAME]]", "input-rebuilt", "[[RULE2_NAME]]" },
 
 client:
   name: basic

--- a/unittests/BuildSystem/BuildSystemTaskTests.cpp
+++ b/unittests/BuildSystem/BuildSystemTaskTests.cpp
@@ -197,8 +197,7 @@ TEST(BuildSystemTaskTests, directoryContents) {
 
   // Build a specific key.
   {
-    auto result = system.build(BuildKey::makeDirectoryContents(tempDir.str(),
-                                                               StringList()));
+    auto result = system.build(BuildKey::makeDirectoryContents(tempDir.str()));
     ASSERT_TRUE(result.hasValue());
     ASSERT_TRUE(result->isDirectoryContents());
     ASSERT_EQ(result->getDirectoryContents(), std::vector<StringRef>({
@@ -208,8 +207,7 @@ TEST(BuildSystemTaskTests, directoryContents) {
   // Check that a missing directory behaves properly.
   {
     auto result = system.build(BuildKey::makeDirectoryContents(
-                                   tempDir.str() + "/missing-subpath",
-                                                               StringList()));
+                                   tempDir.str() + "/missing-subpath"));
     ASSERT_TRUE(result.hasValue());
     ASSERT_TRUE(result->isMissingInput());
   }
@@ -310,8 +308,7 @@ TEST(BuildSystemTaskTests, directorySignature) {
   }
   
   // Create the build system.
-  auto keyToBuild = BuildKey::makeDirectoryTreeSignature(tempDir.str(),
-                                                         StringList());
+  auto keyToBuild = BuildKey::makeDirectoryTreeSignature(tempDir.str(), StringList());
   auto description = llvm::make_unique<BuildDescription>();
   MockBuildSystemDelegate delegate;
   BuildSystem system(delegate, createLocalFileSystem());


### PR DESCRIPTION
This change moves filtered directory support into a parallel tree of
nodes. It also introduces a new 'stat' node that produces the stat
information for a file system object.  The combination of these changes
allows filtered directories to work as intended, depending upon the
filter contents only, and not the stat info of the containing directory.

Supports rdar://problem/30640904