### PR TITLE
Handle failed inputs in `DirectoryContentsTask`

### DIFF
--- a/lib/BuildSystem/BuildSystem.cpp
+++ b/lib/BuildSystem/BuildSystem.cpp
@@ -828,6 +828,11 @@ class DirectoryContentsTask : public Task {
       return;
     }
 
+    if (directoryValue.isFailedInput()) {
+      engine.taskIsComplete(this, BuildValue::makeFailedInput().toData());
+      return;
+    }
+
     std::vector<std::string> filenames;
     getContents(path, filenames);
 


### PR DESCRIPTION
I'm not really sure how to construct a test for this, but I think it makes sense to handle failed inputs here. The current behaviour is a runtime assertion if failed inputs are encountered by `DirectoryContentsTask`.