### PR TITLE
BuildSystem: use `llvm-ar` rather than `ar`

### DIFF
--- a/lib/BuildSystem/BuildSystem.cpp
+++ b/lib/BuildSystem/BuildSystem.cpp
@@ -3252,7 +3252,10 @@ class ArchiveShellCommand : public ExternalCommand {
 
   std::vector<std::string> getArgs() const {
     std::vector<std::string> args;
-    args.push_back("ar");
+    if (const char *ar = std::getenv("AR"))
+      args.push_back(std::string(ar));
+    else
+      args.push_back("ar");
     args.push_back("cr");
     args.push_back(archiveName);
     args.insert(args.end(), archiveInputs.begin(), archiveInputs.end());


### PR DESCRIPTION
Unlike UNIX systems, Windows does not have an archiver.  Traditionally,
this role has been fulfilled by `link`.  Since we already need `clang`
and `LLVM`, let us just switch to `llvm-ar` which can support BSD style
archives (Darwin), GNU style archives (Linux), and SysV archives
(Windows).