### PR TITLE
Add some missing sqlite3_finalize() statements.

### DIFF
--- a/lib/Core/SQLiteBuildDB.cpp
+++ b/lib/Core/SQLiteBuildDB.cpp
@@ -154,6 +154,7 @@ class SQLiteBuildDB : public BuildDB {
         clientVersion = sqlite3_column_int(stmt, 1);
       } else {
         *error_out = getCurrentErrorMessage();
+        sqlite3_finalize(stmt);
         return false;
       }
       sqlite3_finalize(stmt);
@@ -347,6 +348,7 @@ public:
     if (result != SQLITE_ROW) {
       *success_out = false;
       *error_out = getCurrentErrorMessage();
+      sqlite3_finalize(stmt);
       return 0;
     }
 
@@ -378,6 +380,7 @@ public:
     result = sqlite3_step(stmt);
     if (result != SQLITE_DONE) {
       *error_out = getCurrentErrorMessage();
+      sqlite3_finalize(stmt);
       return false;
     }
 


### PR DESCRIPTION
Some (error) paths in `SQLiteBuildDB.cpp` failed to finalize temporary statements, possibly causing leaks if the resultant errors were handled gracefully further up the stack (i.e. by not quitting immediately). Seemed like a potential issue that'd be easy to clear up—in case some future changes don't treat the resulting errors as fatal (since that doesn't seem to be delineated anywhere).