### PR TITLE
[plugins] Allocate shell handlers once per build.

### DIFF
--- a/docs/buildsystem-extensions.md
+++ b/docs/buildsystem-extensions.md
@@ -27,7 +27,7 @@ and without needing a complex system-wide registration process).
 ### Extension Discovery
 
 llbuild dynamically discovers the presence of an "extension" for a particular
-tool, but searching the file system for an additional extension configuration
+tool, by searching the file system for an additional extension configuration
 executable adjacent to the tool in the file system. This executable is
 identified by appending `-for-llbuild` to the original tool name. This mechanism
 allows projects to transparently provide llbuild extension support simply by

--- a/include/llbuild/BuildSystem/BuildSystemCommandInterface.h
+++ b/include/llbuild/BuildSystem/BuildSystemCommandInterface.h
@@ -87,7 +87,7 @@ public:
   /// @name BuildSystem Extensions API
   /// @{
 
-  virtual std::unique_ptr<ShellCommandHandler>
+  virtual ShellCommandHandler*
   resolveShellCommandHandler(ShellCommand*) = 0;
   
   /// @}

--- a/include/llbuild/BuildSystem/BuildSystemExtensions.h
+++ b/include/llbuild/BuildSystem/BuildSystemExtensions.h
@@ -45,13 +45,20 @@ public:
 };
 
 /// A concrete build system extension.
+///
+/// NOTE: This class *must* be thread-safe.
 class BuildSystemExtension {
 public:
-  explicit BuildSystemExtension();
+  explicit BuildSystemExtension() {}
   virtual ~BuildSystemExtension();
 
+  /// Instantiate a shell command handler for the given toolpah.
+  ///
+  /// The build system will always create a unique handler for each build
+  /// invocation; the extension should cache the handler if necessary for
+  /// performance.
   virtual std::unique_ptr<ShellCommandHandler>
-  resolveShellCommandHandler(ShellCommand*) = 0;
+  createShellCommandHandler(StringRef toolPath) = 0;
 };
 
 }

--- a/include/llbuild/BuildSystem/BuildSystemHandlers.h
+++ b/include/llbuild/BuildSystem/BuildSystemHandlers.h
@@ -28,24 +28,24 @@ namespace core {
 namespace buildsystem {
 
 class BuildSystemCommandInterface;
-class ExternalCommand;
+class ShellCommand;
 
 class HandlerState {
 public:
-  explicit HandlerState();
+  explicit HandlerState() {}
   virtual ~HandlerState();
 };
   
 class ShellCommandHandler {
 public:
-  explicit ShellCommandHandler();
+  explicit ShellCommandHandler() {}
   virtual ~ShellCommandHandler();
   
   virtual std::unique_ptr<HandlerState>
-  start(BuildSystemCommandInterface&, ExternalCommand* command) const = 0;
+  start(BuildSystemCommandInterface&, ShellCommand* command) const = 0;
 
   virtual void
-  execute(HandlerState*, ExternalCommand* command, BuildSystemCommandInterface&,
+  execute(HandlerState*, ShellCommand* command, BuildSystemCommandInterface&,
           core::Task* task, basic::QueueJobContext* context,
           basic::ProcessCompletionFn) const = 0;
 };

--- a/include/llbuild/BuildSystem/ShellCommand.h
+++ b/include/llbuild/BuildSystem/ShellCommand.h
@@ -87,7 +87,7 @@ class ShellCommand : public ExternalCommand {
   std::atomic<basic::CommandSignature> cachedSignature{ };
 
   /// The handler to use for this command, if present.
-  std::unique_ptr<ShellCommandHandler> handler;
+  ShellCommandHandler* handler;
 
   /// The handler state, if used.
   std::unique_ptr<HandlerState> handlerState;
@@ -120,6 +120,11 @@ public:
     controlEnabled(controlEnabled) { }
 
   virtual const std::vector<StringRef>& getArgs() const { return args; }
+
+  virtual const SmallVector<std::pair<StringRef, StringRef>, 1>&
+  getEnv() const { return env; }
+
+  bool getInheritEnv() const { return inheritEnv; }
   
   virtual void getShortDescription(SmallVectorImpl<char> &result) const override {
     llvm::raw_svector_ostream(result) << getDescription();

--- a/lib/BuildSystem/BuildSystem.cpp
+++ b/lib/BuildSystem/BuildSystem.cpp
@@ -1870,6 +1870,10 @@ llvm::Optional<BuildValue> BuildSystemImpl::build(BuildKey key) {
   // completion).
   executionQueue.reset();
 
+  // Clear out the shell handlers, as we do not want to hold on to them across
+  // multiple builds.
+  shellHandlers.clear();
+
   if (buildWasAborted)
     return None;
   return BuildValue::fromData(result);

--- a/lib/BuildSystem/ShellCommand.cpp
+++ b/lib/BuildSystem/ShellCommand.cpp
@@ -33,8 +33,8 @@ void ShellCommand::start(BuildSystemCommandInterface& bsci,
   handler = bsci.resolveShellCommandHandler(this);
 
   // Delegate to handler, if used.
-  if (auto p = handler.get()) {
-    handlerState = p->start(bsci, this);
+  if (handler) {
+    handlerState = handler->start(bsci, this);
   }
 
   this->ExternalCommand::start(bsci, task);
@@ -364,10 +364,16 @@ void ShellCommand::executeExternalCommand(
   };
       
   // Delegate to the handler, if present.
-  if (auto *p = handler.get()) {
+  if (handler) {
     // FIXME: We should consider making this interface capable of feeding
     // back the dependencies directly.
-    p->execute(
+    //
+    // FIXME: This needs to honor certain properties of the execution queue
+    // (like indicating when the work starts and stops, and communicating with
+    // the execution queue delegate controlling how output is handled). It could
+    // be the case that this should actually be delegating this work to run on
+    // the execution queue, and the queue handles the handoff.
+    handler->execute(
         handlerState.get(), this, bsci, task, context, commandCompletionFn);
     return;
   }

--- a/llbuild.xcodeproj/project.pbxproj
+++ b/llbuild.xcodeproj/project.pbxproj
@@ -3035,7 +3035,6 @@
 			hasScannedForEncodings = 0;
 			knownRegions = (
 				English,
-				en,
 				Base,
 			);
 			mainGroup = E1A223E819F98F1C0059043E;


### PR DESCRIPTION
 - This is more efficient, while also allowing extensions to easily tie their
   lifetime to the lifetime of the build.

 - This also allows the buildsystem to avoid a lock on the common lookup path.