### PR TITLE
Fix SwiftBuildToolTests on Windows

### DIFF
--- a/tests/SwiftBuildTool/Inputs/swiftc-shim.cpp
+++ b/tests/SwiftBuildTool/Inputs/swiftc-shim.cpp
@@ -1,0 +1,17 @@
+#include <stdlib.h>
+#include <string>
+int main(int argc, char** argv) {
+  std::string args;
+  for (int i = 1; i < argc; i++) {
+    args += " \"";
+    args += argv[i];
+    args += "\"";
+  }
+
+#if defined(_WIN32)
+  system(("python SOURCEDIR/Inputs/pseudo-swiftc" + args).c_str());
+#else
+  system(("SOURCEDIR/Inputs/pseudo-swiftc" + args).c_str());
+#endif
+  return 0;
+}

--- a/tests/SwiftBuildTool/changed-commands.swift-build
+++ b/tests/SwiftBuildTool/changed-commands.swift-build
@@ -9,19 +9,22 @@
 # RUN: mkdir -p %t.build
 # RUN: touch %t.build/s1.swift %t.build/s2.swift
 #
+# RUN: sed -e "s#SOURCEDIR#%/S#g" < %S/Inputs/swiftc-shim.cpp > %t.build/swiftc-shim.cpp
+# RUN: clang++ %t.build/swiftc-shim.cpp -o %t.build/swiftc-shim.exe
+#
 # RUN: grep -A1000 "VERSION-BEGIN-[1]" %s | grep -B10000 "VERSION-END-1" | grep -ve '^--$' > %t.build/build.swift-build.tmp
-# RUN: sed -e "s#SOURCEDIR#%S#g" -e "s#TMPDIR#%t#g" < %t.build/build.swift-build.tmp > %t.build/build.swift-build
+# RUN: sed -e "s#SOURCEDIR#%/S#g" -e "s#TMPDIR#%/t#g" < %t.build/build.swift-build.tmp > %t.build/build.swift-build
 # RUN: %{swift-build-tool} -v --chdir %t.build > %t1.out
 # RUN: %{FileCheck} --check-prefix CHECK-VERSION-1 --input-file %t1.out %s
 #
 # RUN: grep -A1000 "VERSION-BEGIN-[2]" %s | grep -B10000 "VERSION-END-2" | grep -ve '^--$' > %t.build/build.swift-build.tmp
-# RUN: sed -e "s#SOURCEDIR#%S#g" -e "s#TMPDIR#%t#g" < %t.build/build.swift-build.tmp > %t.build/build.swift-build
+# RUN: sed -e "s#SOURCEDIR#%/S#g" -e "s#TMPDIR#%/t#g" < %t.build/build.swift-build.tmp > %t.build/build.swift-build
 # RUN: %{swift-build-tool} -v --chdir %t.build > %t2.out
 # RUN: %{FileCheck} --check-prefix CHECK-VERSION-2 --input-file %t2.out %s
 
 ##### VERSION-BEGIN-1 #####
 
-# CHECK-VERSION-1: swiftc {{.*}} s1.swift s2.swift
+# CHECK-VERSION-1: swiftc-shim.exe {{.*}} s1.swift s2.swift
 client:
   name: swift-build
 
@@ -33,7 +36,7 @@ commands:
     tool: swift-compiler
     inputs: ["s1.swift", "s2.swift"]
     outputs: ["s1.o", "s2.o"]
-    executable: SOURCEDIR/Inputs/pseudo-swiftc
+    executable: TMPDIR.build/swiftc-shim.exe
     module-name: Foo
     module-output-path: Foo.swiftmodule
     sources: ["s1.swift", "s2.swift"]
@@ -45,7 +48,7 @@ commands:
 
 ##### VERSION-BEGIN-2 #####
 
-# CHECK-VERSION-2: swiftc {{.*}} s1.swift
+# CHECK-VERSION-2: swiftc-shim.exe {{.*}} s1.swift
 client:
   name: swift-build
 
@@ -57,7 +60,7 @@ commands:
     tool: swift-compiler
     inputs: ["s1.swift"]
     outputs: ["s1.o"]
-    executable: SOURCEDIR/Inputs/pseudo-swiftc
+    executable: TMPDIR.build/swiftc-shim.exe
     module-name: Foo
     module-output-path: Foo.swiftmodule
     sources: ["s1.swift"]

