### PR TITLE
Revert "Fixed the Unit Tests on Windows"

### DIFF
--- a/docs/buildsystem.rst
+++ b/docs/buildsystem.rst
@@ -437,7 +437,7 @@ Symlink Tool
 This tool is used to create a symbolic link at a particular location, with
 appropriate dependency tracking. Due to the nature of symbolic links it is
 important to use this tool when creating links during a build, as opposed to the
-usual `shell` tool. The reason why is that the build system will, by default,
+usuall `shell` tool. The reason why is that the build system will, by default,
 use `stat(2)` to examine the contents of output files for the purposes of
 evaluating the build state. In the case of a symbolic link this is incorrect, as
 it will retrieve the status information of the target, not the link itself. This

--- a/include/llbuild/Basic/PlatformUtility.h
+++ b/include/llbuild/Basic/PlatformUtility.h
@@ -47,9 +47,6 @@ char *strsep(char **stringp, const char *delim);
 // it's path.
 std::string makeTmpDir();
 
-// Return a string containing all valid path separators on the current platform
-std::string getPathSeparators();
-
 /// Sets the max open file limit to min(max(soft_limit, limit), hard_limit),
 /// where soft_limit and hard_limit are gathered from the system.
 ///

--- a/lib/Basic/FileSystem.cpp
+++ b/lib/Basic/FileSystem.cpp
@@ -171,17 +171,10 @@ public:
       return true;
     }
 
-#if defined(_WIN32)
-    // Windows sets EACCES if the file is a directory
-    if (errno != EACCES) {
-      return false;
-    }
-#else
     // Error can't be that `path` is actually a directory (on Linux `EISDIR` will be returned since 2.1.132).
     if (errno != EPERM && errno != EISDIR) {
       return false;
     }
-#endif
 
     // Check if `path` is a directory.
     llbuild::basic::sys::StatStruct statbuf;

