### PR TITLE
[llbuildSwift] Fix TaskWrapper Memory Leak

### DIFF
--- a/products/libllbuild/Core-C-API.cpp
+++ b/products/libllbuild/Core-C-API.cpp
@@ -118,6 +118,12 @@ public:
              "missing task inputs_available function");
   }
 
+  virtual ~CAPITask() {
+    if (cAPIDelegate.destroy_context) {
+      cAPIDelegate.destroy_context(cAPIDelegate.context);
+    }
+  }
+
   virtual void start(BuildEngine& engine) override {
     CAPIBuildEngineDelegate* delegate =
       static_cast<CAPIBuildEngineDelegate*>(engine.getDelegate());

--- a/products/libllbuild/include/llbuild/core.h
+++ b/products/libllbuild/include/llbuild/core.h
@@ -234,6 +234,9 @@ typedef struct llb_task_delegate_t_ {
     /// User context pointer.
     void* context;
 
+    /// Callback for releasing the user context, called on task destruction.
+    void (*destroy_context)(void* context);
+
     /// The callback indicating the task has been started.
     ///
     /// Xparam context The task context pointer.

--- a/products/libllbuild/include/llbuild/llbuild.h
+++ b/products/libllbuild/include/llbuild/llbuild.h
@@ -38,6 +38,8 @@
 ///
 /// Version History:
 ///
+/// 7: Added destroy_context task delegate method.
+///
 /// 6: Added delegate methods for specific diagnostics.
 ///
 /// 5: Added `llb_buildsystem_command_extended_result_t`, changed command_process_finished signature.
@@ -51,7 +53,7 @@
 /// 1: Added `environment` parameter to llb_buildsystem_invocation_t.
 ///
 /// 0: Pre-history
-#define LLBUILD_C_API_VERSION 6
+#define LLBUILD_C_API_VERSION 7
 
 /// Get the full version of the llbuild library.
 LLBUILD_EXPORT const char* llb_get_full_version_string(void);

--- a/products/llbuildSwift/CoreBindings.swift
+++ b/products/llbuildSwift/CoreBindings.swift
@@ -533,8 +533,10 @@ public class BuildEngine {
         //
         // FIXME: Separate the delegate from the context pointer.
         var taskDelegate = llb_task_delegate_t()
-        // FIXME: We need a deallocation callback in order to ensure this is released.
         taskDelegate.context = unsafeBitCast(Unmanaged.passRetained(taskWrapper), to: UnsafeMutableRawPointer.self)
+        taskDelegate.destroy_context = { (context) in
+            Unmanaged<TaskWrapper>.fromOpaque(context!).release()
+        }
         taskDelegate.start = { (context, engineContext, internalTask) in
             let taskWrapper = BuildEngine.toTaskWrapper(context!)
             taskWrapper.task.start(taskWrapper)


### PR DESCRIPTION
Add a destroy_context callback to the C API's task delegate, which, like the build engine's delegate, is called from the destructor. Add the appropriate implementation in the Swift core bindings to release the TaskWrapper associated with the C API's task delegate so it no longer leaks.