### PR TITLE
Rename Compile to Compiling to fix the tense

### DIFF
--- a/lib/BuildSystem/BuildSystem.cpp
+++ b/lib/BuildSystem/BuildSystem.cpp
@@ -2682,7 +2682,7 @@ public:
 
   virtual void getShortDescription(SmallVectorImpl<char> &result) const override {
       llvm::raw_svector_ostream(result)
-        << "Compile Swift Module '" << moduleName
+        << "Compiling Swift Module '" << moduleName
         << "' (" << sourcesList.size() << " sources)";
   }
 

--- a/tests/SwiftBuildTool/swift-compiler-whole-module-optimization.swift-build
+++ b/tests/SwiftBuildTool/swift-compiler-whole-module-optimization.swift-build
@@ -8,7 +8,7 @@
 # RUN: %{FileCheck} --input-file=%t.out %s
 # RUN: %{FileCheck} --check-prefix=CHECK-VERBOSE --input-file=%t-verbose.out %s
 #
-# CHECK: Compile Swift Module 'Foo'
+# CHECK: Compiling Swift Module 'Foo'
 # CHECK-VERBOSE: swiftc -module-name Bar -incremental -emit-dependencies -emit-module -emit-module-path Bar.swiftmodule -output-file-map bar.build/output-file-map.json -parse-as-library -whole-module-optimization -num-threads 1 -c s1.swift -I importB
 # CHECK-VERBOSE-NEXT: swiftc -module-name Foo -incremental -emit-dependencies -emit-module -emit-module-path Foo.swiftmodule -output-file-map foo.build/output-file-map.json -parse-as-library -whole-module-optimization -num-threads 0 -c s1.swift s2.swift -I importA -I importB -Onone -I somePath
 

--- a/tests/SwiftBuildTool/swift-compiler.swift-build
+++ b/tests/SwiftBuildTool/swift-compiler.swift-build
@@ -8,7 +8,7 @@
 # RUN: %{FileCheck} --input-file=%t.out %s
 # RUN: %{FileCheck} --check-prefix=CHECK-VERBOSE --input-file=%t-verbose.out %s
 #
-# CHECK: Compile Swift Module 'Foo'
+# CHECK: Compiling Swift Module 'Foo'
 # FIXME: This should quote output paths.
 # CHECK-VERBOSE: swiftc -module-name Foo -incremental -emit-dependencies -emit-module -emit-module-path Foo.swiftmodule -output-file-map temps/output-file-map.json -parse-as-library -c "s 1.swift" "s 2.swift" -I "import A" -I "import B" -Onone -I "path with spaces"
 


### PR DESCRIPTION
Fix the tense in the Swift compilation tool description. A SwiftPM PR needs to be merged first or this change will break it: https://github.com/apple/swift-package-manager/pull/1877