--- a/lib/Basic/Subprocess.cpp
+++ b/lib/Basic/Subprocess.cpp
@@ -285,10 +285,11 @@ static void cleanUpExecutedProcess(ProcessDelegate& delegate,
   FILETIME stimeTicks;
   int waitResult = WaitForSingleObject(pid, INFINITE);
   int err = GetLastError();
-  DWORD exitCode = 0;
+  DWORD exitCode;
   GetExitCodeProcess(pid, &exitCode);
 
-  if (waitResult == WAIT_FAILED || waitResult == WAIT_ABANDONED) {
+  if (exitCode != 0 || waitResult == WAIT_FAILED ||
+      waitResult == WAIT_ABANDONED) {
     auto result = ProcessResult::makeFailed(exitCode);
     delegate.processHadError(ctx, handle,
                              Twine("unable to wait for process (") +
@@ -297,25 +298,6 @@ static void cleanUpExecutedProcess(ProcessDelegate& delegate,
     completionFn(result);
     return;
   }
-#else
-  // Wait for the command to complete.
-  struct rusage usage;
-  int exitCode, result = wait4(pid, &exitCode, 0, &usage);
-  while (result == -1 && errno == EINTR)
-    result = wait4(pid, &exitCode, 0, &usage);
-#endif
-  // Close the release pipe
-  //
-  // Note: We purposely hold this open until after the process has finished as
-  // it simplifies client implentation. If we close it early, clients need to be
-  // aware of and potentially handle a SIGPIPE.
-  if (releaseFd >= 0) {
-    sys::FileDescriptorTraits<>::Close(releaseFd);
-  }
-
-  // Update the set of spawned processes.
-  pgrp.remove(pid);
-#if defined(_WIN32)
   PROCESS_MEMORY_COUNTERS counters;
   bool res =
       GetProcessTimes(pid, &creationTime, &exitTime, &stimeTicks, &utimeTicks);
@@ -335,6 +317,9 @@ static void cleanUpExecutedProcess(ProcessDelegate& delegate,
       ((uint64_t)stimeTicks.dwHighDateTime << 32 | stimeTicks.dwLowDateTime) /
       10;
   GetProcessMemoryInfo(pid, &counters, sizeof(counters));
+  sys::FileDescriptorTraits<>::Close(releaseFd);
+
+  pgrp.remove(pid);
 
   // We report additional info in the tracing interval
   //   - user time, in µs
@@ -345,16 +330,32 @@ static void cleanUpExecutedProcess(ProcessDelegate& delegate,
   // subprocess (probably as a new point sample).
 
   // Notify of the process completion.
-  ProcessStatus processStatus =
-      (exitCode == 0) ? ProcessStatus::Succeeded : ProcessStatus::Failed;
+  ProcessStatus processStatus = ProcessStatus::Succeeded;
   ProcessResult processResult(processStatus, exitCode, pid, utime, stime,
                               counters.PeakWorkingSetSize);
 #else  // !defined(_WIN32)
+  // Wait for the command to complete.
+  struct rusage usage;
+  int exitCode, result = wait4(pid, &exitCode, 0, &usage);
+  while (result == -1 && errno == EINTR)
+    result = wait4(pid, &exitCode, 0, &usage);
+
+  // Close the release pipe
+  //
+  // Note: We purposely hold this open until after the process has finished as
+  // it simplifies client implentation. If we close it early, clients need to be
+  // aware of and potentially handle a SIGPIPE.
+  if (releaseFd >= 0) {
+    sys::FileDescriptorTraits<>::Close(releaseFd);
+  }
+
+  // Update the set of spawned processes.
+  pgrp.remove(pid);
+
   if (result == -1) {
     auto result = ProcessResult::makeFailed(exitCode);
     delegate.processHadError(ctx, handle,
-                             Twine("unable to wait for process (") +
-                                 strerror(errno) + ")");
+                             Twine("unable to wait for process (") + strerror(errno) + ")");
     delegate.processFinished(ctx, handle, result);
     completionFn(result);
     return;
@@ -438,8 +439,8 @@ void llbuild::basic::spawnProcess(
   startupInfo.dwFlags = STARTF_USESTDHANDLES;
   // Set NUL as stdin
   HANDLE nul =
-      CreateFileW(L"NUL", GENERIC_READ, FILE_SHARE_READ | FILE_SHARE_WRITE,
-                  NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
+      CreateFileA("NUL", GENERIC_READ, FILE_SHARE_READ | FILE_SHARE_WRITE, NULL,
+                  OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
   startupInfo.hStdInput = nul;
 #else
   // Initialize the spawn attributes.

--- a/unittests/Basic/FileSystemTest.cpp
+++ b/unittests/Basic/FileSystemTest.cpp
@@ -40,7 +40,7 @@ TEST(FileSystemTest, basic) {
     std::error_code ec;
     llvm::raw_fd_ostream os(tempPath.str(), ec, llvm::sys::fs::F_Text);
     EXPECT_FALSE(ec);
-    os << "Hello, world!";
+    os << "Hello, world!\n";
     os.close();
   }
 
@@ -54,7 +54,7 @@ TEST(FileSystemTest, basic) {
   EXPECT_EQ(missingFileContents.get(), nullptr);
 
   auto ourFileContents = fs->getFileContents(tempPath.str());
-  EXPECT_EQ(ourFileContents->getBuffer().str(), "Hello, world!");
+  EXPECT_EQ(ourFileContents->getBuffer().str(), "Hello, world!\n");
 
   // Remote the temporary file.
   auto ec = llvm::sys::fs::remove(tempPath.str());
@@ -62,7 +62,7 @@ TEST(FileSystemTest, basic) {
 }
 
 TEST(FileSystemTest, testRecursiveRemoval) {
-  TmpDir rootTempDir(__func__);
+  TmpDir rootTempDir{ __FUNCTION__ };
 
   SmallString<256> tempDir { rootTempDir.str() };
   llvm::sys::path::append(tempDir, "root");
@@ -74,7 +74,7 @@ TEST(FileSystemTest, testRecursiveRemoval) {
     std::error_code ec;
     llvm::raw_fd_ostream os(file.str(), ec, llvm::sys::fs::F_Text);
     EXPECT_FALSE(ec);
-    os << "Hello, world!";
+    os << "Hello, world!\n";
     os.close();
   }
 
@@ -87,7 +87,7 @@ TEST(FileSystemTest, testRecursiveRemoval) {
     std::error_code ec;
     llvm::raw_fd_ostream os(dir.str(), ec, llvm::sys::fs::F_Text);
     EXPECT_FALSE(ec);
-    os << "Hello, world!";
+    os << "Hello, world!\n";
     os.close();
   }
 
@@ -101,7 +101,7 @@ TEST(FileSystemTest, testRecursiveRemoval) {
 }
 
 TEST(FileSystemTest, testRecursiveRemovalDoesNotFollowSymlinks) {
-  TmpDir rootTempDir(__func__);
+  TmpDir rootTempDir{ __FUNCTION__ };
 
   SmallString<256> file{ rootTempDir.str() };
   llvm::sys::path::append(file, "test.txt");
@@ -109,7 +109,7 @@ TEST(FileSystemTest, testRecursiveRemovalDoesNotFollowSymlinks) {
     std::error_code ec;
     llvm::raw_fd_ostream os(file.str(), ec, llvm::sys::fs::F_Text);
     EXPECT_FALSE(ec);
-    os << "Hello, world!";
+    os << "Hello, world!\n";
     os.close();
   }
 
@@ -123,7 +123,7 @@ TEST(FileSystemTest, testRecursiveRemovalDoesNotFollowSymlinks) {
     std::error_code ec;
     llvm::raw_fd_ostream os(otherFile.str(), ec, llvm::sys::fs::F_Text);
     EXPECT_FALSE(ec);
-    os << "Hello, world!";
+    os << "Hello, world!\n";
     os.close();
   }
 
@@ -165,7 +165,7 @@ TEST(DeviceAgnosticFileSystemTest, basic) {
     std::error_code ec;
     llvm::raw_fd_ostream os(tempPath.str(), ec, llvm::sys::fs::F_Text);
     EXPECT_FALSE(ec);
-    os << "Hello, world!";
+    os << "Hello, world!\n";
     os.close();
   }
 
@@ -182,7 +182,8 @@ TEST(DeviceAgnosticFileSystemTest, basic) {
   EXPECT_EQ(missingFileContents.get(), nullptr);
 
   auto ourFileContents = fs->getFileContents(tempPath.str());
-  EXPECT_EQ(ourFileContents->getBuffer().str(), "Hello, world!");
+  EXPECT_EQ(ourFileContents->getBuffer().str(), "Hello, world!\n");
+
   // Remote the temporary file.
   auto ec = llvm::sys::fs::remove(tempPath.str());
   EXPECT_FALSE(ec);

--- a/unittests/BuildSystem/BuildSystemFrontendTest.cpp
+++ b/unittests/BuildSystem/BuildSystemFrontendTest.cpp
@@ -118,7 +118,7 @@ public:
   virtual void hadCommandFailure() override {
     {
       std::lock_guard<std::mutex> lock(traceMutex);
-      traceStream << __func__ << "\n";
+      traceStream << __FUNCTION__ << "\n";
     }
     super::hadCommandFailure();
   }
@@ -126,7 +126,7 @@ public:
   virtual void commandPreparing(Command* command) override {
     {
       std::lock_guard<std::mutex> lock(traceMutex);
-      traceStream << __func__ << ": " << command->getName() << "\n";
+      traceStream << __FUNCTION__ << ": " << command->getName() << "\n";
     }
     super::commandPreparing(command);
   }
@@ -134,7 +134,7 @@ public:
   virtual bool shouldCommandStart(Command* command) override {
     {
       std::lock_guard<std::mutex> lock(traceMutex);
-      traceStream << __func__ << ": " << command->getName() << "\n";
+      traceStream << __FUNCTION__ << ": " << command->getName() << "\n";
     }
 
     if (commandsToSkip.find(command->getName()) != commandsToSkip.end()) {
@@ -147,7 +147,7 @@ public:
   virtual void commandStarted(Command* command) override {
     {
       std::lock_guard<std::mutex> lock(traceMutex);
-      traceStream << __func__ << ": " << command->getName() << "\n";
+      traceStream << __FUNCTION__ << ": " << command->getName() << "\n";
     }
     super::commandStarted(command);
   }
@@ -155,8 +155,7 @@ public:
   virtual void commandFinished(Command* command, ProcessStatus result) override {
     {
       std::lock_guard<std::mutex> lock(traceMutex);
-      traceStream << __func__ << ": " << command->getName() << ": "
-                  << (int)result << "\n";
+      traceStream << __FUNCTION__ << ": " << command->getName() << ": " << (int)result << "\n";
     }
     super::commandFinished(command, result);
   }
@@ -164,7 +163,7 @@ public:
   virtual void commandProcessStarted(Command* command, ProcessHandle handle) override {
     {
       std::lock_guard<std::mutex> lock(traceMutex);
-      traceStream << __func__ << ": " << command->getName() << "\n";
+      traceStream << __FUNCTION__ << ": " << command->getName() << "\n";
     }
     super::commandProcessStarted(command, handle);
   }
@@ -173,8 +172,7 @@ public:
                                       const Twine& message) override {
     {
       std::lock_guard<std::mutex> lock(traceMutex);
-      traceStream << __func__ << ": " << command->getName() << ": " << message
-                  << "\n";
+      traceStream << __FUNCTION__ << ": " << command->getName() << ": " << message << "\n";
     }
     super::commandProcessHadError(command, handle, message);
   }
@@ -183,7 +181,7 @@ public:
                                       const ProcessResult& result) override {
     {
         std::lock_guard<std::mutex> lock(traceMutex);
-        traceStream << __func__ << ": " << command->getName() << ": "
+        traceStream << __FUNCTION__ << ": " << command->getName() << ": "
                     << result.exitCode << "\n";
     }
     super::commandProcessFinished(command, handle, result);
@@ -197,7 +195,7 @@ public:
 
   virtual void error(StringRef filename, const Token& at, const Twine& message) override {
     std::lock_guard<std::mutex> lock(traceMutex);
-    traceStream << __func__ << ": " << message << "\n";
+    traceStream << __FUNCTION__ << ": " << message << "\n";
   }
 };
 
@@ -345,20 +343,6 @@ commands:
     ASSERT_FALSE(frontend.build(""));
     ASSERT_EQ(1u, delegate.getNumFailedCommands());
 
-#if defined(_WIN32)
-    ASSERT_TRUE(delegate.checkTrace(R"END(
-commandPreparing: 2
-commandPreparing: 1
-shouldCommandStart: 1
-commandFinished: 1: 3
-shouldCommandStart: 2
-commandStarted: 2
-commandProcessStarted: 2
-commandProcessFinished: 2: 1
-commandFinished: 2: 1
-hadCommandFailure
-)END"));
-#else
     ASSERT_TRUE(delegate.checkTrace(R"END(
 commandPreparing: 2
 commandPreparing: 1
@@ -371,7 +355,7 @@ commandProcessFinished: 2: 256
 commandFinished: 2: 1
 hadCommandFailure
 )END"));
-#endif
+
     ASSERT_TRUE(fs->getFileInfo(tempDir.str() + "/1").isMissing());
     ASSERT_TRUE(fs->getFileInfo(tempDir.str() + "/2").isMissing());
   }
@@ -465,13 +449,8 @@ commands:
         tool: shell
         inputs: ["2"]
         outputs: ["3"]
-)END" +
-#if defined(_WIN32)
-                 std::string("        args: del 2")
-#else
-                 std::string("        args: rm 2")
-#endif
-  );
+        args: rm 2
+)END");
   // We need to delete the symlink ourselves, because llvm's remove()
   // currently refuses to delete symlinks.
 

--- a/unittests/BuildSystem/BuildSystemTaskTests.cpp
+++ b/unittests/BuildSystem/BuildSystemTaskTests.cpp
@@ -120,7 +120,7 @@ public:
 
 /// Check that we evaluate a path key properly.
 TEST(BuildSystemTaskTests, basics) {
-  TmpDir tempDir(__func__);
+  TmpDir tempDir{ __FUNCTION__ };
 
   // Create a sample file.
   SmallString<256> path{ tempDir.str() };
@@ -148,7 +148,7 @@ TEST(BuildSystemTaskTests, basics) {
 
 /// Check that we evaluate a missing input path key properly.
 TEST(BuildSystemTaskTests, missingInput) {
-  TmpDir tempDir(__func__);
+  TmpDir tempDir{ __FUNCTION__ };
 
   // Create a non-existent sample file path.
   SmallString<256> path{ tempDir.str() };
@@ -169,7 +169,7 @@ TEST(BuildSystemTaskTests, missingInput) {
 
 /// Check the evaluation of directory contents.
 TEST(BuildSystemTaskTests, directoryContents) {
-  TmpDir tempDir(__func__);
+  TmpDir tempDir{ __FUNCTION__ };
 
   // Create a directory with sample files.
   SmallString<256> fileA{ tempDir.str() };
@@ -215,23 +215,14 @@ TEST(BuildSystemTaskTests, directoryContents) {
 
 /// Check that we evaluate a produced node dependency properly
 TEST(BuildSystemTaskTests, producedNode) {
-  TmpDir tempDir(__func__);
-
+  TmpDir tempDir{ __FUNCTION__ };
   auto localFS = createLocalFileSystem();
 
   // Create a outputFile path
   SmallString<256> outputFile{ tempDir.str() };
   sys::path::append(outputFile, "a.txt");
-  for (auto& c : outputFile) {
-    if (c == '\\')
-      c = '/';
-  }
 
   SmallString<256> manifest{ tempDir.str() };
-  for (auto& c : manifest) {
-    if (c == '\\')
-      c = '/';
-  }
   sys::path::append(manifest, "manifest.llbuild");
   {
     std::error_code ec;
@@ -284,7 +275,7 @@ TEST(BuildSystemTaskTests, producedNode) {
 
 /// Check the evaluation of directory signatures.
 TEST(BuildSystemTaskTests, directorySignature) {
-  TmpDir tempDir(__func__);
+  TmpDir tempDir{ __FUNCTION__ };
   auto localFS = createLocalFileSystem();
   
   // Create a directory with sample files.
@@ -370,13 +361,9 @@ TEST(BuildSystemTaskTests, directorySignature) {
 }
 
 TEST(BuildSystemTaskTests, doesNotProcessDependenciesAfterCancellation) {
-  TmpDir tempDir(__func__);
+  TmpDir tempDir{ __FUNCTION__ };
 
   std::string outputFile = tempDir.str() + "/output.txt";
-  for (auto& c : outputFile) {
-    if (c == '\\')
-      c = '/';
-  }
 
   SmallString<256> manifest{ tempDir.str() };
   sys::path::append(manifest, "manifest.llbuild");
@@ -437,7 +424,7 @@ TEST(BuildSystemTaskTests, doesNotProcessDependenciesAfterCancellation) {
 TEST(BuildSystemTaskTests, cancelAllInQueue) {
 // Disabled: <rdar://problem/32142112> BuildSystem/BuildSystemTests/BuildSystemTaskTests.cancelAllInQueue FAILED
 #ifdef false
-  TmpDir tempDir(__func__);
+  TmpDir tempDir{ __FUNCTION__ };
 
   SmallString<256> manifest{ tempDir.str() };
   sys::path::append(manifest, "manifest.llbuild");
@@ -502,7 +489,7 @@ commands:
 
 // Tests the behaviour of StaleFileRemovalTool
 TEST(BuildSystemTaskTests, staleFileRemoval) {
-  TmpDir tempDir(__func__);
+  TmpDir tempDir{ __FUNCTION__ };
 
   SmallString<256> manifest{ tempDir.str() };
   sys::path::append(manifest, "manifest.llbuild");
@@ -592,7 +579,7 @@ commands:
 }
 
 TEST(BuildSystemTaskTests, staleFileRemovalWithRoots) {
-  TmpDir tempDir(__func__);
+  TmpDir tempDir{ __FUNCTION__ };
 
   SmallString<256> manifest{ tempDir.str() };
   sys::path::append(manifest, "manifest.llbuild");
@@ -690,7 +677,7 @@ commands:
 }
 
 TEST(BuildSystemTaskTests, staleFileRemovalWithRootsEnforcesAbsolutePaths) {
-  TmpDir tempDir(__func__);
+  TmpDir tempDir{ __FUNCTION__ };
 
   SmallString<256> manifest{ tempDir.str() };
   sys::path::append(manifest, "manifest.llbuild");
@@ -777,7 +764,7 @@ commands:
 }
 
 TEST(BuildSystemTaskTests, staleFileRemovalWithRootsIsAgnosticToTrailingPathSeparator) {
-  TmpDir tempDir(__func__);
+  TmpDir tempDir{ __FUNCTION__ };
 
   SmallString<256> manifest{ tempDir.str() };
   sys::path::append(manifest, "manifest.llbuild");
@@ -872,7 +859,7 @@ commands:
 }
 
 TEST(BuildSystemTaskTests, staleFileRemovalWithManyFiles) {
-  TmpDir tempDir(__func__);
+  TmpDir tempDir{ __FUNCTION__ };
 
   SmallString<256> manifest{ tempDir.str() };
   sys::path::append(manifest, "manifest.llbuild");
@@ -988,22 +975,14 @@ TEST(BuildSystemTaskTests, staleFileRemovalPathIsPrefixedByPath) {
 /// Check that we evaluate properly handle a previously missing input that may
 /// now be produced.
 TEST(BuildSystemTaskTests, producedNodeAfterPreviouslyMissing) {
-  TmpDir tempDir(__func__);
+  TmpDir tempDir{ __FUNCTION__ };
   auto localFS = createLocalFileSystem();
 
   SmallString<256> builddb{ tempDir.str() };
   sys::path::append(builddb, "build.db");
-  for (auto& c : builddb) {
-    if (c == '\\')
-      c = '/';
-  }
 
   SmallString<256> outputFile{ tempDir.str() };
   sys::path::append(outputFile, "a.txt");
-  for (auto& c : outputFile) {
-    if (c == '\\')
-      c = '/';
-  }
 
   // Try to build the missing output file
   {

--- a/unittests/BuildSystem/TempDir.cpp
+++ b/unittests/BuildSystem/TempDir.cpp
@@ -13,47 +13,27 @@
 #include "TempDir.h"
 
 #include "llbuild/Basic/FileSystem.h"
-#include "llbuild/Basic/PlatformUtility.h"
 
 #include "llvm/Support/FileSystem.h"
 #include "llvm/Support/Path.h"
 #include "llvm/Support/SourceMgr.h"
 
-#if defined(_WIN32)
-#include "llvm/Support/ConvertUTF.h"
-#include <windows.h>
-#endif
-
 llbuild::TmpDir::TmpDir(llvm::StringRef namePrefix) {
-  llvm::SmallString<256> tempDirPrefix;
-  llvm::sys::path::system_temp_directory(true, tempDirPrefix);
-  llvm::sys::path::append(tempDirPrefix, namePrefix);
+    llvm::SmallString<256> tempDirPrefix;
+    llvm::sys::path::system_temp_directory(true, tempDirPrefix);
+    llvm::sys::path::append(tempDirPrefix, namePrefix);
 
-  std::error_code ec =
-      llvm::sys::fs::createUniqueDirectory(tempDirPrefix.str(), tempDir);
-  assert(!ec);
-  (void)ec;
+    std::error_code ec = llvm::sys::fs::createUniqueDirectory(
+        tempDirPrefix.str(), tempDir);
+    assert(!ec);
+    (void)ec;
 }
 
 llbuild::TmpDir::~TmpDir() {
-#if defined(_WIN32)
-  // On windows you can't delete a directory is it's your current working
-  // directory. So if we're in the directory we're trying to delete, move out
-  // of it first.
-  wchar_t wCurrPath[MAX_PATH];
-  GetCurrentDirectoryW(MAX_PATH, wCurrPath);
-  llvm::SmallVector<UTF16, 20> wTmpPath;
-  llvm::convertUTF8ToUTF16String(str(), wTmpPath);
-  if (lstrcmpW(wCurrPath, (LPCWSTR)wTmpPath.data()) == 0) {
-    std::string currPath = str();
-    StringRef parent = llvm::sys::path::parent_path(currPath);
-    llbuild::basic::sys::chdir(parent.str().c_str());
-  }
-#endif
-  auto fs = basic::createLocalFileSystem();
-  bool result = fs->remove(tempDir.c_str());
-  assert(result);
-  (void)result;
+    auto fs = basic::createLocalFileSystem();
+    bool result = fs->remove(tempDir.c_str());
+    assert(result);
+    (void)result;
 }
 
 const char *llbuild::TmpDir::c_str() { return tempDir.c_str(); }

--- a/unittests/CAPI/BuildSystem-C-API.cpp
+++ b/unittests/CAPI/BuildSystem-C-API.cpp
@@ -257,11 +257,7 @@ static void command_process_finished(void* context,
 
 TEST(BuildSystemCAPI, CustomToolWithDiscoveredDependencies) {
   std::string tmpDirPath = llbuild::basic::sys::makeTmpDir();
-  for (auto& c : tmpDirPath) {
-    if (c == '\\') {
-      c = '/';
-    }
-  }
+
   // We write out an indirectly referenced file containing data to be copied to
   // the output file.
   std::string indirectInputFilePath = tmpDirPath + "/" + "indirect-input-file";


### PR DESCRIPTION
Reverts apple/swift-llbuild#422

Broke Swift-CI:

`
11:08:12 /usr/bin/clang++    -I/home/buildnode/jenkins/workspace/oss-swift-5.0-incremental-RA-linux-ubuntu-14_04-long-test/llbuild/include -std=c++14 -fno-rtti -fno-exceptions -Wmost -Wdocumentation  -Woverloaded-virtual -Wparentheses -Wswitch -Wunused-function -Wunused-variable -Wunused-value -Wempty-body -Wuninitialized -Wconstant-conversion -Wint-conversion -Wbool-conversion -Wenum-conversion -Wsign-compare -Wnewline-eof -Wdeprecated-declarations -Winvalid-offsetof -Wnon-virtual-dtor -Wimplicit-fallthrough -fPIC -include "/home/buildnode/jenkins/workspace/oss-swift-5.0-incremental-RA-linux-ubuntu-14_04-long-test/llbuild/include/libstdc++14-workaround.h" -Wdocumentation -Wimplicit-fallthrough -Wunreachable-code -Woverloaded-virtual -O3 -MMD -MT lib/BuildSystem/CMakeFiles/llbuildBuildSystem.dir/BuildSystem.cpp.o -MF lib/BuildSystem/CMakeFiles/llbuildBuildSystem.dir/BuildSystem.cpp.o.d -o lib/BuildSystem/CMakeFiles/llbuildBuildSystem.dir/BuildSystem.cpp.o -c /home/buildnode/jenkins/workspace/oss-swift-5.0-incremental-RA-linux-ubuntu-14_04-long-test/llbuild/lib/BuildSystem/BuildSystem.cpp
11:08:12 In file included from /home/buildnode/jenkins/workspace/oss-swift-5.0-incremental-RA-linux-ubuntu-14_04-long-test/llbuild/lib/BuildSystem/BuildSystem.cpp:13:
11:08:12 In file included from /home/buildnode/jenkins/workspace/oss-swift-5.0-incremental-RA-linux-ubuntu-14_04-long-test/llbuild/include/llbuild/BuildSystem/BuildSystem.h:18:
11:08:12 In file included from /home/buildnode/jenkins/workspace/oss-swift-5.0-incremental-RA-linux-ubuntu-14_04-long-test/llbuild/include/llbuild/Basic/Subprocess.h:19:
11:08:12 In file included from /home/buildnode/jenkins/workspace/oss-swift-5.0-incremental-RA-linux-ubuntu-14_04-long-test/llbuild/include/llbuild/Basic/POSIXEnvironment.h:18:
11:08:12 In file included from /home/buildnode/jenkins/workspace/oss-swift-5.0-incremental-RA-linux-ubuntu-14_04-long-test/llbuild/include/llvm/ADT/SmallString.h:17:
11:08:12 In file included from /home/buildnode/jenkins/workspace/oss-swift-5.0-incremental-RA-linux-ubuntu-14_04-long-test/llbuild/include/llvm/ADT/SmallVector.h:22:
11:08:12 In file included from /usr/bin/../lib/gcc/x86_64-linux-gnu/4.8/../../../../include/c++/4.8/algorithm:61:
11:08:12 
/usr/bin/../lib/gcc/x86_64-linux-gnu/4.8/../../../../include/c++/4.8/bits/stl_algobase.h:1206:42: error: type '__gnu_cxx::__normal_iterator<char *, std::basic_string<char> >' does not provide a call operator
11:08:12       while (__first1 != __last1 && bool(__binary_pred(*__first1, *__first2)))
11:08:12                                          ^~~~~~~~~~~~~
11:08:12 /home/buildnode/jenkins/workspace/oss-swift-5.0-incremental-RA-linux-ubuntu-14_04-long-test/llbuild/lib/BuildSystem/BuildSystem.cpp:4017:19: note: in instantiation of function template specialization 'std::mismatch<__gnu_cxx::__normal_iterator<char *, std::basic_string<char> >, __gnu_cxx::__normal_iterator<char *, std::basic_string<char> >, __gnu_cxx::__normal_iterator<char *, std::basic_string<char> > >' requested here
11:08:12   auto res = std::mismatch(prefixPath.begin(), prefixPath.end(), path.begin(),
11:08:12                   ^
11:08:12 1 error generated.
`