--- a/tests/SwiftBuildTool/dependencies.swift-build
+++ b/tests/SwiftBuildTool/dependencies.swift-build
@@ -2,12 +2,14 @@
 #
 # RUN: rm -rf %t.build
 # RUN: mkdir -p %t.build
+# RUN: sed -e "s#SOURCEDIR#%/S#g" < %S/Inputs/swiftc-shim.cpp > %t.build/swiftc-shim.cpp
+# RUN: clang++ %t.build/swiftc-shim.cpp -o %t.build/swiftc-shim.exe
 # RUN: touch %t.build/input
-# RUN: sed -e "s#SOURCEDIR#%S#g" -e "s#TMPDIR#%t#g" < %s > %t.build/build.swift-build
+# RUN: sed -e "s#SOURCEDIR#%/S#g" -e "s#TMPDIR#%/t#g" < %s > %t.build/build.swift-build
 # RUN: %{swift-build-tool} -v --chdir %t.build > %t.out
 # RUN: %{FileCheck} --check-prefix=CHECK-INITIAL --input-file %t.out %s
 #
-# CHECK-INITIAL: {{.*}}/pseudo-swiftc
+# CHECK-INITIAL: {{.*}}/swiftc-shim
 
 # Check that the next build is null.
 #
@@ -23,7 +25,7 @@
 # RUN: %{swift-build-tool} -v --chdir %t.build > %t.out
 # RUN: %{FileCheck} --check-prefix=CHECK-REBUILD --input-file %t.out %s
 #
-# CHECK-REBUILD: {{.*}}/pseudo-swiftc
+# CHECK-REBUILD: {{.*}}/swiftc-shim
 
 client:
   name: swift-build
@@ -35,7 +37,7 @@ commands:
   C1:
     tool: swift-compiler
     outputs: ["<output>"]
-    executable: SOURCEDIR/Inputs/pseudo-swiftc
+    executable: TMPDIR.build/swiftc-shim.exe
     module-name: Foo
     sources: input.swift
     objects: output.o

--- a/tests/SwiftBuildTool/swift-compiler-whole-module-optimization.swift-build
+++ b/tests/SwiftBuildTool/swift-compiler-whole-module-optimization.swift-build
@@ -2,26 +2,28 @@
 #
 # RUN: rm -rf %t.build
 # RUN: mkdir -p %t.build
-# RUN: sed -e "s#SOURCEDIR#%S#g" -e "s#TMPDIR#%t#g" < %s > %t.build/build.swift-build
+# RUN: sed -e "s#SOURCEDIR#%/S#g" < %S/Inputs/swiftc-shim.cpp > %t.build/swiftc-shim.cpp
+# RUN: clang++ %t.build/swiftc-shim.cpp -o %t.build/swiftc-shim.exe
+# RUN: sed -e "s#SOURCEDIR#%/S#g" -e "s#TMPDIR#%/t#g" < %s > %t.build/build.swift-build
 # RUN: %{swift-build-tool} --no-db --chdir %t.build > %t.out
 # RUN: %{swift-build-tool} --no-db -v --chdir %t.build > %t-verbose.out
 # RUN: %{FileCheck} --input-file=%t.out %s
 # RUN: %{FileCheck} --check-prefix=CHECK-VERBOSE --input-file=%t-verbose.out %s
 #
 # CHECK: Compiling Swift Module 'Foo'
-# CHECK-VERBOSE: swiftc -module-name Bar -incremental -emit-dependencies -emit-module -emit-module-path Bar.swiftmodule -output-file-map bar.build/output-file-map.json -parse-as-library -whole-module-optimization -num-threads 1 -c s1.swift -I importB
-# CHECK-VERBOSE-NEXT: swiftc -module-name Foo -incremental -emit-dependencies -emit-module -emit-module-path Foo.swiftmodule -output-file-map foo.build/output-file-map.json -parse-as-library -whole-module-optimization -num-threads 0 -c s1.swift s2.swift -I importA -I importB -Onone -I somePath
+# CHECK-VERBOSE: swiftc-shim.exe -module-name Bar -incremental -emit-dependencies -emit-module -emit-module-path Bar.swiftmodule -output-file-map bar.build{{/|\\}}output-file-map.json -parse-as-library -whole-module-optimization -num-threads 1 -c s1.swift -I importB
+# CHECK-VERBOSE-NEXT: swiftc-shim.exe -module-name Foo -incremental -emit-dependencies -emit-module -emit-module-path Foo.swiftmodule -output-file-map foo.build{{/|\\}}output-file-map.json -parse-as-library -whole-module-optimization -num-threads 0 -c s1.swift s2.swift -I importA -I importB -Onone -I somePath
 
 # # Sanity check the output file map.
 #
 # RUN: %{FileCheck} --check-prefix=CHECK-OUTPUT-FILE-MAP --input-file=%t.build/foo.build/output-file-map.json %s
 # CHECK-OUTPUT-FILE-MAP: "": {
