### PR TITLE
Disable SwiftBuildTool tests on Windows

### DIFF
--- a/tests/SwiftBuildTool/changed-commands.swift-build
+++ b/tests/SwiftBuildTool/changed-commands.swift-build
@@ -1,3 +1,5 @@
+# Windows doesn't have a way to exec python files
+# UNSUPPORTED: platform=Windows
 # Check that we behave properly when a command changes.
 #
 # This is a regression test for a subtle bug when our hash function was too

--- a/tests/SwiftBuildTool/dependencies.swift-build
+++ b/tests/SwiftBuildTool/dependencies.swift-build
@@ -1,3 +1,5 @@
+# Windows doesn't have a way to exec python files
+# UNSUPPORTED: platform=Windows
 # Check that we properly pick up dependencies from the Swift compiler.
 #
 # RUN: rm -rf %t.build

--- a/tests/SwiftBuildTool/swift-compiler-whole-module-optimization.swift-build
+++ b/tests/SwiftBuildTool/swift-compiler-whole-module-optimization.swift-build
@@ -1,3 +1,5 @@
+# Windows doesn't have a way to exec python files
+# UNSUPPORTED: platform=Windows
 # Check that we communicate properly with the Swift compiler.
 #
 # RUN: rm -rf %t.build

--- a/tests/SwiftBuildTool/swift-compiler.swift-build
+++ b/tests/SwiftBuildTool/swift-compiler.swift-build
@@ -1,3 +1,5 @@
+# Windows doesn't have a way to exec python files
+# UNSUPPORTED: platform=Windows
 # Check that we communicate properly with the Swift compiler.
 #
 # RUN: rm -rf %t.build

--- a/tests/SwiftBuildTool/swift-version.swift-build
+++ b/tests/SwiftBuildTool/swift-version.swift-build
@@ -1,3 +1,5 @@
+# Windows doesn't have a way to exec python files
+# UNSUPPORTED: platform=Windows
 # Check that we properly rebuild when the Swift compiler changes.
 #
 # RUN: rm -rf %t.build


### PR DESCRIPTION
Windows doesn't do shebangs and working around this is pretty messy for
really not a lot of gain. (See also
https://github.com/apple/swift-llbuild/pull/434 for alternatively fixing
them.)