### PR TITLE
[BuildSystem] Handle relative paths in 'shell' makefile-style dependencies

### DIFF
--- a/tests/BuildSystem/Build/discovered-makefile-deps-relative.llbuild
+++ b/tests/BuildSystem/Build/discovered-makefile-deps-relative.llbuild
@@ -1,0 +1,58 @@
+# Check the handling of compiler-based discovered dependencies with relative
+# paths
+
+# We test with a simple command that just writes a fake .d file which lists an
+# input dependency on "header-1".
+
+# RUN: rm -rf %t.build
+# RUN: mkdir -p %t.build/wd
+# RUN: touch %t.build/wd/header-1 %t.build/wd/input-1
+# RUN: cp %s %t.build/build.llbuild
+
+
+# Check the first build.
+#
+# RUN: %{llbuild} buildsystem build --serial --chdir %t.build > %t1.out
+# RUN: %{FileCheck} --check-prefix=CHECK-INITIAL --input-file=%t1.out %s
+#
+# CHECK-INITIAL: CC output-1
+# CHECK-INITIAL: cat output-1 > ../output
+
+
+# Check a build that modifies the header.
+#
+# RUN: echo "mod" >> %t.build/header-1
+# RUN: %{llbuild} buildsystem build --serial --chdir %t.build &> %t2.out
+# RUN: %{FileCheck} --check-prefix=CHECK-AFTER-MOD --input-file=%t2.out %s
+#
+# CHECK-AFTER-MOD: CC output-1
+# CHECK-AFTER-MOD: cat output-1 > ../output
+#
+# REQUIRES: platform=Darwin
+
+
+client:
+  name: basic
+
+targets:
+  "": ["output"]
+
+commands:
+  output-1:
+    tool: shell
+    inputs: ["wd/input-1"]
+    outputs: ["wd/output-1"]
+    args: "echo \"output-1: input-1 header-1\" > output-1.d && cat input-1 header-1 > output-1"
+    description: CC output-1
+    deps: output-1.d
+    deps-style: makefile
+    working-directory: wd
+    
+  output:
+    tool: shell
+    inputs: ["wd/output-1"]
+    outputs: ["output"]
+    args: cat output-1 > ../output
+    working-directory: wd
+
+


### PR DESCRIPTION
Under some situations clang will emit relative paths for included
dependencies. This changes 'shell' commands that use makefile-style
deps files to attempt to make dependecy paths absolute before generating
the node key.

rdar://problem/44463222