### PR TITLE
Implement i686 Linux (32-bit x86) Support

### DIFF
--- a/cmake/modules/CheckAtomic.cmake
+++ b/cmake/modules/CheckAtomic.cmake
@@ -1,0 +1,106 @@
+# atomic builtins are required for threading support.
+
+INCLUDE(CheckCXXSourceCompiles)
+INCLUDE(CheckLibraryExists)
+
+# Sometimes linking against libatomic is required for atomic ops, if
+# the platform doesn't support lock-free atomics.
+
+function(check_working_cxx_atomics varname)
+  set(OLD_CMAKE_REQUIRED_FLAGS ${CMAKE_REQUIRED_FLAGS})
+  set(CMAKE_REQUIRED_FLAGS "${CMAKE_REQUIRED_FLAGS} -std=c++11")
+  CHECK_CXX_SOURCE_COMPILES("
+#include <atomic>
+std::atomic<int> x;
+int main() {
+  return x;
+}
+" ${varname})
+  set(CMAKE_REQUIRED_FLAGS ${OLD_CMAKE_REQUIRED_FLAGS})
+endfunction(check_working_cxx_atomics)
+
+function(check_working_cxx_atomics64 varname)
+  set(OLD_CMAKE_REQUIRED_FLAGS ${CMAKE_REQUIRED_FLAGS})
+  set(CMAKE_REQUIRED_FLAGS "-std=c++11 ${CMAKE_REQUIRED_FLAGS}")
+  CHECK_CXX_SOURCE_COMPILES("
+#include <atomic>
+#include <cstdint>
+std::atomic<uint64_t> x (0);
+int main() {
+  uint64_t i = x.load(std::memory_order_relaxed);
+  return 0;
+}
+" ${varname})
+  set(CMAKE_REQUIRED_FLAGS ${OLD_CMAKE_REQUIRED_FLAGS})
+endfunction(check_working_cxx_atomics64)
+
+
+# This isn't necessary on MSVC, so avoid command-line switch annoyance
+# by only running on GCC-like hosts.
+if (LLVM_COMPILER_IS_GCC_COMPATIBLE)
+  # First check if atomics work without the library.
+  check_working_cxx_atomics(HAVE_CXX_ATOMICS_WITHOUT_LIB)
+  # If not, check if the library exists, and atomics work with it.
+  if(NOT HAVE_CXX_ATOMICS_WITHOUT_LIB)
+    check_library_exists(atomic __atomic_fetch_add_4 "" HAVE_LIBATOMIC)
+    if( HAVE_LIBATOMIC )
+      list(APPEND CMAKE_REQUIRED_LIBRARIES "atomic")
+      check_working_cxx_atomics(HAVE_CXX_ATOMICS_WITH_LIB)
+      if (NOT HAVE_CXX_ATOMICS_WITH_LIB)
+	message(FATAL_ERROR "Host compiler must support std::atomic!")
+      endif()
+    else()
+      message(FATAL_ERROR "Host compiler appears to require libatomic, but cannot find it.")
+    endif()
+  endif()
+endif()
+
+# Check for 64 bit atomic operations.
+if(MSVC)
+  set(HAVE_CXX_ATOMICS64_WITHOUT_LIB True)
+else()
+  check_working_cxx_atomics64(HAVE_CXX_ATOMICS64_WITHOUT_LIB)
+endif()
+
+# If not, check if the library exists, and atomics work with it.
+if(NOT HAVE_CXX_ATOMICS64_WITHOUT_LIB)
+  check_library_exists(atomic __atomic_load_8 "" HAVE_CXX_LIBATOMICS64)
+  if(HAVE_CXX_LIBATOMICS64)
+    list(APPEND CMAKE_REQUIRED_LIBRARIES "atomic")
+    check_working_cxx_atomics64(HAVE_CXX_ATOMICS64_WITH_LIB)
+    if (NOT HAVE_CXX_ATOMICS64_WITH_LIB)
+      message(FATAL_ERROR "Host compiler must support std::atomic!")
+    endif()
+  else()
+    message(FATAL_ERROR "Host compiler appears to require libatomic, but cannot find it.")
+  endif()
+endif()
+
+## TODO: This define is only used for the legacy atomic operations in
+## llvm's Atomic.h, which should be replaced.  Other code simply
+## assumes C++11 <atomic> works.
+CHECK_CXX_SOURCE_COMPILES("
+#ifdef _MSC_VER
+#include <windows.h>
+#endif
+int main() {
+#ifdef _MSC_VER
+        volatile LONG val = 1;
+        MemoryBarrier();
+        InterlockedCompareExchange(&val, 0, 1);
+        InterlockedIncrement(&val);
+        InterlockedDecrement(&val);
+#else
+        volatile unsigned long val = 1;
+        __sync_synchronize();
+        __sync_val_compare_and_swap(&val, 1, 0);
+        __sync_add_and_fetch(&val, 1);
+        __sync_sub_and_fetch(&val, 1);
+#endif
+        return 0;
+      }
+" LLVM_HAS_ATOMICS)
+
+if( NOT LLVM_HAS_ATOMICS )
+  message(STATUS "Warning: LLVM will be built thread-unsafe because atomic builtins are missing")
+endif()

--- a/include/llbuild/Basic/Subprocess.h
+++ b/include/llbuild/Basic/Subprocess.h
@@ -58,7 +58,7 @@ namespace llbuild {
     /// Handle used to communicate information about a launched process.
     struct ProcessHandle {
       /// Opaque ID.
-      uint64_t id;
+      uintptr_t id;
     };
 
     struct ProcessInfo {

--- a/lib/llvm/Support/CMakeLists.txt
+++ b/lib/llvm/Support/CMakeLists.txt
@@ -38,10 +38,20 @@ circular_raw_ostream.cpp
 raw_ostream.cpp
 )
 
+include(CheckAtomic)
+
+set(DEPENDENCIES pthread)
+
+if(NOT HAVE_CXX_ATOMICS64_WITHOUT_LIB)
+  list(APPEND DEPENDENCIES atomic)
+endif()
+
 if(${CMAKE_SYSTEM_NAME} MATCHES "FreeBSD")
-  target_link_libraries(llvmSupport execinfo pthread)
+  list(APPEND DEPENDENCIES execinfo)
+  target_link_libraries(llvmSupport ${DEPENDENCIES})
 endif()
 
 if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
-  target_link_libraries(llvmSupport pthread dl)
+  list(APPEND DEPENDENCIES dl)
+  target_link_libraries(llvmSupport ${DEPENDENCIES})
 endif()


### PR DESCRIPTION
i686 mostly works already, minus a couple issues that need to be fixed for a build to complete successfully.

1) Subprocess.h introduced a uintptr_t property of ProcessHandle as uint64_t instead, which is correctly caught by the compiler on 32-bit platforms.
2) i686 uses libatomic instead of built-ins, and this needs to be correctly detected. The implementation behind this was somewhat shamelessly borrowed from LLVM, as I wasn't able to find a cleaner way to simply ask LLVM itself about the state of libatomic.