### PR TITLE
[BuildSystem] Allow control channel to be disabled

### DIFF
--- a/include/llbuild/Basic/Subprocess.h
+++ b/include/llbuild/Basic/Subprocess.h
@@ -235,6 +235,10 @@ namespace llbuild {
       /// If set, the working directory to change into before spawning (only
       /// supported on macOS)
       StringRef workingDir = {};
+
+      /// If true, exposes a control file descriptor that may be used to
+      /// communicate with the build system.
+      bool controlEnabled = true;
     };
 
     /// Execute the given command line.

--- a/tests/BuildSystem/Build/no-control-fd.llbuild
+++ b/tests/BuildSystem/Build/no-control-fd.llbuild
@@ -1,0 +1,27 @@
+# Check that the control FD environment variable is not exported when it is
+# disabled.
+#
+# RUN: rm -rf %t.build
+# RUN: mkdir -p %t.build
+# RUN: cp %s %t.build/build.llbuild
+# RUN: %{llbuild} buildsystem build --serial --chdir %t.build --trace %t.trace > %t.out
+# RUN: %{FileCheck} --input-file=%t.out %s
+#
+# CHECK: /usr/bin/env
+# CHECK-NOT: LLBUILD_CONTROL_FD=
+# CHECK: LLBUILD_TASK_ID={{[a-f0-9]+}}
+
+
+client:
+  name: basic
+
+targets:
+  basic: ["<env>"]
+default: basic
+
+commands:
+  "<env>":
+    tool: shell
+    outputs: ["<env>"]
+    control-enabled: false
+    args: /usr/bin/env | /usr/bin/sort


### PR DESCRIPTION
Allows 'shell' tool commands to optionally disable the export of the
control file descriptor and accompanying environment variable.

rdar://problem/46152060