### PR TITLE
Revert "Avoid escaping array-to-pointer conversions"

### DIFF
--- a/products/llbuildSwift/BuildSystemBindings.swift
+++ b/products/llbuildSwift/BuildSystemBindings.swift
@@ -32,7 +32,7 @@ private func copiedDataFromBytes(_ bytes: [UInt8]) -> llb_data_t {
     let buf = UnsafeMutableBufferPointer(start: UnsafeMutablePointer<UInt8>.allocate(capacity: bytes.count), count: bytes.count)
 
     // Copy the data.
-    memcpy(buf.baseAddress!, bytes, buf.count)
+    memcpy(buf.baseAddress!, UnsafePointer<UInt8>(bytes), buf.count)
 
     // Fill in the result structure.
     return llb_data_t(length: UInt64(buf.count), data: unsafeBitCast(buf.baseAddress, to: UnsafePointer<UInt8>.self))
@@ -531,29 +531,22 @@ public protocol BuildSystemDelegate {
 /// Utility class for constructing a C-style environment.
 private final class CStyleEnvironment {
     /// The list of individual bindings, which must be deallocated.
-    private let bindings: UnsafeMutableBufferPointer<UnsafePointer<CChar>?>
+    private let bindings: [UnsafeMutablePointer<CChar>]
 
     /// The environment array, which will be a valid C-style environment pointer
     /// for the lifetime of the instance.
-    var envp: UnsafePointer<UnsafePointer<CChar>?> {
-        return UnsafePointer(bindings.baseAddress!)
-    }
+    let envp: [UnsafePointer<CChar>?]
 
     init(_ environment: [String: String]) {
         // Allocate the individual binding strings.
-        let bindingPtrs = environment.map{ "\($0.0)=\($0.1)".withCString(strdup)! }
+        self.bindings = environment.map{ "\($0.0)=\($0.1)".withCString(strdup)! }
 
-        // Allocate the bindings pointer buffer.
-        self.bindings = .allocate(capacity: bindingPtrs.count + 1)
-        _ = self.bindings.initialize(from: bindingPtrs)
-        self.bindings[bindingPtrs.count] = nil
+        // Allocate the envp array.
+        self.envp = self.bindings.map{ UnsafePointer($0) } + [nil]
     }
 
     deinit {
-        for binding in bindings.dropLast() {
-            free(UnsafeMutablePointer(mutating: binding!))
-        }
-        bindings.deallocate()
+        bindings.forEach{ free($0) }
     }
 }
 
@@ -604,7 +597,7 @@ public final class BuildSystem {
         _invocation.buildFilePath = UnsafePointer(pathPtr)
         _invocation.dbPath = UnsafePointer(dbPathPtr)
         _invocation.traceFilePath = UnsafePointer(tracePathPtr)
-        _invocation.environment = _cEnvironment?.envp
+        _invocation.environment = _cEnvironment.map{ UnsafePointer($0.envp) }
         _invocation.showVerboseStatus = true
         _invocation.useSerialBuild = serial
         _invocation.schedulerAlgorithm = BuildSystem.schedulerAlgorithm.llbValue()


### PR DESCRIPTION
This reverts commit 3b7df215161607ecf9dddda9322654edfc6b4a1b.

 - This is causing crashes in llbuild when used in some cases, so we apparently
   have some missing test coverage. Will further investigate to find the actual
   bug...