### PR TITLE
Fix some process spawning issues on Windows

### DIFF
--- a/lib/Basic/ShellUtility.cpp
+++ b/lib/Basic/ShellUtility.cpp
@@ -27,27 +27,32 @@ void appendShellEscapedString(llvm::raw_ostream& os, StringRef string) {
     return;
   }
 
+#if defined(_WIN32)
+  std::string escQuote = "\"";
+#else
+  std::string escQuote = "'";
+#endif
   // We only need to escape the single quote, if it isn't present we can
   // escape using single quotes.
-  auto singleQuotePos = string.find_first_of("'", pos);
+  auto singleQuotePos = string.find_first_of(escQuote, pos);
   if (singleQuotePos == std::string::npos) {
-    os << "'";
+    os << escQuote;
     os << string;
-    os << "'";
+    os << escQuote;
     return;
   }
 
   // Otherwise iterate and escape all the single quotes.
-  os << "'";
+  os << escQuote;
   os << string.slice(0, singleQuotePos);
   for (auto idx = singleQuotePos; idx < string.size(); idx++) {
-    if (string[idx] == '\'') {
-      os << "'\\''";
+    if (string[idx] == escQuote[0]) {
+      os << escQuote << "\\" << escQuote << escQuote;
     } else {
       os << string[idx];
     }
   }
-  os << "'";
+  os << escQuote;
 }
 
 std::string shellEscaped(StringRef string) {

--- a/lib/Basic/Subprocess.cpp
+++ b/lib/Basic/Subprocess.cpp
@@ -414,7 +414,7 @@ void llbuild::basic::spawnProcess(
   // if the arguments contain spaces. This should instead use std::string
   // flattenWindowsCommandLine(ArrayRef<StringRef> Args) from llvm once that
   // gets pulled in.
-  std::for_each(std::begin(argsStorage) + 1, std::end(argsStorage),
+  std::for_each(std::begin(argsStorage), std::end(argsStorage),
                 [&args](auto arg) { args += arg + " "; });
   if (!args.empty()) {
     args.pop_back();

--- a/unittests/Basic/ShellUtilityTest.cpp
+++ b/unittests/Basic/ShellUtilityTest.cpp
@@ -19,6 +19,15 @@ using namespace llbuild::basic;
 
 namespace {
 
+std::string quoted(std::string s) {
+#if defined(_WIN32)
+  std::string quote = "\"";
+#else
+  std::string quote = "'";
+#endif
+  return quote + s + quote;
+}
+
 TEST(UtilityTest, basic) {
   // No escapable char.
   std::string output = shellEscaped("input01");
@@ -26,31 +35,50 @@ TEST(UtilityTest, basic) {
 
   // Space.
   output = shellEscaped("input A");
-  EXPECT_EQ(output, "'input A'");
+#if defined(_WIN32)
+  std::string quote = "\"";
+#else
+  std::string quote = "'";
+#endif
+
+  EXPECT_EQ(output, quoted("input A"));
 
   // Two spaces.
   output = shellEscaped("input A B");
-  EXPECT_EQ(output, "'input A B'");
+  EXPECT_EQ(output, quoted("input A B"));
 
   // Double Quote.
   output = shellEscaped("input\"A");
-  EXPECT_EQ(output, "'input\"A'");
+#if defined(_WIN32)
+  EXPECT_EQ(output, quoted("input") + "\\" + quote + quoted("A"));
+#else
+  EXPECT_EQ(output, quoted("input\"A"));
+#endif
 
   // Single Quote.
   output = shellEscaped("input'A");
+#if defined(_WIN32)
+  EXPECT_EQ(output, quoted("input'A"));
+#else
   EXPECT_EQ(output, "'input'\\''A'");
+#endif
 
   // Question Mark.
   output = shellEscaped("input?A");
-  EXPECT_EQ(output, "'input?A'");
+  EXPECT_EQ(output, quoted("input?A"));
 
   // New line.
   output = shellEscaped("input\nA");
-  EXPECT_EQ(output, "'input\nA'");
+  EXPECT_EQ(output, quoted("input\nA"));
 
   // Multiple special chars.
+#if defined(_WIN32)
+  output = shellEscaped("input\nA'B C>D*[$;()^><");
+  EXPECT_EQ(output, quoted("input\nA'B C>D*[$;()^><"));
+#else
   output = shellEscaped("input\nA\"B C>D*[$;()^><");
-  EXPECT_EQ(output, "'input\nA\"B C>D*[$;()^><'");
+  EXPECT_EQ(output, quoted("input\nA\"B C>D*[$;()^><"));
+#endif
 }
 
 }


### PR DESCRIPTION
- CreateProcessW Command args _should_ include the executable name as
  argv[0]
- cmd doesn't know what single quotes are, use double quotes instead on
  Windows