### PR TITLE
Fix the Unit Tests on Windows [Fixed Mismatch]

### DIFF
--- a/docs/buildsystem.rst
+++ b/docs/buildsystem.rst
@@ -437,7 +437,7 @@ Symlink Tool
 This tool is used to create a symbolic link at a particular location, with
 appropriate dependency tracking. Due to the nature of symbolic links it is
 important to use this tool when creating links during a build, as opposed to the
-usuall `shell` tool. The reason why is that the build system will, by default,
+usual `shell` tool. The reason why is that the build system will, by default,
 use `stat(2)` to examine the contents of output files for the purposes of
 evaluating the build state. In the case of a symbolic link this is incorrect, as
 it will retrieve the status information of the target, not the link itself. This

--- a/include/llbuild/Basic/PlatformUtility.h
+++ b/include/llbuild/Basic/PlatformUtility.h
@@ -47,6 +47,9 @@ char *strsep(char **stringp, const char *delim);
 // it's path.
 std::string makeTmpDir();
 
+// Return a string containing all valid path separators on the current platform
+std::string getPathSeparators();
+
 /// Sets the max open file limit to min(max(soft_limit, limit), hard_limit),
 /// where soft_limit and hard_limit are gathered from the system.
 ///

--- a/lib/Basic/FileSystem.cpp
+++ b/lib/Basic/FileSystem.cpp
@@ -171,10 +171,17 @@ public:
       return true;
     }
 
+#if defined(_WIN32)
+    // Windows sets EACCES if the file is a directory
+    if (errno != EACCES) {
+      return false;
+    }
+#else
     // Error can't be that `path` is actually a directory (on Linux `EISDIR` will be returned since 2.1.132).
     if (errno != EPERM && errno != EISDIR) {
       return false;
     }
+#endif
 
     // Check if `path` is a directory.
     llbuild::basic::sys::StatStruct statbuf;

--- a/lib/Basic/PlatformUtility.cpp
+++ b/lib/Basic/PlatformUtility.cpp
@@ -11,12 +11,14 @@
 #include "llbuild/Basic/Stat.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/Support/ConvertUTF.h"
+#include "llvm/Support/Path.h"
 
 #if defined(_WIN32)
 #include "LeanWindows.h"
 #include <Shlwapi.h>
 #include <direct.h>
 #include <io.h>
+#include <time.h>
 #else
 #include <fnmatch.h>
 #include <unistd.h>
