### PR TITLE
[Basic] Move control release check outside poll loop

### DIFF
--- a/lib/Basic/Subprocess.cpp
+++ b/lib/Basic/Subprocess.cpp
@@ -523,29 +523,26 @@ void llbuild::basic::spawnProcess(
           readfds[i].events = 0;
           continue;
         }
-
-        activeEvents |= readfds[i].events;
-
-        if (control.shouldRelease()) {
-          // Close the read end of the release pipe.
-          ::close(releasePipe[0]);
-
-          releaseFn([
-              &delegate, &pgrp, pid, handle, ctx,
-              outputFd=outputPipe[0],
-              completionFn=std::move(completionFn)
-          ]() mutable {
-            if (shouldCaptureOutput)
-              captureExecutedProcessOutput(delegate, outputFd, handle, ctx);
-
-            cleanUpExecutedProcess(delegate, pgrp, pid, handle, ctx,
-                                   std::move(completionFn));
-          });
-          return;
-        }
-      } else {
-        activeEvents |= readfds[i].events;
       }
+      activeEvents |= readfds[i].events;
+    }
+
+    if (control.shouldRelease()) {
+      // Close the read end of the release pipe.
+      ::close(releasePipe[0]);
+
+      releaseFn([
+                 &delegate, &pgrp, pid, handle, ctx,
+                 outputFd=outputPipe[0],
+                 completionFn=std::move(completionFn)
+                 ]() mutable {
+        if (shouldCaptureOutput)
+          captureExecutedProcessOutput(delegate, outputFd, handle, ctx);
+
+        cleanUpExecutedProcess(delegate, pgrp, pid, handle, ctx,
+                               std::move(completionFn));
+      });
+      return;
     }
   } while (activeEvents);
 


### PR DESCRIPTION
When a complete control message arrives in one read, the poll loop
early exits. As such, lane release may not happen until a subsequent
read occurs on the console pipe. Move the check out of the loop so that
we properly release after the current reads have been finished.