### PR TITLE
Add support for setting the working directory of tasks on Linux

### DIFF
--- a/include/llbuild/Basic/Subprocess.h
+++ b/include/llbuild/Basic/Subprocess.h
@@ -228,8 +228,8 @@ namespace llbuild {
       /// ultimately be sent a SIGKILL).
       bool canSafelyInterrupt;
 
-      /// If set, the working directory to change into before spawning (only
-      /// supported on macOS)
+      /// If set, the working directory to change into before spawning (support
+      /// not guaranteed on all platforms).
       StringRef workingDir = {};
 
       /// If true, exposes a control file descriptor that may be used to

--- a/lib/BuildSystem/BuildSystem.cpp
+++ b/lib/BuildSystem/BuildSystem.cpp
@@ -2205,17 +2205,12 @@ public:
       }
       inheritEnv = value == "true";
     } else if (name == "working-directory") {
-#if __APPLE__
       // Ensure the working directory is absolute. This will make sure any
       // relative directories are interpreted as relative to the CWD at the time
       // the rule is defined.
       SmallString<PATH_MAX> wd = value;
       llvm::sys::fs::make_absolute(wd);
       workingDirectory = StringRef(wd);
-#else
-      ctx.error("working-directory unsupported on this platform");
-      return false;
-#endif
     } else if (name == "control-enabled") {
       if (value != "true" && value != "false") {
         ctx.error("invalid value: '" + value + "' for attribute '" +


### PR DESCRIPTION
[Glibc 2.29](https://sourceware.org/git/?p=glibc.git;a=commit;h=4a938cb273e164a475dc123cc80ea6354d7248d4) will add posix_spawn_file_actions_addchdir_np. A method with
the same signature also exists on [Solaris](https://docs.oracle.com/cd/E86824_01/html/E54766/posix-spawn-file-actions-addchdir-np-3c.html), and there is currently a
[proposal](http://austingroupbugs.net/view.php?id=1208) to add a "posix_spawn_file_actions_addchdir" to POSIX, so
proactively re-structure the code to prefer using a
posix_spawn_file_actions_addchdir[_np] style function to set the working
directory.

We fall back to an alternate mechanism where available, or continue to
assert as before.

rdar://46069443