### PR TITLE
[BuildSystem] Add support for setting external process working directory

### DIFF
--- a/include/llbuild/Basic/ExecutionQueue.h
+++ b/include/llbuild/Basic/ExecutionQueue.h
@@ -134,10 +134,7 @@ namespace llbuild {
       /// overlayed on top base environment supplied when creating the queue. If
       /// false, only the supplied environment will be passed to the subprocess.
       ///
-      /// \param canSafelyInterrupt If true, whether it is safe to attempt to
-      /// SIGINT the process to cancel it. If false, the process won't be
-      /// interrupted during cancellation and will be given a chance to complete
-      /// (if it fails to complete it will ultimately be sent a SIGKILL).
+      /// \param attributes Additional attributes for the process to be spawned.
       //
       // FIXME: This interface will need to get more complicated, and provide the
       // command result and facilities for dealing with the output.
@@ -146,7 +143,7 @@ namespace llbuild {
                      ArrayRef<StringRef> commandLine,
                      ArrayRef<std::pair<StringRef, StringRef>> environment,
                      bool inheritEnvironment = true,
-                     bool canSafelyInterrupt = true,
+                     ProcessAttributes attributes = {true},
                      llvm::Optional<ProcessCompletionFn> completionFn = {llvm::None}) = 0;
 
       /// @}

--- a/include/llbuild/Basic/Subprocess.h
+++ b/include/llbuild/Basic/Subprocess.h
@@ -224,6 +224,19 @@ namespace llbuild {
                                    const ProcessResult& result) = 0;
     };
 
+
+    struct ProcessAttributes {
+      /// If true, whether it is safe to attempt to SIGINT the process to cancel
+      /// it. If false, the process won't be interrupted during cancellation and
+      /// will be given a chance to complete (if it fails to complete it will
+      /// ultimately be sent a SIGKILL).
+      bool canSafelyInterrupt;
+
+      /// If set, the working directory to change into before spawning (only
+      /// supported on macOS)
+      StringRef workingDir = {};
+    };
+
     /// Execute the given command line.
     ///
     /// This will launch and execute the given command line and wait for it to
@@ -241,10 +254,7 @@ namespace llbuild {
     ///
     /// \param environment The environment to launch with.
     ///
-    /// \param canSafelyInterrupt If true, whether it is safe to attempt to SIGINT
-    /// the process to cancel it. If false, the process won't be interrupted
-    /// during cancellation and will be given a chance to complete (if it fails to
-    /// complete it will ultimately be sent a SIGKILL).
+    /// \param attributes Additional attributes for the process to be spawned.
     ///
     /// \param releaseFn Functional called when a process wishes to release its
     /// exclusive access to build system resources (namely an execution lane).
@@ -264,7 +274,7 @@ namespace llbuild {
                       ProcessHandle handle,
                       ArrayRef<StringRef> commandLine,
                       POSIXEnvironment environment,
-                      bool canSafelyInterrupt,
+                      ProcessAttributes attributes,
                       ProcessReleaseFn&& releaseFn,
                       ProcessCompletionFn&& completionFn);
 

--- a/lib/Basic/ExecutionQueue.cpp
+++ b/lib/Basic/ExecutionQueue.cpp
@@ -44,7 +44,7 @@ ProcessStatus ExecutionQueue::executeProcess(QueueJobContext* context,
   // here to allow it to go along with the labmda.
   std::shared_ptr<std::promise<ProcessStatus>> p{new std::promise<ProcessStatus>};
   auto result = p->get_future();
-  executeProcess(context, commandLine, {}, true, true,
+  executeProcess(context, commandLine, {}, true, {true},
                  {[p](ProcessResult result) mutable {
     p->set_value(result.status);
   }});

--- a/lib/Basic/LaneBasedExecutionQueue.cpp
+++ b/lib/Basic/LaneBasedExecutionQueue.cpp
@@ -256,7 +256,7 @@ public:
       ArrayRef<StringRef> commandLine,
       ArrayRef<std::pair<StringRef, StringRef>> environment,
       bool inheritEnvironment,
-      bool canSafelyInterrupt,
+      ProcessAttributes attributes,
       llvm::Optional<ProcessCompletionFn> completionFn) override {
 
     LaneBasedExecutionQueueJobContext& context =
@@ -330,7 +330,7 @@ public:
         handle,
         commandLine,
         posixEnv,
-        canSafelyInterrupt,
+        attributes,
         std::move(releaseFn),
         std::move(laneCompletionFn)
     );

--- a/lib/Commands/NinjaBuildCommand.cpp
+++ b/lib/Commands/NinjaBuildCommand.cpp
@@ -1114,7 +1114,7 @@ buildCommand(BuildContext& context, ninja::Command* command) {
         command->getCommandString().c_str()
       };
 
-      context.jobQueue->executeProcess(qctx, args, {}, true, true, {
+      context.jobQueue->executeProcess(qctx, args, {}, true, {true}, {
         [&](ProcessResult result) {
           // Actually run the command.
           if (result.status != ProcessStatus::Succeeded) {

--- a/tests/BuildSystem/Build/working-directory.llbuild
+++ b/tests/BuildSystem/Build/working-directory.llbuild
@@ -1,0 +1,34 @@
+# Check that working directory attribute is processed properly
+#
+# RUN: rm -rf %t.build
+# RUN: mkdir -p %t.build
+# RUN: cp %s %t.build/build.llbuild
+# RUN: %{llbuild} buildsystem build --serial --chdir %t.build > %t.out
+# RUN: test -d %t.build/subdir
+# RUN: test -f %t.build/subdir/file
+# RUN: test -f %t.build/file
+#
+# REQUIRES: platform=Darwin
+
+client:
+  name: basic
+
+targets:
+  "": ["<all>"]
+
+commands:
+  C.all:
+    tool: phony
+    inputs: ["subdir/file", "file"]
+    outputs: ["<all>"]
+  C.touch-subdir:
+    tool: shell
+    description: TOUCH-SUBDIR
+    args: ["touch", "file"]
+    working-directory: "subdir"
+    outputs: ["subdir/file"]
+  C.touch:
+    tool: shell
+    description: TOUCH
+    args: ["touch", "file"]
+    outputs: ["file"]


### PR DESCRIPTION
This currently is limited to Darwin platforms, as it is implemented via a
non-portable pthread API.

rdar://problem/39941219