### PR TITLE
[llbuildSwift] Replace hashValue with hash(into:)

### DIFF
--- a/products/llbuildSwift/BuildSystemBindings.swift
+++ b/products/llbuildSwift/BuildSystemBindings.swift
@@ -252,8 +252,8 @@ public struct ProcessHandle: Hashable {
         self.handle = handle
     }
 
-    public var hashValue: Int {
-        return handle.hashValue
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(handle.hashValue)
     }
 
     public static func ==(lhs: ProcessHandle, rhs: ProcessHandle) -> Bool {


### PR DESCRIPTION
Fixes the deprecation warning and this change is source compatible with Swift 4.2