### PR TITLE
Reimplement Hashable with hash(into:)

### DIFF
--- a/products/llbuildSwift/BuildSystemBindings.swift
+++ b/products/llbuildSwift/BuildSystemBindings.swift
@@ -233,8 +233,8 @@ public struct Command: Hashable, CustomStringConvertible, CustomDebugStringConve
         return verboseDescription
     }
 
-    public var hashValue: Int {
-        return handle!.hashValue
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(handle!)
     }
 
     public static func ==(lhs: Command, rhs: Command) -> Bool {

--- a/products/llbuildSwift/CoreBindings.swift
+++ b/products/llbuildSwift/CoreBindings.swift
@@ -53,13 +53,8 @@ public struct Key: CustomStringConvertible, Equatable, Hashable {
 
     // MARK: Hashable Conformance
 
-    public var hashValue: Int {
-        // FIXME: Use a real hash function.
-        var result = data.count
-        for c in data {
-            result = result*31 + Int(c)
-        }
-        return result
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(data)
     }
 
     // MARK: Implementation


### PR DESCRIPTION
Resolves a FIX to use a real hash function.