### PR TITLE
Rename llbuild.dll to libllbuild.dll on Windows

### DIFF
--- a/products/libllbuild/CMakeLists.txt
+++ b/products/libllbuild/CMakeLists.txt
@@ -9,6 +9,12 @@ set(DEPENDENCIES
   llvmSupport
   sqlite3)
 
+if(${CMAKE_SYSTEM_NAME} STREQUAL "Windows")
+set(LIBLLBUILD_NAME libllbuild)
+else()
+set(LIBLLBUILD_NAME llbuild)
+endif()
+
 if(NOT ${CMAKE_SYSTEM_NAME} STREQUAL "Windows")
   list(APPEND DEPENDENCIES curses)
 endif()
@@ -16,7 +22,7 @@ endif()
 add_llbuild_library(libllbuild
   ${SOURCES}
   SHARED
-  OUTPUT_NAME llbuild)
+  OUTPUT_NAME ${LIBLLBUILD_NAME})
 
 set_property(TARGET libllbuild PROPERTY MACOSX_RPATH ON)
 

--- a/tests/Examples/buildsystem-capi.llbuild
+++ b/tests/Examples/buildsystem-capi.llbuild
@@ -1,6 +1,6 @@
 # Check that the BuildSystem C API example builds and runs correctly.
 #
-# RUN: cc -o %t.exe %{srcroot}/examples/c-api/buildsystem/main.c -I %{srcroot}/products/libllbuild/include -lllbuild -L %{llbuild-lib-dir} -Werror
+# RUN: cc -o %t.exe %{srcroot}/examples/c-api/buildsystem/main.c -I %{srcroot}/products/libllbuild/include -l%{libllbuild} -L %{llbuild-lib-dir} -Werror
 # RUN: env LD_LIBRARY_PATH=%{llbuild-lib-dir} %t.exe %s > %t.out
 # RUN: %{FileCheck} %s --input-file %t.out
 #

--- a/tests/lit.cfg
+++ b/tests/lit.cfg
@@ -90,6 +90,7 @@ config.substitutions.append( ('%{llbuild-tools-dir}', llbuild_tools_dir) )
 config.substitutions.append( ('%{srcroot}', llbuild_src_root) )
 config.substitutions.append( ('%{swiftc-platform-flags}', "" if not config.osx_sysroot else "-sdk " + config.osx_sysroot) )
 config.substitutions.append( ('%{build-dir}', llbuild_obj_root) ) 
+config.substitutions.append( ('%{libllbuild}', 'libllbuild' if platform.system() == 'Windows' else 'llbuild') )
 
 ###
 


### PR DESCRIPTION
Cl by default produces .pdb and .ilk files by simply substituting the
extension of the desired target. This produces conflicts between the
debug files for llbuild.exe and llbuild.dll. This changes llbuild.dll to
be libllbuild.dll to avoid the problem.