### PR TITLE
[tests] Add ninja test that outputs to nonexistent subdir

### DIFF
--- a/tests/Ninja/Build/nonexistent-subdir.ninja
+++ b/tests/Ninja/Build/nonexistent-subdir.ninja
@@ -1,0 +1,20 @@
+# Check that outputs to not yet existing directories works fine
+
+# We run the build in a sandbox in the temp directory to ensure we don't
+# interact with the source dirs.
+
+# This test currently fails even though this works fine with
+# upstream Ninja, see SR-9735
+
+# XFAIL: *
+# RUN: rm -rf %t.build
+# RUN: mkdir -p %t.build
+# RUN: cp %s %t.build/build.ninja
+# RUN: touch %t.build/input
+# RUN: %{llbuild} ninja build --jobs 1 --no-db --chdir %t.build &> %t.out
+# RUN: %{FileCheck} < %t.out %s
+
+rule CAT
+     command = cat ${in} > ${out}
+
+build subdir/output: CAT input


### PR DESCRIPTION
This is an attempt to add a test for [SR-9735](https://bugs.swift.org/browse/SR-9735), until the bug is fixed it is supposed to fail with llbuild but succeed with the "real" Ninja.

I could not figure out how to actually run these tests so I just tried to deduce how to write these tests by looking at the existing tests.