### PR TITLE
[BuildSystem] Track and validate rule signatures

### DIFF
--- a/include/llbuild/BuildSystem/BuildDescription.h
+++ b/include/llbuild/BuildSystem/BuildDescription.h
@@ -15,6 +15,7 @@
 
 #include "llbuild/Basic/Compiler.h"
 #include "llbuild/Basic/ExecutionQueue.h"
+#include "llbuild/Basic/Hashing.h"
 #include "llbuild/Basic/LLVM.h"
 
 #include "llvm/ADT/SmallString.h"
@@ -187,6 +188,8 @@ public:
   
   /// Get a verbose description of the command, for use in status reporting.
   virtual void getVerboseDescription(SmallVectorImpl<char> &result) const override = 0;
+
+  virtual basic::CommandSignature getSignature() const;
   
   /// @}
 

--- a/include/llbuild/BuildSystem/ExternalCommand.h
+++ b/include/llbuild/BuildSystem/ExternalCommand.h
@@ -60,14 +60,6 @@ class ExternalCommand : public Command {
   /// Whether to treat the command as always being out-of-date.
   bool alwaysOutOfDate = false;
 
-  // Build specific data.
-  //
-  // FIXME: We should probably factor this out somewhere else, so we can enforce
-  // it is never used when initialized incorrectly.
-
-  /// The previous build result command signature, if available.
-  basic::CommandSignature priorResultCommandSignature;
-  
   /// If not None, the command should be skipped with the provided BuildValue.
   llvm::Optional<BuildValue> skipValue;
 
@@ -96,7 +88,7 @@ protected:
   StringRef getDescription() const { return description; }
 
   /// This function must be overriden by subclasses for any additional keys.
-  virtual basic::CommandSignature getSignature();
+  virtual basic::CommandSignature getSignature() const override;
 
   /// Extension point for subclasses, to actually execute the command.
   virtual void executeExternalCommand(

--- a/include/llbuild/BuildSystem/ShellCommand.h
+++ b/include/llbuild/BuildSystem/ShellCommand.h
@@ -83,12 +83,12 @@ class ShellCommand : public ExternalCommand {
   bool controlEnabled = true;
 
   /// The cached signature, once computed -- 0 is used as a sentinel value.
-  std::atomic<basic::CommandSignature> cachedSignature{ };
+  mutable std::atomic<basic::CommandSignature> cachedSignature{ };
 
   virtual void start(BuildSystemCommandInterface& bsci,
                      core::Task* task) override;
   
-  virtual basic::CommandSignature getSignature() override;
+  virtual basic::CommandSignature getSignature() const override;
 
   bool processDiscoveredDependencies(BuildSystemCommandInterface& bsci,
                                      core::Task* task,

--- a/include/llbuild/Core/BuildEngine.h
+++ b/include/llbuild/Core/BuildEngine.h
@@ -14,6 +14,7 @@
 #define LLBUILD_CORE_BUILDENGINE_H
 
 #include "llbuild/Basic/Compiler.h"
+#include "llbuild/Basic/Hashing.h"
 
 #include "llvm/ADT/StringRef.h"
 #include "llvm/ADT/Twine.h"
@@ -45,6 +46,9 @@ typedef uint64_t Timestamp;
 struct Result {
   /// The last value that resulted from executing the task.
   ValueType value = {};
+
+  /// The signature of the node that generated the result.
+  basic::CommandSignature signature;
 
   /// The build timestamp during which the result \see Value was computed.
   uint64_t computedAt = 0;
@@ -179,6 +183,9 @@ public:
 
   /// The key computed by the rule.
   KeyType key;
+
+  /// The signature of the rule.
+  basic::CommandSignature signature;
 
   /// Called to create the task to build the rule, when necessary.
   std::function<Task*(BuildEngine&)> action;

--- a/lib/BuildSystem/BuildDescription.cpp
+++ b/lib/BuildSystem/BuildDescription.cpp
@@ -19,6 +19,11 @@ Node::~Node() {}
 
 Command::~Command() {}
 
+basic::CommandSignature Command::getSignature() const {
+  return basic::CommandSignature().combine(name);
+}
+
+
 Tool::~Tool() {}
 
 std::unique_ptr<Command> Tool::createCustomCommand(const BuildKey& key) {

--- a/lib/BuildSystem/BuildNode.cpp
+++ b/lib/BuildSystem/BuildNode.cpp
@@ -25,36 +25,51 @@ using namespace llbuild::buildsystem;
 
 bool BuildNode::configureAttribute(const ConfigureContext& ctx, StringRef name,
                                    StringRef value) {
-  if (name == "is-directory") {
-    if (value == "true") {
-      directory = true;
-      directoryStructure = virtualNode = false;
-    } else if (value == "false") {
-      directory = false;
+  if (name == "type") {
+    if (value == "plain") {
+      type = NodeType::Plain;
+    } else if (value == "directory") {
+      type = NodeType::Plain;
+    } else if (value == "directory-structure") {
+      type = NodeType::DirectoryStructure;
+    } else if (value == "virtual") {
+      type = NodeType::Virtual;
     } else {
       ctx.error("invalid value: '" + value + "' for attribute '"
                 + name + "'");
       return false;
     }
     return true;
-  } else if (name == "is-directory-structure") {
+  } else if (name == "is-directory") { // Note: Deprecated in favor of 'type'.
     if (value == "true") {
-      directoryStructure = true;
-      directory = virtualNode = false;
+      type = NodeType::Directory;
     } else if (value == "false") {
-      directory = false;
+      if (type == NodeType::Directory)
+        type = NodeType::Plain;
     } else {
       ctx.error("invalid value: '" + value + "' for attribute '"
                 + name + "'");
       return false;
     }
     return true;
-  } else if (name == "is-virtual") {
+  } else if (name == "is-directory-structure") { // Note: Deprecated in favor of 'type'.
     if (value == "true") {
-      virtualNode = true;
-      directory = directoryStructure = false;
+      type = NodeType::DirectoryStructure;
     } else if (value == "false") {
-      virtualNode = false;
+      if (type == NodeType::DirectoryStructure)
+        type = NodeType::Plain;
+    } else {
+      ctx.error("invalid value: '" + value + "' for attribute '"
+                + name + "'");
+      return false;
+    }
+    return true;
+  } else if (name == "is-virtual") { // Note: Deprecated in favor of 'type'.
+    if (value == "true") {
+      type = NodeType::Virtual;
+    } else if (value == "false") {
+      if (type == NodeType::Virtual)
+        type = NodeType::Plain;
       commandTimestamp = false;
     } else {
       ctx.error("invalid value: '" + value + "' for attribute '"
@@ -65,8 +80,7 @@ bool BuildNode::configureAttribute(const ConfigureContext& ctx, StringRef name,
   } else if (name == "is-command-timestamp") {
     if (value == "true") {
       commandTimestamp = true;
-      virtualNode = true;
-      directory = directoryStructure = false;
+      type = NodeType::Virtual;
     } else if (value == "false") {
       commandTimestamp = false;
     } else {
@@ -124,6 +138,19 @@ FileInfo BuildNode::getFileInfo(basic::FileSystem& fileSystem) const {
 FileInfo BuildNode::getLinkInfo(basic::FileSystem& fileSystem) const {
   assert(!isVirtual());
   return fileSystem.getLinkInfo(getName());
+}
+
+basic::CommandSignature BuildNode::getSignature() const {
+  basic::CommandSignature sig;
+  sig.combine(static_cast<unsigned int>(type));
+  // We include the name of all producer rules in the signature to ensure that
+  // we properly pick up changes in build graph structure.  For example, a node
+  // that was previously a plain input that has changed to become a produced
+  // node.
+  for (auto* producer : getProducers()) {
+    sig.combine(producer->getName());
+  }
+  return sig;
 }
 
 

--- a/lib/BuildSystem/BuildSystem.cpp
+++ b/lib/BuildSystem/BuildSystem.cpp
@@ -462,8 +462,7 @@ class TargetTask : public Task {
 public:
   TargetTask(Target& target) : target(target) {}
 
-  static bool isResultValid(BuildEngine& engine, Target& node,
-                            const BuildValue& value) {
+  static bool isResultValid(BuildEngine&, Target&, const BuildValue&) {
     // Always treat target tasks as invalid.
     return false;
   }
@@ -760,7 +759,7 @@ public:
   ProducedNodeTask(Node& node)
       : node(node), nodeResult(BuildValue::makeInvalid()) {}
   
-  static bool isResultValid(BuildEngine&, Node& node,
+  static bool isResultValid(BuildEngine& engine, Node& node,
                             const BuildValue& value) {
     // If the result was failure, we always need to rebuild (it may produce an
     // error).
@@ -1484,11 +1483,11 @@ Rule BuildSystemEngineDelegate::lookupRule(const KeyType& keyData) {
       // If there is no such command, produce an error task.
       return Rule{
         keyData,
+        /*signature=*/{},
         /*Action=*/ [](BuildEngine& engine) -> Task* {
           return engine.registerTask(new MissingCommandTask());
         },
-        /*IsValid=*/ [](BuildEngine&, const Rule& rule,
-                        const ValueType& value) -> bool {
+        /*IsValid=*/ [](BuildEngine&, const Rule&, const ValueType&) -> bool {
           // The cached result for a missing command is never valid.
           return false;
         }
@@ -1499,6 +1498,7 @@ Rule BuildSystemEngineDelegate::lookupRule(const KeyType& keyData) {
     Command* command = it->second.get();
     return Rule{
       keyData,
+      command->getSignature(),
       /*Action=*/ [command](BuildEngine& engine) -> Task* {
         return engine.registerTask(new CommandTask(*command));
       },
@@ -1531,6 +1531,7 @@ Rule BuildSystemEngineDelegate::lookupRule(const KeyType& keyData) {
       
       return Rule{
         keyData,
+        command->getSignature(),
         /*Action=*/ [command](BuildEngine& engine) -> Task* {
           return engine.registerTask(new CommandTask(*command));
         },
@@ -1546,11 +1547,11 @@ Rule BuildSystemEngineDelegate::lookupRule(const KeyType& keyData) {
     // task.
     return Rule{
       keyData,
+      /*signature=*/{},
       /*Action=*/ [](BuildEngine& engine) -> Task* {
         return engine.registerTask(new MissingCommandTask());
       },
-      /*IsValid=*/ [](BuildEngine&, const Rule& rule,
-                      const ValueType& value) -> bool {
+      /*IsValid=*/ [](BuildEngine&, const Rule&, const ValueType&) -> bool {
         // The cached result for a missing command is never valid.
         return false;
       }
@@ -1561,6 +1562,7 @@ Rule BuildSystemEngineDelegate::lookupRule(const KeyType& keyData) {
     std::string path = key.getDirectoryPath();
     return Rule{
       keyData,
+      /*signature=*/{},
       /*Action=*/ [path](BuildEngine& engine) -> Task* {
         return engine.registerTask(new DirectoryContentsTask(path));
       },
@@ -1577,6 +1579,7 @@ Rule BuildSystemEngineDelegate::lookupRule(const KeyType& keyData) {
     std::string patterns = key.getContentExclusionPatterns();
     return Rule{
       keyData,
+      /*signature=*/{},
       /*Action=*/ [path, patterns](BuildEngine& engine) -> Task* {
         BinaryDecoder decoder(patterns);
         return engine.registerTask(new FilteredDirectoryContentsTask(path,
@@ -1591,6 +1594,7 @@ Rule BuildSystemEngineDelegate::lookupRule(const KeyType& keyData) {
     std::string filters = key.getContentExclusionPatterns();
     return Rule{
       keyData,
+      /*signature=*/{},
       /*Action=*/ [path, filters](
           BuildEngine& engine) mutable -> Task* {
         BinaryDecoder decoder(filters);
@@ -1607,6 +1611,7 @@ Rule BuildSystemEngineDelegate::lookupRule(const KeyType& keyData) {
     std::string path = key.getDirectoryPath();
     return Rule{
       keyData,
+      /*signature=*/{},
       /*Action=*/ [path](
           BuildEngine& engine) mutable -> Task* {
         return engine.registerTask(new DirectoryTreeStructureSignatureTask(path));
@@ -1648,6 +1653,7 @@ Rule BuildSystemEngineDelegate::lookupRule(const KeyType& keyData) {
       if (node->isVirtual()) {
         return Rule{
           keyData,
+          node->getSignature(),
           /*Action=*/ [](BuildEngine& engine) -> Task* {
             return engine.registerTask(new VirtualInputNodeTask());
           },
@@ -1662,7 +1668,8 @@ Rule BuildSystemEngineDelegate::lookupRule(const KeyType& keyData) {
       if (node->isDirectory()) {
         return Rule{
           keyData,
-            /*Action=*/ [node](BuildEngine& engine) -> Task* {
+          node->getSignature(),
+          /*Action=*/ [node](BuildEngine& engine) -> Task* {
             return engine.registerTask(new DirectoryInputNodeTask(*node));
           },
             // Directory nodes don't require any validation outside of their
@@ -1674,7 +1681,8 @@ Rule BuildSystemEngineDelegate::lookupRule(const KeyType& keyData) {
       if (node->isDirectoryStructure()) {
         return Rule{
           keyData,
-            /*Action=*/ [node](BuildEngine& engine) -> Task* {
+          node->getSignature(),
+          /*Action=*/ [node](BuildEngine& engine) -> Task* {
             return engine.registerTask(
                 new DirectoryStructureInputNodeTask(*node));
           },
@@ -1686,6 +1694,7 @@ Rule BuildSystemEngineDelegate::lookupRule(const KeyType& keyData) {
       
       return Rule{
         keyData,
+        node->getSignature(),
         /*Action=*/ [node](BuildEngine& engine) -> Task* {
           return engine.registerTask(new FileInputNodeTask(*node));
         },
@@ -1700,6 +1709,7 @@ Rule BuildSystemEngineDelegate::lookupRule(const KeyType& keyData) {
     // Otherwise, create a task for a produced node.
     return Rule{
       keyData,
+      node->getSignature(),
       /*Action=*/ [node](BuildEngine& engine) -> Task* {
         return engine.registerTask(new ProducedNodeTask(*node));
       },
@@ -1726,7 +1736,8 @@ Rule BuildSystemEngineDelegate::lookupRule(const KeyType& keyData) {
     // Create the rule to construct this target.
     return Rule{
       keyData,
-        /*Action=*/ [statnode](BuildEngine& engine) -> Task* {
+      /*signature=*/{},
+      /*Action=*/ [statnode](BuildEngine& engine) -> Task* {
         return engine.registerTask(new StatTask(*statnode));
       },
       /*IsValid=*/ [statnode](BuildEngine& engine, const Rule& rule,
@@ -1749,7 +1760,8 @@ Rule BuildSystemEngineDelegate::lookupRule(const KeyType& keyData) {
     Target* target = it->second.get();
     return Rule{
       keyData,
-        /*Action=*/ [target](BuildEngine& engine) -> Task* {
+      /*signature=*/{},
+      /*Action=*/ [target](BuildEngine& engine) -> Task* {
         return engine.registerTask(new TargetTask(*target));
       },
       /*IsValid=*/ [target](BuildEngine& engine, const Rule& rule,
@@ -1785,13 +1797,15 @@ void BuildSystemEngineDelegate::error(const Twine& message) {
 
 std::unique_ptr<BuildNode>
 BuildSystemImpl::lookupNode(StringRef name, bool isImplicit) {
-  bool isDirectory = name.endswith("/");
-  bool isVirtual = !name.empty() && name[0] == '<' && name.back() == '>';
-  return llvm::make_unique<BuildNode>(name, isDirectory,
-                                      /*isDirectoryStructure=*/false,
-                                      isVirtual,
-                                      /*isCommandTimestamp=*/false,
-                                      /*isMutable=*/false);
+  if (name.endswith("/")) {
+    return BuildNode::makeDirectory(name);
+  }
+
+  if (!name.empty() && name[0] == '<' && name.back() == '>') {
+    return BuildNode::makeVirtual(name);
+  }
+
+  return BuildNode::makePlain(name);
 }
 
 llvm::Optional<BuildValue> BuildSystemImpl::build(BuildKey key) {
@@ -1976,7 +1990,7 @@ class ClangShellCommand : public ExternalCommand {
   /// The path to the dependency output file, if used.
   std::string depsPath;
   
-  virtual CommandSignature getSignature() override {
+  virtual CommandSignature getSignature() const override {
     return ExternalCommand::getSignature()
         .combine(args);
   }
@@ -2251,7 +2265,7 @@ public:
     // command and relying on the signature to detect changes.
     //
     // FIXME: We should support BuildValues with arbitrary payloads.
-    resultFn(BuildValue::makeSuccessfulCommand(
+    resultFn(BuildValue::makeSuccessfulCommandWithOutputSignature(
        basic::FileInfo{}, CommandSignature(result)));
   }
 };
@@ -2292,7 +2306,7 @@ class SwiftCompilerShellCommand : public ExternalCommand {
   /// Note: This is only used when whole module optimization is enabled.
   std::string numThreads = "0";
 
-  virtual CommandSignature getSignature() override {
+  virtual CommandSignature getSignature() const override {
     return ExternalCommand::getSignature()
         .combine(executable)
         .combine(moduleName)
@@ -2897,7 +2911,7 @@ class SymlinkCommand : public Command {
       StringRef(linkOutputPath);
   }
   
-  virtual CommandSignature getSignature() {
+  virtual CommandSignature getSignature() const override {
     CommandSignature code(output->getName());
     code = code.combine(contents);
     for (const auto* input: inputs) {
@@ -3013,10 +3027,6 @@ class SymlinkCommand : public Command {
     // If the prior value wasn't for a successful command, recompute.
     if (!value.isSuccessfulCommand())
       return false;
-    
-    // If the command's signature has changed since it was built, rebuild.
-    if (value.getCommandSignature() != getSignature())
-      return false;
 
     // If the prior command doesn't look like one for a link, recompute.
     if (value.getNumOutputs() != 1)
@@ -3104,7 +3114,7 @@ class SymlinkCommand : public Command {
         outputPath);
       
     // Complete with a successful result.
-    resultFn(BuildValue::makeSuccessfulCommand(outputInfo, getSignature()));
+    resultFn(BuildValue::makeSuccessfulCommand(outputInfo));
   }
 
 public:

--- a/lib/BuildSystem/BuildValue.cpp
+++ b/lib/BuildSystem/BuildValue.cpp
@@ -41,6 +41,7 @@ StringRef BuildValue::stringForKind(BuildValue::Kind kind) {
     CASE(SkippedCommand);
     CASE(Target);
     CASE(StaleFileRemoval);
+    CASE(SuccessfulCommandWithOutputSignature);
 #undef CASE
   }
   return "<unknown>";
@@ -48,8 +49,8 @@ StringRef BuildValue::stringForKind(BuildValue::Kind kind) {
   
 void BuildValue::dump(raw_ostream& os) const {
   os << "BuildValue(" << stringForKind(kind);
-  if (kindHasCommandSignature()) {
-    os << ", signature=" << commandSignature.value;
+  if (kindHasSignature()) {
+    os << ", signature=" << signature.value;
   }
   if (kindHasOutputInfo()) {
     os << ", outputInfos=[";

--- a/lib/BuildSystem/ShellCommand.cpp
+++ b/lib/BuildSystem/ShellCommand.cpp
@@ -32,7 +32,7 @@ void ShellCommand::start(BuildSystemCommandInterface& bsci,
   this->ExternalCommand::start(bsci, task);
 }
 
-CommandSignature ShellCommand::getSignature() {
+CommandSignature ShellCommand::getSignature() const {
   CommandSignature signature = cachedSignature;
   if (!signature.isNull())
     return signature;

--- a/lib/Commands/BuildEngineCommand.cpp
+++ b/lib/Commands/BuildEngineCommand.cpp
@@ -205,7 +205,7 @@ static int runAckermannBuild(int m, int n, int recomputeCount,
     virtual core::Rule lookupRule(const core::KeyType& keyData) override {
       ++numRules;
       auto key = AckermannKey(keyData);
-      return core::Rule{key, [key] (core::BuildEngine& engine) {
+      return core::Rule{key, {}, [key] (core::BuildEngine& engine) {
           return new AckermannTask(engine, key.m, key.n); } };
     }
 

--- a/lib/Commands/NinjaBuildCommand.cpp
+++ b/lib/Commands/NinjaBuildCommand.cpp
@@ -1484,6 +1484,7 @@ core::Rule NinjaBuildEngineDelegate::lookupRule(const core::KeyType& key) {
 
   return core::Rule{
     node->getPath(),
+    {},
       [&, node] (core::BuildEngine&) {
       return buildInput(*context, node);
     },
@@ -1865,11 +1866,12 @@ int commands::executeNinjaBuildCommand(std::vector<std::string> args) {
       if (command->getOutputs().size() == 1) {
         context.engine.addRule({
             command->getOutputs()[0]->getPath(),
+            {},
             [=, &context](core::BuildEngine& engine) {
               return buildCommand(context, command);
             },
             [=, &context](core::BuildEngine&, const core::Rule& rule,
-                          const core::ValueType value) {
+                          const core::ValueType& value) {
               // If simulating, assume cached results are valid.
               if (context.simulate)
                 return true;
@@ -1898,11 +1900,12 @@ int commands::executeNinjaBuildCommand(std::vector<std::string> args) {
       // outputs.
       context.engine.addRule({
           compositeRuleName,
+          {},
           [=, &context](core::BuildEngine& engine) {
             return buildCommand(context, command);
           },
           [=, &context](core::BuildEngine&, const core::Rule& rule,
-                        const core::ValueType value) {
+                        const core::ValueType& value) {
             // If simulating, assume cached results are valid.
             if (context.simulate)
               return true;
@@ -1918,12 +1921,13 @@ int commands::executeNinjaBuildCommand(std::vector<std::string> args) {
       for (unsigned i = 0, e = command->getOutputs().size(); i != e; ++i) {
         context.engine.addRule({
             command->getOutputs()[i]->getPath(),
+            {},
             [=, &context] (core::BuildEngine&) {
               return selectCompositeBuildResult(context, command, i,
                                                 compositeRuleName);
             },
             [=, &context] (core::BuildEngine&, const core::Rule& rule,
-                           const core::ValueType value) {
+                           const core::ValueType& value) {
               // If simulating, assume cached results are valid.
               if (context.simulate)
                 return true;
@@ -2004,6 +2008,7 @@ int commands::executeNinjaBuildCommand(std::vector<std::string> args) {
       // Create a dummy rule to build all targets.
       context.engine.addRule({
           "<<build>>",
+          {},
           [&](core::BuildEngine&) {
             return buildTargets(context, targetsToBuild);
           },

--- a/lib/Core/BuildEngineTrace.cpp
+++ b/lib/Core/BuildEngineTrace.cpp
@@ -261,6 +261,13 @@ void BuildEngineTrace::ruleNeedsToRunBecauseNeverBuilt(const Rule* forRule) {
           getRuleName(forRule));
 }
 
+void BuildEngineTrace::ruleNeedsToRunBecauseSignatureChanged(const Rule* forRule) {
+  FILE *fp = static_cast<FILE*>(outputPtr);
+
+  fprintf(fp, "{ \"rule-needs-to-run\", \"%s\", \"signature-changed\" },\n",
+          getRuleName(forRule));
+}
+
 void BuildEngineTrace::ruleNeedsToRunBecauseInvalidValue(const Rule* forRule) {
   FILE *fp = static_cast<FILE*>(outputPtr);
 

--- a/lib/Core/BuildEngineTrace.h
+++ b/lib/Core/BuildEngineTrace.h
@@ -88,6 +88,7 @@ public:
     void ruleScanningDeferredOnTask(const Rule* forRule,
                                     const Task* inputTask);
     void ruleNeedsToRunBecauseNeverBuilt(const Rule* forRule);
+    void ruleNeedsToRunBecauseSignatureChanged(const Rule* forRule);
     void ruleNeedsToRunBecauseInvalidValue(const Rule* forRule);
     void ruleNeedsToRunBecauseInputMissing(const Rule* forRule);
     void ruleNeedsToRunBecauseInputRebuilt(const Rule* forRule,

--- a/perftests/Xcode/PerfTests/CorePerfTests.mm
+++ b/perftests/Xcode/PerfTests/CorePerfTests.mm
@@ -169,17 +169,17 @@ static ActionFn simpleAction(const std::vector<KeyType>& Inputs,
       char InputName[32];
       sprintf(InputName, "i%d", i+1);
       Engine.addRule({
-          Name, simpleAction({ InputName },
+          Name, {}, simpleAction({ InputName },
                              [] (const std::vector<int>& Inputs) {
                                return Inputs[0]; }) });
     } else {
       Engine.addRule({
-          Name,
+          Name, {},
           simpleAction({},
                        [&] (const std::vector<int>& Inputs) {
                          return LastInputValue; }),
-          [&](BuildEngine&, const Rule& rule, const ValueType& Value) {
-              return LastInputValue == IntFromValue(Value);
+          [&](BuildEngine&, const Rule&, const ValueType& value) {
+              return LastInputValue == IntFromValue(value);
           } });
     }
   }
@@ -256,16 +256,16 @@ static int64_t i64pow(int64_t Value, int64_t Exponent) {
           Inputs.push_back(InputName);
         }
         Engine.addRule({
-            Name, simpleAction(Inputs, [] (const std::vector<int>& Inputs) {
+            Name, {}, simpleAction(Inputs, [] (const std::vector<int>& Inputs) {
                 return Inputs[0]; }) });
       } else {
         Engine.addRule({
-            Name,
+            Name, {},
             simpleAction({},
                          [&] (const std::vector<int>& Inputs) {
                            return LastInputValue; }),
-            [&](BuildEngine&, const Rule& rule, const ValueType& Value) {
-              return LastInputValue == IntFromValue(Value);
+            [&](BuildEngine&, const Rule&, const ValueType& value) {
+              return LastInputValue == IntFromValue(value);
             } });
       }
     }
@@ -337,7 +337,7 @@ static int64_t i64pow(int64_t Value, int64_t Exponent) {
         char InputBName[32];
         sprintf(InputBName, "i%d,%d", i, j+1);
         Engine.addRule({
-            Name, simpleAction({ InputAName, InputBName },
+            Name, {}, simpleAction({ InputAName, InputBName },
                                [] (const std::vector<int>& Inputs) {
                                  return Inputs[0]; }) });
       } else if (i != M) {
@@ -346,7 +346,7 @@ static int64_t i64pow(int64_t Value, int64_t Exponent) {
         char InputName[32];
         sprintf(InputName, "i%d,%d", i+1, j);
         Engine.addRule({
-            Name, simpleAction({ InputName },
+            Name, {}, simpleAction({ InputName },
                                [] (const std::vector<int>& Inputs) {
                                  return Inputs[0]; }) });
       } else if (j != N) {
@@ -355,19 +355,19 @@ static int64_t i64pow(int64_t Value, int64_t Exponent) {
         char InputName[32];
         sprintf(InputName, "i%d,%d", i, j+1);
         Engine.addRule({
-            Name, simpleAction({ InputName },
+            Name, {}, simpleAction({ InputName },
                                [] (const std::vector<int>& Inputs) {
                                  return Inputs[0]; }) });
       } else {
         // Top-right corner node.
         assert(i == M && j == N);
         Engine.addRule({
-            Name,
+            Name, {},
             simpleAction({},
                          [&] (const std::vector<int>& Inputs) {
                            return LastInputValue; }),
-            [&](BuildEngine&, const Rule& rule, const ValueType& Value) {
-              return LastInputValue == IntFromValue(Value);
+            [&](BuildEngine&, const Rule&, const ValueType& value) {
+              return LastInputValue == IntFromValue(value);
             } });
       }
     }

--- a/products/libllbuild/BuildSystem-C-API.cpp
+++ b/products/libllbuild/BuildSystem-C-API.cpp
@@ -775,7 +775,7 @@ public:
     llvm::raw_svector_ostream(result) << getName();
   }
 
-  virtual llbuild::basic::CommandSignature getSignature() override {
+  virtual llbuild::basic::CommandSignature getSignature() const override {
     auto sig = ExternalCommand::getSignature();
     if (cAPIDelegate.get_signature) {
       llb_data_t data;

--- a/products/libllbuild/Core-C-API.cpp
+++ b/products/libllbuild/Core-C-API.cpp
@@ -74,7 +74,7 @@ class CAPIBuildEngineDelegate : public BuildEngineDelegate {
 
     return Rule{
       // FIXME: This is a wasteful copy.
-      key,
+      key, {},
       [rule, engineContext] (BuildEngine& engine) {
         return (Task*) rule.create_task(rule.context, engineContext);
       },

--- a/tests/BuildSystem/Build/missing-command-rule.llbuild
+++ b/tests/BuildSystem/Build/missing-command-rule.llbuild
@@ -1,0 +1,108 @@
+# Check that we properly handle changing rule definitions where intermediate
+# steps have removed production rule(s)
+#
+# We use 'grep' to slice out two different subfiles from the same file.
+#
+# RUN: rm -rf %t.build
+# RUN: mkdir -p %t.build
+#
+#
+# Initial build where 'a.h' is produced by rule C.1
+#
+# RUN: grep -A1000 "VERSION-BEGIN-[1]" %s | grep -B10000 "VERSION-END-1" | grep -ve '^--$' > %t.build/build-1.llbuild
+# RUN: touch %t.build/a.i
+# RUN: %{llbuild} buildsystem build --serial --chdir %t.build -f build-1.llbuild > %t.1.out
+# RUN: echo "END-OF-FILE" >> %t.1.out
+# RUN: %{FileCheck} --check-prefix CHECK-VERSION-1 --input-file=%t.1.out %s
+#
+# CHECK-VERSION-1: GENERATE-HEADER
+# CHECK-VERSION-1: COMPILE
+# CHECK-VERSION-1: END-OF-FILE
+#
+#
+# Second build where 'a.i' exists and is the same as before, but is no longer
+# produced by anything in the manifest (i.e. is now a plain file node). This
+# should be a null incremental build, as the input is still up to date. As such
+# this will implicitly drop the dependency on C.1.
+#
+# RUN: grep -A1000 "VERSION-BEGIN-[2]" %s | grep -B10000 "VERSION-END-2" | grep -ve '^--$' > %t.build/build-2.llbuild
+# RUN: %{llbuild} buildsystem build --serial --chdir %t.build -f build-2.llbuild > %t.2.out
+# RUN: echo "END-OF-FILE" >> %t.2.out
+# RUN: %{FileCheck} --check-prefix CHECK-VERSION-2 --input-file %t.2.out %s
+#
+# CHECK-VERSION-2-NOT: GENERATE-HEADER
+# CHECK-VERSION-2-NOT: COMPILE
+# CHECK-VERSION-2: END-OF-FILE
+#
+#
+# Third build where the rule to produce 'a.h' has been added back.  In this case
+# it is still up to date, so we expect the build to continue to be null.
+# However, we do expect that the build system scans rule C.1.
+#
+# RUN: %{llbuild} buildsystem build --serial --chdir %t.build -f build-1.llbuild --trace %t.3.trace > %t.3.out
+# RUN: echo "END-OF-FILE" >> %t.3.out
+# RUN: %{FileCheck} --check-prefix CHECK-VERSION-3 --input-file %t.3.out %s
+# RUN: %{FileCheck} --check-prefix CHECK-TRACE-3 --input-file %t.3.trace %s
+#
+# CHECK-VERSION-3-NOT: GENERATE-HEADER
+# CHECK-VERSION-3-NOT: COMPILE
+# CHECK-VERSION-3: END-OF-FILE
+#
+# CHECK-TRACE-3: "CC.1"
+#
+# Fourth build where we have actually changed 'a.i'. Our production relationship
+# should be properly re-established, thus we expect the generate to occur and
+# then be followed by the compile.
+#
+# RUN: touch %t.build/a.i
+# RUN: %{llbuild} buildsystem build --serial --chdir %t.build -f build-1.llbuild > %t.4.out
+# RUN: echo "END-OF-FILE" >> %t.4.out
+# RUN: %{FileCheck} --check-prefix CHECK-VERSION-4 --input-file %t.4.out %s
+#
+# CHECK-VERSION-4: GENERATE-HEADER
+# CHECK-VERSION-4: COMPILE
+# CHECK-VERSION-4: END-OF-FILE
+#
+
+##### VERSION-BEGIN-1 #####
+
+client:
+  name: basic
+
+targets:
+  "": ["<all>","<c.1>"]
+
+commands:
+  "C.1":
+    tool: shell
+    description: GENERATE-HEADER
+    inputs: ["a.i"]
+    args: cp a.i a.h
+    outputs: ["a.h","<c.1>"]
+
+  "C.2":
+    tool: shell
+    description: COMPILE
+    inputs: ["a.h"]
+    args: cp a.h a.c
+    outputs: ["<all>"]
+
+##### VERSION-END-1 #####
+
+##### VERSION-BEGIN-2 #####
+
+client:
+  name: basic
+
+targets:
+  "": ["<all>"]
+
+commands:
+  "C.2":
+    tool: shell
+    description: COMPILE
+    inputs: ["a.h"]
+    args: cp a.h a.c
+    outputs: ["<all>"]
+
+##### VERSION-END-2 #####

--- a/tests/BuildSystem/Build/now-produced-rule.llbuild
+++ b/tests/BuildSystem/Build/now-produced-rule.llbuild
@@ -1,0 +1,74 @@
+# Check that we properly handle changing rule definitions where a previously
+# plain file input node is now a produced node
+#
+# We use 'grep' to slice out two different subfiles from the same file.
+#
+# RUN: rm -rf %t.build
+# RUN: mkdir -p %t.build
+#
+#
+#
+# RUN: grep -A1000 "VERSION-BEGIN-[1]" %s | grep -B10000 "VERSION-END-1" | grep -ve '^--$' > %t.build/build-1.llbuild
+# RUN: touch %t.build/a.h
+# RUN: %{llbuild} buildsystem build --serial --chdir %t.build -f build-1.llbuild > %t.1.out
+# RUN: echo "END-OF-FILE" >> %t.1.out
+# RUN: %{FileCheck} --check-prefix CHECK-VERSION-1 --input-file=%t.1.out %s
+#
+# CHECK-VERSION-1: COMPILE
+# CHECK-VERSION-1: END-OF-FILE
+#
+#
+# RUN: grep -A1000 "VERSION-BEGIN-[2]" %s | grep -B10000 "VERSION-END-2" | grep -ve '^--$' > %t.build/build-2.llbuild
+# RUN: touch %t.build/a.i
+# RUN: %{llbuild} buildsystem build --serial --chdir %t.build -f build-2.llbuild > %t.2.out
+# RUN: echo "END-OF-FILE" >> %t.2.out
+# RUN: %{FileCheck} --check-prefix CHECK-VERSION-2 --input-file %t.2.out %s
+#
+# CHECK-VERSION-2: GENERATE-HEADER
+# CHECK-VERSION-2: COMPILE
+# CHECK-VERSION-2: END-OF-FILE
+#
+
+##### VERSION-BEGIN-1 #####
+
+client:
+  name: basic
+
+targets:
+  "": ["<all>"]
+
+commands:
+  "C.2":
+    tool: shell
+    description: COMPILE
+    inputs: ["a.h"]
+    args: cp a.h a.c
+    outputs: ["<all>"]
+
+##### VERSION-END-1 #####
+
+##### VERSION-BEGIN-2 #####
+
+client:
+  name: basic
+
+targets:
+  "": ["<all>"]
+
+commands:
+  "C.1":
+    tool: shell
+    description: GENERATE-HEADER
+    inputs: ["a.i"]
+    args: cp a.i a.h
+    outputs: ["a.h"]
+
+  "C.2":
+    tool: shell
+    description: COMPILE
+    inputs: ["a.h"]
+    args: cp a.h a.c
+    outputs: ["<all>"]
+
+##### VERSION-END-2 #####
+

--- a/unittests/BuildSystem/BuildValueTest.cpp
+++ b/unittests/BuildSystem/BuildValueTest.cpp
@@ -55,73 +55,100 @@ TEST(BuildValueTest, virtualValueSerialization) {
 }
 
 TEST(BuildValueTest, commandValueSingleOutputSerialization) {
-  auto signature = llbuild::basic::CommandSignature(0xDEADBEEF);
   basic::FileInfo infos[1] = {};
   infos[0].size = 1;
   
   // Check that two identical values are equivalent.
   {
-    BuildValue a = BuildValue::makeSuccessfulCommand(infos, signature);
-    EXPECT_EQ(a.toData(),
-              BuildValue::makeSuccessfulCommand(infos, signature).toData());
+    BuildValue a = BuildValue::makeSuccessfulCommand(infos);
+    EXPECT_EQ(a.toData(), BuildValue::makeSuccessfulCommand(infos).toData());
   }
 
   // Check that a moved complex value is equivalent.
   {
-    BuildValue tmp = BuildValue::makeSuccessfulCommand(infos, signature);
+    BuildValue tmp = BuildValue::makeSuccessfulCommand(infos);
     BuildValue a = std::move(tmp);
-    EXPECT_EQ(a.toData(),
-              BuildValue::makeSuccessfulCommand(infos, signature).toData());
+    EXPECT_EQ(a.toData(), BuildValue::makeSuccessfulCommand(infos).toData());
   }
 
   // Check that an rvalue initialized complex value is equivalent.
   {
-    BuildValue tmp = BuildValue::makeSuccessfulCommand(infos, signature);
+    BuildValue tmp = BuildValue::makeSuccessfulCommand(infos);
     BuildValue a{ std::move(tmp) };
-    EXPECT_EQ(a.toData(),
-              BuildValue::makeSuccessfulCommand(infos, signature).toData());
+    EXPECT_EQ(a.toData(), BuildValue::makeSuccessfulCommand(infos).toData());
   }
 
   // Check that a round-tripped value is equivalent.
-  EXPECT_EQ(BuildValue::makeSuccessfulCommand(infos, signature).toData(),
+  EXPECT_EQ(BuildValue::makeSuccessfulCommand(infos).toData(),
             BuildValue::fromData(
-                BuildValue::makeSuccessfulCommand(
-                    infos, signature).toData()).toData());
+                BuildValue::makeSuccessfulCommand(infos).toData()).toData());
 }
 
 TEST(BuildValueTest, commandValueMultipleOutputsSerialization) {
-  auto signature = llbuild::basic::CommandSignature(0xDEADBEEF);
   basic::FileInfo infos[2] = {};
   infos[0].size = 1;
   infos[1].size = 2;
   
   // Check that two identical values are equivalent.
   {
-    BuildValue a = BuildValue::makeSuccessfulCommand(infos, signature);
+    BuildValue a = BuildValue::makeSuccessfulCommand(infos);
     EXPECT_EQ(a.toData(),
-              BuildValue::makeSuccessfulCommand(infos, signature).toData());
+              BuildValue::makeSuccessfulCommand(infos).toData());
   }
 
   // Check that a moved complex value is equivalent.
   {
-    BuildValue tmp = BuildValue::makeSuccessfulCommand(infos, signature);
+    BuildValue tmp = BuildValue::makeSuccessfulCommand(infos);
     BuildValue a = std::move(tmp);
     EXPECT_EQ(a.toData(),
-              BuildValue::makeSuccessfulCommand(infos, signature).toData());
+              BuildValue::makeSuccessfulCommand(infos).toData());
   }
 
   // Check that an rvalue initialized complex value is equivalent.
   {
-    BuildValue tmp = BuildValue::makeSuccessfulCommand(infos, signature);
+    BuildValue tmp = BuildValue::makeSuccessfulCommand(infos);
     BuildValue a{ std::move(tmp) };
-    EXPECT_EQ(a.toData(),
-              BuildValue::makeSuccessfulCommand(infos, signature).toData());
+    EXPECT_EQ(a.toData(), BuildValue::makeSuccessfulCommand(infos).toData());
   }
 
   // Check that a round-tripped value is equivalent.
-  EXPECT_EQ(BuildValue::makeSuccessfulCommand(infos, signature).toData(),
+  EXPECT_EQ(BuildValue::makeSuccessfulCommand(infos).toData(),
             BuildValue::fromData(
-                BuildValue::makeSuccessfulCommand(
+                BuildValue::makeSuccessfulCommand(infos).toData()).toData());
+}
+
+TEST(BuildValueTest, commandValueWithSignatureSingleOutputSerialization) {
+  auto signature = llbuild::basic::CommandSignature(0xDEADBEEF);
+  basic::FileInfo infos[1] = {};
+  infos[0].size = 1;
+
+  // Check that two identical values are equivalent.
+  {
+    BuildValue a = BuildValue::makeSuccessfulCommandWithOutputSignature(infos, signature);
+    EXPECT_EQ(a.toData(),
+              BuildValue::makeSuccessfulCommandWithOutputSignature(infos, signature).toData());
+  }
+
+  // Check that a moved complex value is equivalent.
+  {
+    BuildValue tmp = BuildValue::makeSuccessfulCommandWithOutputSignature(infos, signature);
+    BuildValue a = std::move(tmp);
+    EXPECT_EQ(a.toData(),
+              BuildValue::makeSuccessfulCommandWithOutputSignature(infos, signature).toData());
+  }
+
+  // Check that an rvalue initialized complex value is equivalent.
+  {
+    BuildValue tmp = BuildValue::makeSuccessfulCommandWithOutputSignature(infos, signature);
+    BuildValue a{ std::move(tmp) };
+    EXPECT_EQ(a.toData(),
+              BuildValue::makeSuccessfulCommandWithOutputSignature(infos, signature).toData());
+  }
+
+  // Check that a round-tripped value is equivalent.
+  EXPECT_EQ(BuildValue::makeSuccessfulCommandWithOutputSignature(infos, signature).toData(),
+            BuildValue::fromData(
+                BuildValue::makeSuccessfulCommandWithOutputSignature(
                     infos, signature).toData()).toData());
 }
 

--- a/unittests/Core/BuildEngineCancellationTest.cpp
+++ b/unittests/Core/BuildEngineCancellationTest.cpp
@@ -130,7 +130,7 @@ TEST(BuildEngineCancellationTest, basic) {
   core::BuildEngine engine(delegate);
   bool cancelIt = false;
   engine.addRule({
-      "value-A", simpleAction({}, [&] (const std::vector<int>& inputs) {
+      "value-A", {}, simpleAction({}, [&] (const std::vector<int>& inputs) {
           builtKeys.push_back("value-A");
           fprintf(stderr, "building A (and cancelling ? %d)\n", cancelIt);
           if (cancelIt) {
@@ -138,7 +138,7 @@ TEST(BuildEngineCancellationTest, basic) {
           }
           return 2; }) });
   engine.addRule({
-      "result",
+      "result", {},
       simpleAction({"value-A"},
                    [&] (const std::vector<int>& inputs) {
                      EXPECT_EQ(1U, inputs.size());
@@ -168,7 +168,7 @@ TEST(BuildEngineCancellationDueToDuplicateTaskTest, basic) {
   core::BuildEngine engine(delegate);
   Task* taskA = nullptr;
   engine.addRule({
-     "value-A", simpleActionExternalTask({"value-B"},
+     "value-A", {}, simpleActionExternalTask({"value-B"},
         [&] (const std::vector<int>& inputs) {
           builtKeys.push_back("value-A");
           fprintf(stderr, "building A\n");
@@ -177,13 +177,13 @@ TEST(BuildEngineCancellationDueToDuplicateTaskTest, basic) {
         &taskA)
     });
   engine.addRule({
-     "value-B", simpleAction({}, [&] (const std::vector<int>& inputs) {
+     "value-B", {}, simpleAction({}, [&] (const std::vector<int>& inputs) {
        builtKeys.push_back("value-B");
        fprintf(stderr, "building B (and reporting A complete early)\n");
        engine.taskIsComplete(taskA, intToValue(2));
        return 3; }) });
   engine.addRule({
-      "result",
+      "result", {},
       simpleAction({"value-A", "value-B"},
                    [&] (const std::vector<int>& inputs) {
                      EXPECT_EQ(2U, inputs.size());

--- a/unittests/Core/DepsBuildEngineTest.cpp
+++ b/unittests/Core/DepsBuildEngineTest.cpp
@@ -134,16 +134,16 @@ TEST(DepsBuildEngineTest, BogusConcurrentDepScan) {
   // isn't immediately obvious it needs to run).
   int dirListValue = 2 * 3;
   engine.addRule({
-      "dir-list-input",
+      "dir-list-input", {},
       simpleAction({}, [&] (const std::vector<int>& inputs) {
           builtKeys.push_back("dir-list-input");
           return dirListValue; }),
-      [&](BuildEngine&, const Rule& rule, const ValueType& value) {
+      [&](BuildEngine&, const Rule&, const ValueType&) {
         // Always rebuild
         return false;
       } });
   engine.addRule({
-      "dir-list",
+      "dir-list", {},
       simpleAction({ "dir-list-input" }, [&] (const std::vector<int>& inputs) {
           builtKeys.push_back("dir-list");
           assert(inputs.size() == 1);
@@ -151,20 +151,20 @@ TEST(DepsBuildEngineTest, BogusConcurrentDepScan) {
 
   // These are the rules for individual discovered "files".
   engine.addRule({
-      "input-2",
+      "input-2", {},
       simpleAction({}, [&] (const std::vector<int>& inputs) {
           builtKeys.push_back("input-2");
           return 5; }),
-      [&](BuildEngine&, const Rule& rule, const ValueType& value) {
+      [&](BuildEngine&, const Rule&, const ValueType&) {
         // Always rebuild
         return false;
       } });
   engine.addRule({
-      "input-3",
+      "input-3", {},
       simpleAction({}, [&] (const std::vector<int>& inputs) {
           builtKeys.push_back("input-3");
           return 7; }),
-      [&](BuildEngine&, const Rule& rule, const ValueType& value) {
+      [&](BuildEngine&, const Rule&, const ValueType&) {
         // Always rebuild
         return false;
       } });
@@ -205,7 +205,7 @@ TEST(DepsBuildEngineTest, BogusConcurrentDepScan) {
     }
   };
   engine.addRule({
-      "output",
+      "output", {},
       [&builtKeys] (BuildEngine& engine) {
         builtKeys.push_back("output");
         return engine.registerTask(new DynamicTask());
@@ -265,17 +265,17 @@ TEST(DepsBuildEngineTest, KeysWithNull) {
     std::string inputA{"i\0A", 3};
     std::string inputB{"i\0B", 3};
     engine.addRule({
-        inputA,
+        inputA, {},
         simpleAction({}, [&] (const std::vector<int>& inputs) {
             builtKeys.push_back(inputA);
             return 2; }) });
     engine.addRule({
-        inputB,
+        inputB, {},
         simpleAction({}, [&] (const std::vector<int>& inputs) {
             builtKeys.push_back(inputB);
             return 3; }) });
     engine.addRule({
-        "output",
+        "output", {},
         simpleAction({ inputA, inputB }, [&] (const std::vector<int>& inputs) {
             assert(inputs.size() == 2);
             builtKeys.push_back("output");


### PR DESCRIPTION
Promotes signatures to a first class feature of rules in the engine and
db. Signatures are supplied during rule construction and validated
against the last signature used to build the prior result during
scanning.

Command signatures have been moved out of the build value and into rule
signatures. Nodes now make use of signatures as track changes in the
build graph.

rdar://problem/48578317