### PR TITLE
Update manifest version to 5.0

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,13 +1,7 @@
-// swift-tools-version:4.0
+// swift-tools-version:5.0
 
 // This file defines Swift package manager support for llbuild. See:
 //  https://github.com/apple/swift-package-manager/tree/master/Documentation
-//
-// You can build using:
-//
-// ```shell
-// swift build -Xlinker -lsqlite3 -Xlinker -lncurses $(utils/generate-version-h.sh)
-// ```
 
 import PackageDescription
 
@@ -61,7 +55,8 @@ let package = Package(
         .target(
             name: "llbuildCore",
             dependencies: ["llbuildBasic"],
-            path: "lib/Core"
+            path: "lib/Core",
+            linkerSettings: [.linkedLibrary("sqlite3")]
         ),
         .target(
             name: "llbuildBuildSystem",
@@ -117,7 +112,8 @@ let package = Package(
 
         .target(
             name: "llvmSupport",
-            path: "lib/llvm/Support"
+            path: "lib/llvm/Support",
+            linkerSettings: [.linkedLibrary("ncurses")]
         ),
     ],
     cxxLanguageStandard: .cxx14

--- a/products/libllbuild/include/module.modulemap
+++ b/products/libllbuild/include/module.modulemap
@@ -1,9 +1,3 @@
 module "llbuild" {
   umbrella header "llbuild/llbuild.h"
-
-  // Hack: This allows the clients to autolink these system libraries when
-  // building using SwiftPM. We should declare this in the Package.swift
-  // manifest file once SwiftPM exposes an API for it.
-  link "sqlite3"
-  link "ncurses"
 }


### PR DESCRIPTION
This allows us to use the latest build settings API for linking the
required libraries.