### PR TITLE
Handling Memory Across the API Boundary

### DIFF
--- a/lib/Basic/Subprocess.cpp
+++ b/lib/Basic/Subprocess.cpp
@@ -416,7 +416,9 @@ void llbuild::basic::spawnProcess(
   // gets pulled in.
   std::for_each(std::begin(argsStorage) + 1, std::end(argsStorage),
                 [&args](auto arg) { args += arg + " "; });
-  args.pop_back();
+  if (!args.empty()) {
+    args.pop_back();
+  }
   // Convert the command line string to utf16
   llvm::SmallVector<UTF16, 20> u16Executable;
   llvm::SmallVector<UTF16, 20> u16CmdLine;
@@ -603,6 +605,7 @@ void llbuild::basic::spawnProcess(
     if (!res.getError()) {
       argsStorage[0] = *res;
 #if defined(_WIN32)
+      u16Executable.clear();
       llvm::convertUTF8ToUTF16String(argsStorage[0], u16Executable);
 #else
       args[0] = argsStorage[0].c_str();

--- a/products/libllbuild/BuildSystem-C-API.cpp
+++ b/products/libllbuild/BuildSystem-C-API.cpp
@@ -932,3 +932,5 @@ void llb_set_quality_of_service(llb_quality_of_service_t level) {
   }
 }
 
+void* llb_alloc(size_t size) { return malloc(size); }
+void llb_free(void* ptr) { free(ptr); }

--- a/products/libllbuild/include/llbuild/buildsystem.h
+++ b/products/libllbuild/include/llbuild/buildsystem.h
@@ -254,11 +254,11 @@ typedef struct llb_buildsystem_delegate_t_ {
   ///
   /// \\returns True on success (the directory was created, or already exists).
   bool (*fs_create_directory)(void* context, const char* path);
-  
+
   /// Get the file contents for the given path.
   ///
   /// The contents *MUST* be returned in a new buffer allocated with \see
-  /// malloc().
+  /// llb_alloc().
   ///
   /// Xparam path The path to provide the contents for.
   ///
@@ -735,7 +735,18 @@ llb_get_scheduler_lane_width();
 /// be automatically translated into the number of cores detected on the host.
 LLBUILD_EXPORT void
 llb_set_scheduler_lane_width(uint32_t width);
+/// @}
 
+/// @name Memory APIs
+// MARK: Allocating and freeing memory
+/// Allocate memory usable by the build system
+/// \param size The number bytes to allocate
+LLBUILD_EXPORT void*
+llb_alloc(size_t size);
+/// Free memory allocated for or by the build system
+/// \param ptr A pointer to the allocated memory to free
+LLBUILD_EXPORT void
+llb_free(void* ptr);
 /// @}
 
 #endif

--- a/tests/Examples/buildsystem-capi.llbuild
+++ b/tests/Examples/buildsystem-capi.llbuild
@@ -4,7 +4,7 @@
 # RUN: env LD_LIBRARY_PATH=%{llbuild-lib-dir} %t.exe %s > %t.out
 # RUN: %{FileCheck} %s --input-file %t.out
 #
-# CHECK: -- read file contents: {{.*}}/buildsystem-capi.llbuild
+# CHECK: -- read file contents: {{.*[/\\]}}buildsystem-capi.llbuild
 # CHECK: initial build:
 # CHECK: -- stat: /
 # CHECK: command_started: <hello> -- HELLO


### PR DESCRIPTION
Freeing across modules [can cause issues in Windows](https://docs.microsoft.com/en-us/cpp/c-runtime-library/potential-errors-passing-crt-objects-across-dll-boundaries?view=vs-2017) which llbuild currently does when [getting file contents](https://github.com/apple/swift-llbuild/blob/master/products/libllbuild/include/llbuild/buildsystem.h#L260) using a delegate. This adds a fs_free field which can be used to call the correct free in the library.

However, [there's a comment](https://github.com/apple/swift-llbuild/blob/master/products/libllbuild/include/llbuild/buildsystem.h#L272):   
```
// FIXME: Design clean data types for clients to return unowned/unowned
// memory.
```
which seems like a better idea than adding the fs_free field which would be highly prone to error. Are there existing ideas/proposals for this? I'd refer to "do it properly" and implement that instead. If I want to add something like that, how stable is the llbuild public api considered to be right now?