### PR TITLE
build: update for the Foundation CMake based build layout

### DIFF
--- a/products/llbuildSwift/CMakeLists.txt
+++ b/products/llbuildSwift/CMakeLists.txt
@@ -12,9 +12,10 @@ else()
   # On Linux, use Foundation and Dispatch libraries built and provided by swift's build-script.
   if(FOUNDATION_BUILD_DIR)
     list(APPEND additional_args
-      -L${FOUNDATION_BUILD_DIR}/Foundation
-      -I${FOUNDATION_BUILD_DIR}/Foundation
-      -I${FOUNDATION_BUILD_DIR}/Foundation/usr/lib/swift)
+      -L${FOUNDATION_BUILD_DIR}
+      -Fsystem
+      ${FOUNDATION_BUILD_DIR}/CoreFoundation-prefix/System/Library/Frameworks
+      -I${FOUNDATION_BUILD_DIR}/swift)
   endif()
   if(LIBDISPATCH_BUILD_DIR)
     list(APPEND additional_args -L${LIBDISPATCH_BUILD_DIR})


### PR DESCRIPTION
The build layout for the CMake based build of Foundation is slightly different
(and more uniform with XCTest and libdispatch).  This updates the search paths
to allow us to switch to the CMake based build of Foundation.