### PR TITLE
Use Windows Lean and Mean

### DIFF
--- a/products/libllbuild/include/llbuild/buildsystem.h
+++ b/products/libllbuild/include/llbuild/buildsystem.h
@@ -27,6 +27,7 @@
 #ifdef _MSC_VER
 // Ignore the conflicting min/max defined in windows.h
 #define NOMINMAX
+#define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 typedef HANDLE llbuild_pid_t;
 typedef HANDLE FD;


### PR DESCRIPTION
Importing non lean and mean Windows.h conflicts with the lean and mean
Windows imported by (Core)Foundation