-# CHECK-OUTPUT-FILE-MAP-NEXT: "dependencies": "foo.build/Foo.d"
-# CHECK-OUTPUT-FILE-MAP-NEXT: "object": "foo.build/Foo.o"
+# CHECK-OUTPUT-FILE-MAP-NEXT: "dependencies": "foo.build{{/|\\\\}}Foo.d"
+# CHECK-OUTPUT-FILE-MAP-NEXT: "object": "foo.build{{/|\\\\}}Foo.o"
 #
 # RUN: %{FileCheck} --check-prefix=CHECK-OUTPUT-FILE-MAP-BAR --input-file=%t.build/bar.build/output-file-map.json %s
 # CHECK-OUTPUT-FILE-MAP-BAR: "": {
-# CHECK-OUTPUT-FILE-MAP-BAR-NEXT: "dependencies": "bar.build/Bar.d"
+# CHECK-OUTPUT-FILE-MAP-BAR-NEXT: "dependencies": "bar.build{{/|\\\\}}Bar.d"
 
 
 client:
@@ -34,7 +36,7 @@ commands:
   C0:
     tool: swift-compiler
     outputs: ["<C0>"]
-    executable: SOURCEDIR/Inputs/pseudo-swiftc
+    executable: TMPDIR.build/swiftc-shim.exe
     module-name: Bar
     module-output-path: Bar.swiftmodule
     sources: ["s1.swift"]
@@ -50,7 +52,7 @@ commands:
     tool: swift-compiler
     inputs: ["<C0>"]
     outputs: ["<output>"]
-    executable: SOURCEDIR/Inputs/pseudo-swiftc
+    executable: TMPDIR.build/swiftc-shim.exe
     module-name: Foo
     module-output-path: Foo.swiftmodule
     sources: ["s1.swift", "s2.swift"]

--- a/tests/SwiftBuildTool/swift-compiler.swift-build
+++ b/tests/SwiftBuildTool/swift-compiler.swift-build
@@ -2,7 +2,9 @@
 #
 # RUN: rm -rf %t.build
 # RUN: mkdir -p %t.build/temps/nested
-# RUN: sed -e "s#SOURCEDIR#%S#g" -e "s#TMPDIR#%t#g" < %s > %t.build/build.swift-build
+# RUN: sed -e "s#SOURCEDIR#%/S#g" < %S/Inputs/swiftc-shim.cpp > %t.build/swiftc-shim.cpp
+# RUN: clang++ %t.build/swiftc-shim.cpp -o %t.build/swiftc-shim.exe
+# RUN: sed -e "s#SOURCEDIR#%/S#g" -e "s#TMPDIR#%/t#g" < %s > %t.build/build.swift-build
 # RUN: %{swift-build-tool} --no-db --chdir %t.build > %t.out
 # RUN: %{swift-build-tool} --no-db -v --chdir %t.build > %t-verbose.out
 # RUN: %{FileCheck} --input-file=%t.out %s
@@ -10,15 +12,15 @@
 #
 # CHECK: Compiling Swift Module 'Foo'
 # FIXME: This should quote output paths.
-# CHECK-VERBOSE: swiftc -module-name Foo -incremental -emit-dependencies -emit-module -emit-module-path Foo.swiftmodule -output-file-map temps/output-file-map.json -parse-as-library -c "s 1.swift" "s 2.swift" -I "import A" -I "import B" -Onone -I "path with spaces"
+# CHECK-VERBOSE: swiftc-shim.exe -module-name Foo -incremental -emit-dependencies -emit-module -emit-module-path Foo.swiftmodule -output-file-map temps{{/|\\}}output-file-map.json -parse-as-library -c "s 1.swift" "s 2.swift" -I "import A" -I "import B" -Onone -I "path with spaces"
 
 # Sanity check the output file map.
 #
 # RUN: %{FileCheck} --check-prefix=CHECK-OUTPUT-FILE-MAP --input-file=%t.build/temps/output-file-map.json %s
 # CHECK-OUTPUT-FILE-MAP: "s 1.swift": {