@@ -28,7 +30,9 @@ using namespace llbuild::basic;
 
 bool sys::chdir(const char *fileName) {
 #if defined(_WIN32)
-  return SetCurrentDirectoryA(fileName);
+  llvm::SmallVector<UTF16, 20> wFileName;
+  llvm::convertUTF8ToUTF16String(fileName, wFileName);
+  return SetCurrentDirectoryW((LPCWSTR)wFileName.data());
 #else
   return ::chdir(fileName) == 0;
 #endif
@@ -42,11 +46,68 @@ int sys::close(int fileHandle) {
 #endif
 }
 
+#if defined(_WIN32)
+time_t filetimeToTime_t(FILETIME ft) {
+  long long ltime = ft.dwLowDateTime | ((long long)ft.dwHighDateTime << 32);
+  return (time_t)((ltime - 116444736000000000) / 10000000);
+}
+#endif
+
 int sys::lstat(const char *fileName, sys::StatStruct *buf) {
 #if defined(_WIN32)
-  // We deliberately ignore lstat on Windows, and delegate
-  // to stat.
-  return ::_stat(fileName, buf);
+  llvm::SmallVector<UTF16, 20> wfilename;
+  llvm::convertUTF8ToUTF16String(fileName, wfilename);
+  HANDLE h = CreateFileW(
+      /*lpFileName=*/(LPCWSTR)wfilename.data(),
+      /*dwDesiredAccess=*/0,
+      /*dwShareMode=*/FILE_SHARE_READ,
+      /*lpSecurityAttributes=*/NULL,
+      /*dwCreationDisposition=*/OPEN_EXISTING,
+      /*dwFlagsAndAttributes=*/FILE_FLAG_OPEN_REPARSE_POINT |
+          FILE_FLAG_BACKUP_SEMANTICS,
+      /*hTemplateFile=*/NULL);
+  if (h == INVALID_HANDLE_VALUE) {
+    int err = GetLastError();
+    if (err == ERROR_FILE_NOT_FOUND) {
+      errno = ENOENT;
+    }
+    return -1;
+  }
+  BY_HANDLE_FILE_INFORMATION info;
+  GetFileInformationByHandle(h, &info);
+  // Group id is always 0 on Windows
+  buf->st_gid = 0;
+  buf->st_atime = filetimeToTime_t(info.ftLastAccessTime);
+  buf->st_ctime = filetimeToTime_t(info.ftCreationTime);
+  buf->st_dev = info.dwVolumeSerialNumber;
+  // inodes have meaning on FAT/HPFS/NTFS
+  buf->st_ino = 0;
+  buf->st_rdev = info.dwVolumeSerialNumber;
+  buf->st_mode =
+      // On a symlink to a directory, Windows sets both the REPARSE_POINT and
+      // DIRECTORY attributes. Since Windows doesn't provide S_IFLNK and we
+      // want unix style "symlinks to directories are not directories
+      // themselves, we say symlinks are regular files
+      (info.dwFileAttributes & FILE_ATTRIBUTE_REPARSE_POINT)
+          ? _S_IFREG
+          : (info.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) ? _S_IFDIR
+                                                               : _S_IFREG;
+  buf->st_mode |= (info.dwFileAttributes & FILE_ATTRIBUTE_READONLY)
+                      ? _S_IREAD
+                      : _S_IREAD | _S_IWRITE;
+  llvm::StringRef extension =
+      llvm::sys::path::extension(llvm::StringRef(fileName));
+  if (extension == ".exe" || extension == ".cmd" || extension == ".bat" ||
+      extension == ".com") {
+    buf->st_mode |= _S_IEXEC;
+  }
+  buf->st_mtime = filetimeToTime_t(info.ftLastWriteTime);
+  buf->st_nlink = info.nNumberOfLinks;
+  buf->st_size = ((long long)info.nFileSizeHigh << 32) | info.nFileSizeLow;
+  // Uid is always 0 on Windows systems
+  buf->st_uid = 0;
+  CloseHandle(h);
+  return 0;
 #else
   return ::lstat(fileName, buf);
 #endif
@@ -109,17 +170,25 @@ int sys::stat(const char *fileName, StatStruct *buf) {
 #endif
 }
 
-int sys::symlink(const char *source, const char *target) {
+// Create a symlink named linkPath which contains the string pointsTo
+int sys::symlink(const char *pointsTo, const char *linkPath) {
 #if defined(_WIN32)
-  DWORD attributes = GetFileAttributesA(source);
-  if (attributes != INVALID_FILE_ATTRIBUTES &&
-      (attributes & FILE_ATTRIBUTE_DIRECTORY) != 0) {
-    return ::CreateSymbolicLinkA(source, target, SYMBOLIC_LINK_FLAG_DIRECTORY);
-  }
-
-  return ::CreateSymbolicLinkA(source, target, 0);
+  llvm::SmallVector<UTF16, 20> wPointsTo;
+  llvm::convertUTF8ToUTF16String(pointsTo, wPointsTo);
+  llvm::SmallVector<UTF16, 20> wLinkPath;
+  llvm::convertUTF8ToUTF16String(linkPath, wLinkPath);
+  DWORD attributes = GetFileAttributesW((LPCWSTR)wPointsTo.data());
+  DWORD directoryFlag = (attributes != INVALID_FILE_ATTRIBUTES &&
+                         attributes & FILE_ATTRIBUTE_DIRECTORY)
+                            ? SYMBOLIC_LINK_FLAG_DIRECTORY
+                            : 0;
+  // Note that CreateSymbolicLinkW takes its arguments in reverse order
+  // compared to symlink/_symlink
+  return !::CreateSymbolicLinkW(
+      (LPCWSTR)wLinkPath.data(), (LPCWSTR)wPointsTo.data(),
+      SYMBOLIC_LINK_FLAG_ALLOW_UNPRIVILEGED_CREATE | directoryFlag);
 #else
-  return ::symlink(source, target);
+  return ::symlink(pointsTo, linkPath);
 #endif
 }
 
@@ -217,23 +286,29 @@ std::string sys::strerror(int error) {
 
 char *sys::strsep(char **stringp, const char *delim) {
 #if defined(_WIN32)
-  char *begin, *end = *stringp;
+  // If *stringp is NULL, the strsep() function returns NULL and does nothing
+  // else.
   if (*stringp == NULL) {
     return NULL;
   }
-  int delimLen = strlen(delim);
-  bool found = false;
-  while (*end) {
-    for (int i = 0; i < delimLen; i++) {
+  char *begin = *stringp;
+  char *end = *stringp;
+  do {
+    // Otherwise, this function finds the first token in the string *stringp,
+    // that is delimited by one of the bytes in the string delim.
+    for (int i = 0; delim[i] != '\0'; i++) {
       if (*end == delim[i]) {
-        found = true;
+        // This token is terminated by overwriting the delimiter with a null
+        // byte ('\0'), and *stringp is updated to point past the token.
+        *end = '\0';
+        *stringp = end + 1;
+        return begin;
       }
     }
-    if (found) {
-      *stringp = end + 1;
-    }
-  }
-  *end = '\0';
+  } while (*(++end));
+  // In case no delimiter was found, the token is taken to be the entire string
+  // *stringp, and *stringp is made NULL.
+  *stringp = NULL;
   return begin;
 #else
   return ::strsep(stringp, delim);
@@ -244,9 +319,20 @@ std::string sys::makeTmpDir() {
 #if defined(_WIN32)
   char path[MAX_PATH];
   tmpnam_s(path, MAX_PATH);
+  llvm::SmallVector<UTF16, 20> wPath;
+  llvm::convertUTF8ToUTF16String(path, wPath);
+  CreateDirectoryW((LPCWSTR)wPath.data(), NULL);
   return std::string(path);
 #else
   char tmpDirPathBuf[] = "/tmp/fileXXXXXX";
   return std::string(mkdtemp(tmpDirPathBuf));
+#endif
+}
+
+std::string sys::getPathSeparators() {
+#if defined(_WIN32)
+  return "/\\";
+#else
+  return "/";
 #endif
 }

--- a/unittests/Basic/FileSystemTest.cpp
+++ b/unittests/Basic/FileSystemTest.cpp
@@ -40,7 +40,7 @@ TEST(FileSystemTest, basic) {
     std::error_code ec;
     llvm::raw_fd_ostream os(tempPath.str(), ec, llvm::sys::fs::F_Text);
     EXPECT_FALSE(ec);
-    os << "Hello, world!\n";
+    os << "Hello, world!";
     os.close();
   }
 
@@ -54,7 +54,7 @@ TEST(FileSystemTest, basic) {
   EXPECT_EQ(missingFileContents.get(), nullptr);
 
   auto ourFileContents = fs->getFileContents(tempPath.str());
-  EXPECT_EQ(ourFileContents->getBuffer().str(), "Hello, world!\n");
+  EXPECT_EQ(ourFileContents->getBuffer().str(), "Hello, world!");
 
   // Remote the temporary file.
   auto ec = llvm::sys::fs::remove(tempPath.str());
@@ -62,7 +62,7 @@ TEST(FileSystemTest, basic) {
 }
 
 TEST(FileSystemTest, testRecursiveRemoval) {
-  TmpDir rootTempDir{ __FUNCTION__ };
+  TmpDir rootTempDir(__func__);
 
   SmallString<256> tempDir { rootTempDir.str() };
   llvm::sys::path::append(tempDir, "root");
@@ -74,7 +74,7 @@ TEST(FileSystemTest, testRecursiveRemoval) {
     std::error_code ec;
     llvm::raw_fd_ostream os(file.str(), ec, llvm::sys::fs::F_Text);
     EXPECT_FALSE(ec);
-    os << "Hello, world!\n";
+    os << "Hello, world!";
     os.close();
   }
 
@@ -87,7 +87,7 @@ TEST(FileSystemTest, testRecursiveRemoval) {
     std::error_code ec;
     llvm::raw_fd_ostream os(dir.str(), ec, llvm::sys::fs::F_Text);
     EXPECT_FALSE(ec);
-    os << "Hello, world!\n";
+    os << "Hello, world!";
     os.close();
   }
 
@@ -101,7 +101,7 @@ TEST(FileSystemTest, testRecursiveRemoval) {
 }
 
 TEST(FileSystemTest, testRecursiveRemovalDoesNotFollowSymlinks) {
-  TmpDir rootTempDir{ __FUNCTION__ };
+  TmpDir rootTempDir(__func__);
 
   SmallString<256> file{ rootTempDir.str() };
   llvm::sys::path::append(file, "test.txt");
@@ -109,7 +109,7 @@ TEST(FileSystemTest, testRecursiveRemovalDoesNotFollowSymlinks) {
     std::error_code ec;
     llvm::raw_fd_ostream os(file.str(), ec, llvm::sys::fs::F_Text);
     EXPECT_FALSE(ec);
-    os << "Hello, world!\n";
+    os << "Hello, world!";
     os.close();
   }
 
@@ -123,7 +123,7 @@ TEST(FileSystemTest, testRecursiveRemovalDoesNotFollowSymlinks) {
     std::error_code ec;
     llvm::raw_fd_ostream os(otherFile.str(), ec, llvm::sys::fs::F_Text);
     EXPECT_FALSE(ec);
-    os << "Hello, world!\n";
+    os << "Hello, world!";
     os.close();
   }
 
@@ -165,7 +165,7 @@ TEST(DeviceAgnosticFileSystemTest, basic) {
     std::error_code ec;
     llvm::raw_fd_ostream os(tempPath.str(), ec, llvm::sys::fs::F_Text);
     EXPECT_FALSE(ec);
-    os << "Hello, world!\n";
+    os << "Hello, world!";
     os.close();
   }
 
@@ -182,8 +182,7 @@ TEST(DeviceAgnosticFileSystemTest, basic) {
   EXPECT_EQ(missingFileContents.get(), nullptr);
 
   auto ourFileContents = fs->getFileContents(tempPath.str());
-  EXPECT_EQ(ourFileContents->getBuffer().str(), "Hello, world!\n");
-
+  EXPECT_EQ(ourFileContents->getBuffer().str(), "Hello, world!");
   // Remote the temporary file.
   auto ec = llvm::sys::fs::remove(tempPath.str());
   EXPECT_FALSE(ec);

--- a/unittests/BuildSystem/BuildSystemTaskTests.cpp
+++ b/unittests/BuildSystem/BuildSystemTaskTests.cpp
@@ -120,7 +120,7 @@ public:
 
 /// Check that we evaluate a path key properly.
 TEST(BuildSystemTaskTests, basics) {
-  TmpDir tempDir{ __FUNCTION__ };
+  TmpDir tempDir(__func__);
 
   // Create a sample file.
   SmallString<256> path{ tempDir.str() };
@@ -148,7 +148,7 @@ TEST(BuildSystemTaskTests, basics) {
 
 /// Check that we evaluate a missing input path key properly.
 TEST(BuildSystemTaskTests, missingInput) {
-  TmpDir tempDir{ __FUNCTION__ };
+  TmpDir tempDir(__func__);
 
   // Create a non-existent sample file path.
   SmallString<256> path{ tempDir.str() };
@@ -169,7 +169,7 @@ TEST(BuildSystemTaskTests, missingInput) {
 
 /// Check the evaluation of directory contents.
 TEST(BuildSystemTaskTests, directoryContents) {
-  TmpDir tempDir{ __FUNCTION__ };
+  TmpDir tempDir(__func__);
 
   // Create a directory with sample files.
   SmallString<256> fileA{ tempDir.str() };
@@ -215,14 +215,23 @@ TEST(BuildSystemTaskTests, directoryContents) {
 
 /// Check that we evaluate a produced node dependency properly
 TEST(BuildSystemTaskTests, producedNode) {
-  TmpDir tempDir{ __FUNCTION__ };
+  TmpDir tempDir(__func__);
+
   auto localFS = createLocalFileSystem();
 
   // Create a outputFile path
   SmallString<256> outputFile{ tempDir.str() };
   sys::path::append(outputFile, "a.txt");
+  for (auto& c : outputFile) {
+    if (c == '\\')
+      c = '/';
+  }
 
   SmallString<256> manifest{ tempDir.str() };
+  for (auto& c : manifest) {
+    if (c == '\\')
+      c = '/';
+  }
   sys::path::append(manifest, "manifest.llbuild");
   {
     std::error_code ec;
@@ -275,7 +284,7 @@ TEST(BuildSystemTaskTests, producedNode) {
 
 /// Check the evaluation of directory signatures.
 TEST(BuildSystemTaskTests, directorySignature) {
-  TmpDir tempDir{ __FUNCTION__ };
+  TmpDir tempDir(__func__);
   auto localFS = createLocalFileSystem();
   
   // Create a directory with sample files.
@@ -361,9 +370,13 @@ TEST(BuildSystemTaskTests, directorySignature) {
 }
 
 TEST(BuildSystemTaskTests, doesNotProcessDependenciesAfterCancellation) {
-  TmpDir tempDir{ __FUNCTION__ };
+  TmpDir tempDir(__func__);
 
   std::string outputFile = tempDir.str() + "/output.txt";
+  for (auto& c : outputFile) {
+    if (c == '\\')
+      c = '/';
+  }
 
   SmallString<256> manifest{ tempDir.str() };
   sys::path::append(manifest, "manifest.llbuild");
@@ -424,7 +437,7 @@ TEST(BuildSystemTaskTests, doesNotProcessDependenciesAfterCancellation) {
 TEST(BuildSystemTaskTests, cancelAllInQueue) {
 // Disabled: <rdar://problem/32142112> BuildSystem/BuildSystemTests/BuildSystemTaskTests.cancelAllInQueue FAILED
 #ifdef false
-  TmpDir tempDir{ __FUNCTION__ };
+  TmpDir tempDir(__func__);
 
   SmallString<256> manifest{ tempDir.str() };
   sys::path::append(manifest, "manifest.llbuild");
@@ -489,7 +502,7 @@ commands:
 
 // Tests the behaviour of StaleFileRemovalTool
 TEST(BuildSystemTaskTests, staleFileRemoval) {
-  TmpDir tempDir{ __FUNCTION__ };
+  TmpDir tempDir(__func__);
 
   SmallString<256> manifest{ tempDir.str() };
   sys::path::append(manifest, "manifest.llbuild");
@@ -579,7 +592,7 @@ commands:
 }
 
 TEST(BuildSystemTaskTests, staleFileRemovalWithRoots) {
-  TmpDir tempDir{ __FUNCTION__ };
+  TmpDir tempDir(__func__);
 
   SmallString<256> manifest{ tempDir.str() };
   sys::path::append(manifest, "manifest.llbuild");
@@ -677,7 +690,7 @@ commands:
 }
 
 TEST(BuildSystemTaskTests, staleFileRemovalWithRootsEnforcesAbsolutePaths) {
-  TmpDir tempDir{ __FUNCTION__ };
+  TmpDir tempDir(__func__);
 
   SmallString<256> manifest{ tempDir.str() };
   sys::path::append(manifest, "manifest.llbuild");
@@ -764,7 +777,7 @@ commands:
 }
 
 TEST(BuildSystemTaskTests, staleFileRemovalWithRootsIsAgnosticToTrailingPathSeparator) {
-  TmpDir tempDir{ __FUNCTION__ };
+  TmpDir tempDir(__func__);
 
   SmallString<256> manifest{ tempDir.str() };
   sys::path::append(manifest, "manifest.llbuild");
@@ -859,7 +872,7 @@ commands:
 }
 
 TEST(BuildSystemTaskTests, staleFileRemovalWithManyFiles) {
-  TmpDir tempDir{ __FUNCTION__ };
+  TmpDir tempDir(__func__);
 
   SmallString<256> manifest{ tempDir.str() };
   sys::path::append(manifest, "manifest.llbuild");
@@ -975,14 +988,22 @@ TEST(BuildSystemTaskTests, staleFileRemovalPathIsPrefixedByPath) {
 /// Check that we evaluate properly handle a previously missing input that may
 /// now be produced.
 TEST(BuildSystemTaskTests, producedNodeAfterPreviouslyMissing) {
-  TmpDir tempDir{ __FUNCTION__ };
+  TmpDir tempDir(__func__);
   auto localFS = createLocalFileSystem();
 
   SmallString<256> builddb{ tempDir.str() };
   sys::path::append(builddb, "build.db");
+  for (auto& c : builddb) {
+    if (c == '\\')
+      c = '/';
+  }
 
   SmallString<256> outputFile{ tempDir.str() };
   sys::path::append(outputFile, "a.txt");
+  for (auto& c : outputFile) {
+    if (c == '\\')
+      c = '/';
+  }
 
   // Try to build the missing output file
   {

--- a/unittests/BuildSystem/TempDir.cpp
+++ b/unittests/BuildSystem/TempDir.cpp
@@ -13,27 +13,47 @@
 #include "TempDir.h"
 
 #include "llbuild/Basic/FileSystem.h"
+#include "llbuild/Basic/PlatformUtility.h"
 
 #include "llvm/Support/FileSystem.h"
 #include "llvm/Support/Path.h"
 #include "llvm/Support/SourceMgr.h"
 
-llbuild::TmpDir::TmpDir(llvm::StringRef namePrefix) {
-    llvm::SmallString<256> tempDirPrefix;
-    llvm::sys::path::system_temp_directory(true, tempDirPrefix);
-    llvm::sys::path::append(tempDirPrefix, namePrefix);
+#if defined(_WIN32)
+#include "llvm/Support/ConvertUTF.h"
+#include <windows.h>
+#endif
 
-    std::error_code ec = llvm::sys::fs::createUniqueDirectory(
-        tempDirPrefix.str(), tempDir);
-    assert(!ec);
-    (void)ec;
+llbuild::TmpDir::TmpDir(llvm::StringRef namePrefix) {
+  llvm::SmallString<256> tempDirPrefix;
+  llvm::sys::path::system_temp_directory(true, tempDirPrefix);
+  llvm::sys::path::append(tempDirPrefix, namePrefix);
+
+  std::error_code ec =
+      llvm::sys::fs::createUniqueDirectory(tempDirPrefix.str(), tempDir);
+  assert(!ec);
+  (void)ec;
 }
 
 llbuild::TmpDir::~TmpDir() {
-    auto fs = basic::createLocalFileSystem();
-    bool result = fs->remove(tempDir.c_str());
-    assert(result);
-    (void)result;
+#if defined(_WIN32)
+  // On windows you can't delete a directory is it's your current working
+  // directory. So if we're in the directory we're trying to delete, move out
+  // of it first.
+  wchar_t wCurrPath[MAX_PATH];
+  GetCurrentDirectoryW(MAX_PATH, wCurrPath);
+  llvm::SmallVector<UTF16, 20> wTmpPath;
+  llvm::convertUTF8ToUTF16String(str(), wTmpPath);
+  if (lstrcmpW(wCurrPath, (LPCWSTR)wTmpPath.data()) == 0) {
+    std::string currPath = str();
+    StringRef parent = llvm::sys::path::parent_path(currPath);
+    llbuild::basic::sys::chdir(parent.str().c_str());
+  }
+#endif
+  auto fs = basic::createLocalFileSystem();
+  bool result = fs->remove(tempDir.c_str());
+  assert(result);
+  (void)result;
 }
 
 const char *llbuild::TmpDir::c_str() { return tempDir.c_str(); }

--- a/unittests/CAPI/BuildSystem-C-API.cpp
+++ b/unittests/CAPI/BuildSystem-C-API.cpp
@@ -257,7 +257,11 @@ static void command_process_finished(void* context,
 
 TEST(BuildSystemCAPI, CustomToolWithDiscoveredDependencies) {
   std::string tmpDirPath = llbuild::basic::sys::makeTmpDir();
-
+  for (auto& c : tmpDirPath) {
+    if (c == '\\') {
+      c = '/';
+    }
+  }
   // We write out an indirectly referenced file containing data to be copied to
   // the output file.
   std::string indirectInputFilePath = tmpDirPath + "/" + "indirect-input-file";


### PR DESCRIPTION
- Fixing Symlink handling on Windows
- The windows process handling I did was broken in a few places
- Handling Windows paths
- Working around a few Clang/MSVC inconsistencies

Same thing as https://github.com/apple/swift-llbuild/pull/422 but avoiding the use of `mismatch(first1, last1, first2, last2)`