### PR TITLE
[Utils] Expand docker images, add check-all

### DIFF
--- a/cmake/modules/FindFileCheck.cmake
+++ b/cmake/modules/FindFileCheck.cmake
@@ -6,7 +6,7 @@
 
 find_program(FILECHECK_EXECUTABLE
              NAMES FileCheck
-             PATHS /usr/local/opt/llvm/bin /usr/lib/llvm-3.6/bin /usr/lib/llvm-3.7/bin
+             PATHS /usr/local/opt/llvm/bin /usr/lib/llvm-3.6/bin /usr/lib/llvm-3.7/bin  /usr/lib/llvm-6.0/bin
              DOC "Path to 'FileCheck' executable")
 
 # Handle REQUIRED and QUIET arguments, this will also set FILECHECK_FOUND to true

--- a/include/llbuild/Basic/Tracing.h
+++ b/include/llbuild/Basic/Tracing.h
@@ -135,6 +135,7 @@ struct TracingEngineTaskCallback {
   ~TracingEngineTaskCallback() {
     if (!TracingEnabled) return;
     LLBUILD_TRACE_INTERVAL_END("engine_task_callback", "key:%llu", key);
+    key = 0;
   }
 private:
   uint64_t key;
@@ -162,6 +163,7 @@ struct TracingEngineQueueItemEvent {
   ~TracingEngineQueueItemEvent() {
     if (!TracingEnabled) return;
     LLBUILD_TRACE_INTERVAL_END("engine_queue_item_event", "key:%s", key)
+    key = nullptr;
   }
 private:
   char const *key;

--- a/llbuild.xcodeproj/project.pbxproj
+++ b/llbuild.xcodeproj/project.pbxproj
@@ -781,11 +781,17 @@
 		1484D21D2094E99900D3830F /* Memory.inc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.pascal; path = Memory.inc; sourceTree = "<group>"; };
 		1484D21E2094E9CE00D3830F /* LeanWindows.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = LeanWindows.h; path = ../../../lib/Basic/LeanWindows.h; sourceTree = "<group>"; };
 		402614262087B10B005BD956 /* Tracing.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Tracing.cpp; sourceTree = "<group>"; };
-		40377C7B2061C44900C0FD4D /* generate-version-h.sh */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = "generate-version-h.sh"; sourceTree = "<group>"; };
 		40377C7C2061D24200C0FD4D /* Package.swift */ = {isa = PBXFileReference; indentWidth = 4; lastKnownFileType = sourcecode.swift; path = Package.swift; sourceTree = "<group>"; tabWidth = 4; };
 		403B1A48205312000018A322 /* version.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = version.h; sourceTree = "<group>"; };
 		404C888E20924BF8000C201A /* DenseMapInfo.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DenseMapInfo.h; sourceTree = "<group>"; };
 		4062058120C7263C00B28281 /* StringList.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = StringList.h; sourceTree = "<group>"; };
+		406A04FD21627FD900EBA895 /* requirements.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = requirements.txt; sourceTree = "<group>"; };
+		406A04FE21627FD900EBA895 /* Dockerfile-16.04 */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = "Dockerfile-16.04"; sourceTree = "<group>"; };
+		406A04FF21627FD900EBA895 /* docker-utils */ = {isa = PBXFileReference; explicitFileType = text.script.python; fileEncoding = 4; path = "docker-utils"; sourceTree = "<group>"; };
+		406A05002162813E00EBA895 /* Dockerfile-14.04 */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = "Dockerfile-14.04"; sourceTree = "<group>"; };
+		406A05012162815000EBA895 /* Dockerfile-18.04 */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = "Dockerfile-18.04"; sourceTree = "<group>"; };
+		406A05022162A20800EBA895 /* check-all */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.script.sh; path = "check-all"; sourceTree = "<group>"; };
+		406A05032162A5A200EBA895 /* build-and-test */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.script.sh; path = "build-and-test"; sourceTree = "<group>"; };
 		40B3C8FF20D3AEBC007C5847 /* CMakeLists.txt */ = {isa = PBXFileReference; lastKnownFileType = text; path = CMakeLists.txt; sourceTree = "<group>"; };
 		40B3C91A20D3AEC9007C5847 /* CAPITests */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = CAPITests; sourceTree = BUILT_PRODUCTS_DIR; };
 		40B3C91B20D3AF9B007C5847 /* C-API.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "C-API.cpp"; sourceTree = "<group>"; };
@@ -1407,6 +1413,18 @@
 			path = Windows;
 			sourceTree = "<group>";
 		};
+		406A04FC21627FD900EBA895 /* docker */ = {
+			isa = PBXGroup;
+			children = (
+				406A04FD21627FD900EBA895 /* requirements.txt */,
+				406A04FE21627FD900EBA895 /* Dockerfile-16.04 */,
+				406A05012162815000EBA895 /* Dockerfile-18.04 */,
+				406A05002162813E00EBA895 /* Dockerfile-14.04 */,
+				406A04FF21627FD900EBA895 /* docker-utils */,
+			);
+			path = docker;
+			sourceTree = "<group>";
+		};
 		40B3C8FE20D3AE80007C5847 /* CAPI */ = {
 			isa = PBXGroup;
 			children = (
@@ -1844,15 +1862,17 @@
 		E1A2246A19F998C30059043E /* utils */ = {
 			isa = PBXGroup;
 			children = (
-				1484D2042094E8B100D3830F /* check-coverage */,
-				1484D2052094E8C300D3830F /* create-dummy-ninja-from-DB.py */,
-				40377C7B2061C44900C0FD4D /* generate-version-h.sh */,
-				1484D2062094E8CE00D3830F /* install-sources */,
+				406A04FC21627FD900EBA895 /* docker */,
 				1484D2112094E90600D3830F /* emacs */,
 				1484D2072094E8DE00D3830F /* manifest-generator */,
 				1484D2092094E8E700D3830F /* ptreetime */,
 				E1A2254E19F9A74B0059043E /* Xcode */,
 				E1A2246B19F998C30059043E /* unittest */,
+				1484D2042094E8B100D3830F /* check-coverage */,
+				406A05022162A20800EBA895 /* check-all */,
+				406A05032162A5A200EBA895 /* build-and-test */,
+				1484D2052094E8C300D3830F /* create-dummy-ninja-from-DB.py */,
+				1484D2062094E8CE00D3830F /* install-sources */,
 			);
 			path = utils;
 			sourceTree = "<group>";

--- a/utils/build-and-test
+++ b/utils/build-and-test
@@ -2,19 +2,16 @@
 
 set -e
 
-TARGETS=${TARGETS:-"14.04 16.04 18.04"}
+if [ "$#" -ne 1 ]; then
+    echo "$0: error: usage: $0 <target-platform>"
+    exit 1
+fi
 
-# Check for required dependencies
-for c in pip docker; do
-  command -v $c >/dev/null 2>&1 || { echo >&2 "error: $c required, but not found"; exit 1; }
-done
+TARGET=$1
+SRCROOT="${PWD}"
+BUILDROOT=".build/.ci/${TARGET}"
 
-# Ensure the docker dependencies are installed
-pip install -r utils/docker/requirements.txt
-
-# Build all the base images
-for TARGET in ${TARGETS}; do
-    utils/docker/docker-utils build --target=${TARGET}
-done
-
-
+mkdir -p "${BUILDROOT}"
+cd "${BUILDROOT}"
+cmake -G Ninja -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ "${SRCROOT}"
+ninja test

--- a/utils/check-all
+++ b/utils/check-all
@@ -1,32 +1,19 @@
-#!/bin/sh
+#!/bin/bash
 
 set -e
 
-SRCROOT="$(realpath $(pwd))"
-OBJROOT="/tmp/llbuild-cov.obj"
+TARGETS=${TARGETS:-"14.04 16.04 18.04"}
 
-# Run a build and test cycle with --coverage enabled to generate the .gcda data.
-if false; then
-    echo "note: building with xcodebuild into '${OBJROOT}'..."
-    time xcodebuild \
-        -scheme test \
-        OBJROOT="${OBJROOT}" \
-        SYMROOT="${OBJROOT}/sym" \
-        DSTROOT="${OBJROOT}/dst" \
-        CCHROOT="${OBJROOT}/cch" \
-        OTHER_CFLAGS="--coverage" OTHER_LDFLAGS="--coverage" &> /tmp/llbuild-cov.log
-else
-    echo "note: building with llbuild into '${OBJROOT}'"
-    mkdir -p ${OBJROOT}
-    (cd ${OBJROOT} &&
-     cmake -G Ninja -DCMAKE_CXX_FLAGS=--coverage -DCMAKE_CXX_COMPILER=/tmp/apple-clang-r442221-t20150326_090132-b26188/usr/bin/clang++ ${SRCROOT} &&
-     xcrun llbuild ninja build --chdir ${OBJROOT} test) &> /tmp/llbuild-cov.log
-fi
+# Check for required dependencies
+for c in pip docker; do
+  command -v $c >/dev/null 2>&1 || { echo >&2 "error: $c required, but not found"; exit 1; }
+done
 
-# Use zcov to generate a coverage report.
-rm -rf build/llbuild.zcov build/llbuild-cov
-mkdir -p build/llbuild-cov
-zcov scan build/llbuild.zcov "${OBJROOT}"
-zcov summarize --root "${SRCROOT}" --prune "/utils/" --prune "/unittests/" build/llbuild.zcov
-zcov genhtml --root "${SRCROOT}" --prune "/utils/" --prune "/unittests/" --hide-branches build/llbuild.zcov build/llbuild-cov
+# Ensure the docker dependencies are installed
+pip install -r utils/docker/requirements.txt
 
+# Check all targets
+for TARGET in ${TARGETS}; do
+    utils/docker/docker-utils build --target=${TARGET}
+    utils/docker/docker-utils run --target=${TARGET} utils/build-and-test ubuntu-${TARGET}
+done

--- a/utils/docker/Dockerfile-14.04
+++ b/utils/docker/Dockerfile-14.04
@@ -6,12 +6,12 @@
 # See http://swift.org/LICENSE.txt for license information
 # See http://swift.org/CONTRIBUTORS.txt for Swift project authors
 
-FROM ubuntu:16.04
+FROM ubuntu:14.04
 
 # Install necesary packages
 RUN apt-get -q update && \
     apt-get -q install -y \
-    clang \
+    clang-3.6 \
     cmake \
     ninja-build \
     sqlite3 \
@@ -19,12 +19,14 @@ RUN apt-get -q update && \
     libsqlite3-dev \
     libncurses5-dev
 RUN pip install lit
-RUN apt-get -q install -y llvm-3.7-tools
+RUN apt-get -q install -y llvm-3.6-tools
 RUN update-alternatives --install /bin/sh sh /bin/bash 100
+RUN update-alternatives --install /usr/bin/clang clang /usr/bin/clang-3.6 100
+RUN update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-3.6 100
 
 ARG SNAPSHOT
-COPY $SNAPSHOT /
-RUN tar -xvzf $SNAPSHOT --directory / --strip-components=1 && \
+COPY "$SNAPSHOT" /
+RUN tar -xvzf "$SNAPSHOT" --directory / --strip-components=1 && \
     rm -rf swift-DEVELOPMENT-SNAPSHOT*
 
 # Set Swift Path

--- a/utils/docker/Dockerfile-16.04
+++ b/utils/docker/Dockerfile-16.04
@@ -23,8 +23,8 @@ RUN apt-get -q install -y llvm-3.7-tools
 RUN update-alternatives --install /bin/sh sh /bin/bash 100
 
 ARG SNAPSHOT
-COPY $SNAPSHOT /
-RUN tar -xvzf $SNAPSHOT --directory / --strip-components=1 && \
+COPY "$SNAPSHOT" /
+RUN tar -xvzf "$SNAPSHOT" --directory / --strip-components=1 && \
     rm -rf swift-DEVELOPMENT-SNAPSHOT*
 
 # Set Swift Path

--- a/utils/docker/Dockerfile-18.04
+++ b/utils/docker/Dockerfile-18.04
@@ -6,7 +6,7 @@
 # See http://swift.org/LICENSE.txt for license information
 # See http://swift.org/CONTRIBUTORS.txt for Swift project authors
 
-FROM ubuntu:16.04
+FROM ubuntu:18.04
 
 # Install necesary packages
 RUN apt-get -q update && \
@@ -19,12 +19,12 @@ RUN apt-get -q update && \
     libsqlite3-dev \
     libncurses5-dev
 RUN pip install lit
-RUN apt-get -q install -y llvm-3.7-tools
+RUN apt-get -q install -y llvm-6.0-tools
 RUN update-alternatives --install /bin/sh sh /bin/bash 100
 
 ARG SNAPSHOT
-COPY $SNAPSHOT /
-RUN tar -xvzf $SNAPSHOT --directory / --strip-components=1 && \
+COPY "$SNAPSHOT" /
+RUN tar -xvzf "$SNAPSHOT" --directory / --strip-components=1 && \
     rm -rf swift-DEVELOPMENT-SNAPSHOT*
 
 # Set Swift Path

--- a/utils/docker/docker-utils
+++ b/utils/docker/docker-utils
@@ -17,68 +17,102 @@
 import argparse
 import urllib2
 import os
+import shutil
 import subprocess
+import tempfile
 import yaml
+
+
+defaultTarget = "16.04"
 
 def call(args):
     """Prints and executes a command."""
     print " ".join(args)
     return subprocess.call(args)
 
-def docker_run(command_args):
-    """Runs a command in the container."""
+def build(args):
+    """Builds a docker image with the latest snapshot."""
+    target = args.target
+    targetNoDot = target.replace(".", "")
+
+    # Create a temporary directory
+    tmpdir = tempfile.mkdtemp()
+
+    try:
+        # Get latest snapshot info.
+        latest_build_url = "https://swift.org/builds/development/ubuntu{}/latest-build.yml".format(targetNoDot)
+        latest_build_data = yaml.load(urllib2.urlopen(latest_build_url).read())
+        snapshot_filename = latest_build_data["download"]
+        # FIXME: We shouldn"t need to do this, it should be available in the API.
+        snapshot_name = snapshot_filename.replace("-ubuntu{}.tar.gz".format(target), "")
+        base_url = latest_build_url.rsplit("/", 1)[0]
+        latest_snapshot_url = base_url + "/" + snapshot_name + "/" + snapshot_filename
+        docker_dir = os.path.dirname(os.path.realpath(__file__))
+
+        # Check if we already have the desired snapshot image
+        curImages = subprocess.check_output([
+            "docker",
+            "images",
+            "--filter", "reference=llbuild-docker-{}:latest".format(targetNoDot),
+            "--filter", "label=swift-snapshot={}".format(snapshot_name),
+            "--format", "{{.ID}}"
+        ])
+
+        # Download latest snapshot (if necessary).
+        if len(curImages.split()) == 1:
+            print "Image exists for {} with {}".format(target, snapshot_name)
+            exit(0)
+        else:
+            result = call([
+                "docker",
+                "rmi", "-f",
+                "llbuild-docker-{}".format(target)
+            ])
+
+            if result != 0:
+                print "Unable to clean prior images"
+                exit(1)
+
+            result = call([
+                "curl",
+                "-o",
+                os.path.join(tmpdir, snapshot_filename),
+                latest_snapshot_url
+            ])
+
+            if result != 0:
+                print "Unable to fetch snapshot"
+                exit(1)
+
+        # Create docker image.
+        call([
+            "docker",
+            "build",
+            "-t", "llbuild-docker-{}".format(targetNoDot),
+            "--label", "swift-snapshot={}".format(snapshot_name),
+            "--build-arg", "SNAPSHOT=%s" % snapshot_filename,
+            "--file", os.path.join(docker_dir, "Dockerfile-{}".format(target)),
+            tmpdir
+        ])
+    finally:
+        shutil.rmtree(tmpdir)
+
+def run(args):
+    """Runs an executable in the container."""
+    target = args.target
+    targetNoDot = target.replace(".", "")
+
     call([
         "docker",
         "run",
         "-it",
+        "--cap-add=SYS_PTRACE",
         "--security-opt", "seccomp=unconfined",
         "-v", "%s:/llbuild" % os.getcwd(),
         "-w", "/llbuild",
         "--rm",
-        "llbuild-docker-1604"
-    ] + command_args)
-
-def build(_):
-    """Builds a docker image with the latest snapshot."""
-
-    # Get latest snapshot info.
-    latest_build_url = "https://swift.org/builds/development/ubuntu1604/latest-build.yml"
-    latest_build_data = yaml.load(urllib2.urlopen(latest_build_url).read())
-    snapshot_filename = latest_build_data["download"]
-    # FIXME: We shouldn"t need to do this, it should be available in the API.
-    snapshot_name = snapshot_filename.replace("-ubuntu16.04.tar.gz", "")
-    base_url = latest_build_url.rsplit("/", 1)[0]
-    latest_snapshot_url = base_url + "/" + snapshot_name + "/" + snapshot_filename
-    docker_dir = os.path.dirname(os.path.realpath(__file__))
-
-    # Download latest snapshot (if necessary).
-    if snapshot_filename in os.listdir(docker_dir):
-        print "Not downloading: " + latest_snapshot_url
-    else:
-        # FIXME: We should remove old tarballs if we have newer ones.
-        result = call([
-            "curl",
-            "-o",
-            docker_dir + "/" + snapshot_filename,
-            latest_snapshot_url
-        ])
-
-        if result != 0:
-            print "Unable to install package: " + latest_snapshot_url
-            exit(1)
-
-    # Create docker image.
-    call([
-        "docker",
-        "build",
-        "-t", "llbuild-docker-1604",
-        "--build-arg", "SNAPSHOT=%s" % snapshot_filename,
-        docker_dir
-    ])
-
-def run(args):
-    """Runs an executable in the container."""
-    docker_run(args.command)
+        "llbuild-docker-{}".format(targetNoDot)
+    ] + args.command)
 
 def main():
     """Main script entry-point."""
@@ -94,12 +128,20 @@ def main():
     parser_build = subparsers.add_parser(
         "build",
         help="builds a docker image from the latest snapshot.")
+    parser_build.add_argument(
+        "-t", "--target",
+        help="The target platform",
+        default=defaultTarget)
     parser_build.set_defaults(func=build)
 
     # run
     parser_run = subparsers.add_parser(
         "run",
         help="runs a command in a container.")
+    parser_run.add_argument(
+        "-t", "--target",
+        help="The target platform",
+        default=defaultTarget)
     parser_run.add_argument("command", help="the command to run with its arguments", nargs="*")
     parser_run.set_defaults(func=run)
 


### PR DESCRIPTION
Expands docker-utils image support to all three Ubuntu versions on which
Swift is built. Adds a check-all script that uses docker to build and
test llbuild in all supported images.