-# CHECK-OUTPUT-FILE-MAP-NEXT: "dependencies": "temps/s 1.d"
+# CHECK-OUTPUT-FILE-MAP-NEXT: "dependencies": "temps{{/|\\\\}}s 1.d"
 # CHECK-OUTPUT-FILE-MAP: "s 2.swift": {
-# CHECK-OUTPUT-FILE-MAP-NEXT: "dependencies": "temps/nested/s 2.d"
+# CHECK-OUTPUT-FILE-MAP-NEXT: "dependencies": "temps{{\\?}}/nested{{/|\\\\}}s 2.d"
 
 client:
   name: swift-build
@@ -30,7 +32,7 @@ commands:
   C1:
     tool: swift-compiler
     outputs: ["<output>"]
-    executable: SOURCEDIR/Inputs/pseudo-swiftc
+    executable: TMPDIR.build/swiftc-shim.exe
     module-name: Foo
     module-output-path: Foo.swiftmodule
     sources: ["s 1.swift", "s 2.swift"]

--- a/tests/SwiftBuildTool/swift-version.swift-build
+++ b/tests/SwiftBuildTool/swift-version.swift-build
@@ -3,11 +3,13 @@
 # RUN: rm -rf %t.build
 # RUN: mkdir -p %t.build
 # RUN: touch %t.build/input
-# RUN: sed -e "s#SOURCEDIR#%S#g" -e "s#TMPDIR#%t#g" < %s > %t.build/build.swift-build
+# RUN: sed -e "s#SOURCEDIR#%/S#g" < %S/Inputs/swiftc-shim.cpp > %t.build/swiftc-shim.cpp
+# RUN: clang++ %t.build/swiftc-shim.cpp -o %t.build/swiftc-shim.exe
+# RUN: sed -e "s#SOURCEDIR#%/S#g" -e "s#TMPDIR#%/t#g" < %s > %t.build/build.swift-build
 # RUN: %{swift-build-tool} -v --chdir %t.build > %t.out
 # RUN: %{FileCheck} --check-prefix=CHECK-INITIAL --input-file %t.out %s
 #
-# CHECK-INITIAL: {{.*}}/pseudo-swiftc
+# CHECK-INITIAL: {{.*}}/swiftc-shim.exe
 
 # Check that the next build is null.
 #
@@ -23,7 +25,7 @@
 # RUN: echo "END-OF-INPUT" >> %t.out
 # RUN: %{FileCheck} --check-prefix=CHECK-REBUILD --input-file %t.out %s
 #
-# CHECK-REBUILD: {{.*}}/pseudo-swiftc
+# CHECK-REBUILD: {{.*}}/swiftc-shim.exe
 
 # Check one more null build.
 #
@@ -31,7 +33,7 @@
 # RUN: echo "END-OF-INPUT" >> %t.out
 # RUN: %{FileCheck} --check-prefix=CHECK-REBUILD-NULL --input-file %t.out %s
 #
-# CHECK-REBUILD-NULL-NOT: {{.*}}/pseudo-swiftc
+# CHECK-REBUILD-NULL-NOT: {{.*}}/swiftc-shim.exe
 
 client:
   name: swift-build
@@ -43,7 +45,7 @@ commands:
   C1:
     tool: swift-compiler
     outputs: ["<output>"]
-    executable: SOURCEDIR/Inputs/pseudo-swiftc
+    executable: TMPDIR.build/swiftc-shim.exe
     module-name: Foo
     sources: input.swift
     objects: output.o


### PR DESCRIPTION
This (along with https://github.com/apple/swift-llbuild/pull/433) fixes the SwiftBuildToolTests on Windows. The main issue is the Windows doesn't know what a shebang is so it is unable to exec the python script. It's ugly and I hate that this is the only solution I'm able to come up with, but this adds a shim which the tests compile and execute which then calls the python script.