### PR TITLE
Make it a little easier to find FileCheck via Homebrew

### DIFF
--- a/utils/Xcode/create-lit-site-cfg.sh
+++ b/utils/Xcode/create-lit-site-cfg.sh
@@ -3,7 +3,7 @@
 set -e
 
 # Amend PATH with known location of LLVM tools
-BREW="$(which brew || true)"
+BREW="$(PATH="$PATH:/usr/local/bin" which brew || true)"
 if [ -n "${BREW}" ]; then
     PATH="$PATH:`${BREW} --prefix`/opt/llvm/bin"
 fi


### PR DESCRIPTION
...by falling back to adding the default Homebrew install path as a
search path. Xcode won't see /usr/local/bin when added to PATH via
.profile.