### PR TITLE
Raise open file limit before building

### DIFF
--- a/include/llbuild/Basic/PlatformUtility.h
+++ b/include/llbuild/Basic/PlatformUtility.h
@@ -19,6 +19,7 @@
 #define LLBUILD_BASIC_PLATFORMUTILITY_H
 
 #include <cstdio>
+#include <sys/resource.h>
 
 namespace llbuild {
 namespace basic {
@@ -35,6 +36,13 @@ int rmdir(const char *path);
 int symlink(const char *source, const char *target);
 int unlink(const char *fileName);
 int write(int fileHandle, void *destinationBuffer, unsigned int maxCharCount);
+
+/// Sets the max open file limit to min(max(soft_limit, limit), hard_limit),
+/// where soft_limit and hard_limit are gathered from the system.
+///
+/// Returns: 0 on success, -1 on failure (check errno).
+int raiseOpenFileLimit(rlim_t limit = 2048);
+
 }
 }
 }

--- a/lib/Basic/PlatformUtility.cpp
+++ b/lib/Basic/PlatformUtility.cpp
@@ -135,3 +135,21 @@ int sys::write(int fileHandle, void *destinationBuffer,
   return ::write(fileHandle, destinationBuffer, maxCharCount);
 #endif
 }
+
+int sys::raiseOpenFileLimit(rlim_t limit) {
+  int ret = 0;
+
+  struct rlimit rl;
+  ret = getrlimit(RLIMIT_NOFILE, &rl);
+  if (ret != 0) {
+    return ret;
+  }
+
+  if (rl.rlim_cur >= limit) {
+    return 0;
+  }
+
+  rl.rlim_cur = std::min(limit, rl.rlim_max);
+
+  return setrlimit(RLIMIT_NOFILE, &rl);
+}

--- a/lib/BuildSystem/BuildSystem.cpp
+++ b/lib/BuildSystem/BuildSystem.cpp
@@ -1784,6 +1784,11 @@ BuildSystemImpl::lookupNode(StringRef name, bool isImplicit) {
 
 llvm::Optional<BuildValue> BuildSystemImpl::build(BuildKey key) {
 
+  if (basic::sys::raiseOpenFileLimit() != 0) {
+    error(getMainFilename(), "failed to raise open file limit");
+    return None;
+  }
+
   // Aquire lock and create execution queue.
   {
     std::lock_guard<std::mutex> guard(executionQueueMutex);

--- a/lib/Commands/NinjaBuildCommand.cpp
+++ b/lib/Commands/NinjaBuildCommand.cpp
@@ -1527,6 +1527,12 @@ int commands::executeNinjaBuildCommand(std::vector<std::string> args) {
   double maximumLoadAverage = 0.0;
   std::vector<std::string> debugTools;
 
+  if (basic::sys::raiseOpenFileLimit() != 0) {
+    fprintf(stderr, "%s: error: unable to raise open file limit\n\n",
+            getProgramName());
+    return -1;
+  }
+
   while (!args.empty() && args[0][0] == '-') {
     const std::string option = args[0];
     args.erase(args.begin());


### PR DESCRIPTION
- Adds raiseOpenFileLimit to PlatformUtility
- Raises open file limit before constructing execution queue in
BuildSystem
- Raises open file limit at the start of Ninja builds

rdar://problem/46823730