### PR TITLE
Remove reference to removed generate-version-h.sh

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -6,7 +6,7 @@
 // You can build using:
 //
 // ```shell
-// swift build -Xlinker -lsqlite3 -Xlinker -lncurses $(utils/generate-version-h.sh)
+// swift build -Xlinker -lsqlite3 -Xlinker -lncurses
 // ```
 
 import PackageDescription


### PR DESCRIPTION
In b5e8c9c508bed41a37c3896c8550aefe05cebc10 the version.h generation
script was removed but it is still instructed in the Package.swift
file to use that, which causes

```
    no such file or directory: utils/generate-version-h.sh
```

to be printed when executing the command.