### PR TITLE
Windows: Pass the Environment to Subprocesses

### DIFF
--- a/tests/BuildSystem/Build/basic.llbuild
+++ b/tests/BuildSystem/Build/basic.llbuild
@@ -3,18 +3,18 @@
 # RUN: rm -rf %t.build
 # RUN: mkdir -p %t.build
 # RUN: touch "%t.build/input A"
-# RUN: cp %s %t.build/build.llbuild
+# RUN: cat %s | sed -e 's#ENV_PATH#%{env}#g' -e 's#SORT_PATH#%{sort}#g' >  %t.build/build.llbuild
 # RUN: %{llbuild} buildsystem build --serial --chdir %t.build --trace %t.trace > %t.out
 # RUN: %{FileCheck} --input-file=%t.out %s
 # RUN: diff "%t.build/input A" %t.build/output
 #
-# CHECK: /usr/bin/env
+# CHECK: env
 # CHECK: ENV_KEY=ENV_VALUE_1
-# CHECK-NOT: PATH=
-# CHECK: /usr/bin/env
+# CHECK-NOT: {{^PATH=}}
+# CHECK: env
 # CHECK: ENV_KEY=ENV_VALUE_2
 # CHECK: LLBUILD_TASK_ID={{[a-f0-9]+}}
-# CHECK: PATH=random-overridden-path
+# CHECK: {{^PATH=random-overridden-path}}
 # CHECK: cp 'input A' output
 
 # Check the engine trace.
@@ -66,7 +66,7 @@ commands:
   "<env-1>":
     tool: shell
     outputs: ["<env-1>"]
-    args: /usr/bin/env | /usr/bin/sort
+    args: ENV_PATH | SORT_PATH
     env:
       ENV_KEY: ENV_VALUE_1
     inherit-env: false
@@ -75,7 +75,7 @@ commands:
     tool: shell
     inputs: ["<env-1>"]
     outputs: ["<env-2>"]
-    args: /usr/bin/env | /usr/bin/sort
+    args: ENV_PATH | SORT_PATH
     env:
       ENV_KEY: ENV_VALUE_2
       PATH: random-overridden-path
@@ -84,6 +84,7 @@ commands:
     tool: shell
     inputs: ["input A", "<env-1>", "<env-2>"]
     outputs: ["output"]
+    description: "cp 'input A' output"
     # FIXME: Design a limited mechanism for substitution. Might be tool specific.
     args: ["cp", "input A", "output"]
 

--- a/tests/BuildSystem/Build/file-system-opts.llbuild
+++ b/tests/BuildSystem/Build/file-system-opts.llbuild
@@ -3,18 +3,18 @@
 # RUN: rm -rf %t.build
 # RUN: mkdir -p %t.build
 # RUN: touch "%t.build/input A"
-# RUN: cp %s %t.build/build.llbuild
+# RUN: cat %s | sed -e 's#ENV_PATH#%{env}#g' -e 's#SORT_PATH#%{sort}#g' >  %t.build/build.llbuild
 # RUN: %{llbuild} buildsystem build --serial --chdir %t.build --trace %t.trace > %t.out
 # RUN: %{FileCheck} --input-file=%t.out %s
 # RUN: diff "%t.build/input A" %t.build/output
 #
-# CHECK: /usr/bin/env
+# CHECK: env
 # CHECK: ENV_KEY=ENV_VALUE_1
-# CHECK-NOT: PATH=
-# CHECK: /usr/bin/env
+# CHECK-NOT: {{^PATH=}}
+# CHECK: env
 # CHECK: ENV_KEY=ENV_VALUE_2
 # CHECK: LLBUILD_TASK_ID={{[a-f0-9]+}}
-# CHECK: PATH=random-overridden-path
+# CHECK: {{^PATH=random-overridden-path}}
 # CHECK: cp 'input A' output
 
 # Check the engine trace.
@@ -54,6 +54,7 @@
 #
 # CHECK-REBUILD-OUTPUT-REMOVED: cp 'input A' output
 
+
 client:
   name: basic
   file-system: device-agnostic
@@ -68,7 +69,7 @@ commands:
   "<env-1>":
     tool: shell
     outputs: ["<env-1>"]
-    args: /usr/bin/env | /usr/bin/sort
+    args: ENV_PATH | SORT_PATH
     env:
       ENV_KEY: ENV_VALUE_1
     inherit-env: false
@@ -77,7 +78,7 @@ commands:
     tool: shell
     inputs: ["<env-1>"]
     outputs: ["<env-2>"]
-    args: /usr/bin/env | /usr/bin/sort
+    args: ENV_PATH | SORT_PATH
     env:
       ENV_KEY: ENV_VALUE_2
       PATH: random-overridden-path
@@ -87,6 +88,7 @@ commands:
     inputs: ["input A", "<env-1>", "<env-2>"]
     outputs: ["output"]
     # FIXME: Design a limited mechanism for substitution. Might be tool specific.
+    description: "cp 'input A' output"
     args: ["cp", "input A", "output"]
 
 

--- a/tests/BuildSystem/Build/no-control-fd-tool-level.llbuild
+++ b/tests/BuildSystem/Build/no-control-fd-tool-level.llbuild
@@ -3,11 +3,11 @@
 #
 # RUN: rm -rf %t.build
 # RUN: mkdir -p %t.build
-# RUN: cp %s %t.build/build.llbuild
+# RUN: cat %s | sed -e 's#ENV_PATH#%{env}#g' -e 's#SORT_PATH#%{sort}#g' >  %t.build/build.llbuild
 # RUN: %{llbuild} buildsystem build --serial --chdir %t.build --trace %t.trace > %t.out
 # RUN: %{FileCheck} --input-file=%t.out %s
 #
-# CHECK: /usr/bin/env
+# CHECK: env
 # CHECK-NOT: LLBUILD_CONTROL_FD=
 # CHECK: LLBUILD_TASK_ID={{[a-f0-9]+}}
 
@@ -27,4 +27,4 @@ commands:
   "<env>":
     tool: shell
     outputs: ["<env>"]
-    args: /usr/bin/env | /usr/bin/sort
+    args: ENV_PATH | SORT_PATH

--- a/tests/BuildSystem/Build/no-control-fd.llbuild
+++ b/tests/BuildSystem/Build/no-control-fd.llbuild
@@ -3,11 +3,11 @@
 #
 # RUN: rm -rf %t.build
 # RUN: mkdir -p %t.build
-# RUN: cp %s %t.build/build.llbuild
+# RUN: cat %s | sed -e 's#ENV_PATH#%{env}#g' -e 's#SORT_PATH#%{sort}#g' >  %t.build/build.llbuild
 # RUN: %{llbuild} buildsystem build --serial --chdir %t.build --trace %t.trace > %t.out
 # RUN: %{FileCheck} --input-file=%t.out %s
 #
-# CHECK: /usr/bin/env
+# CHECK: env
 # CHECK-NOT: LLBUILD_CONTROL_FD=
 # CHECK: LLBUILD_TASK_ID={{[a-f0-9]+}}
 
@@ -24,4 +24,4 @@ commands:
     tool: shell
     outputs: ["<env>"]
     control-enabled: false
-    args: /usr/bin/env | /usr/bin/sort
+    args: ENV_PATH | SORT_PATH

--- a/tests/lit.cfg
+++ b/tests/lit.cfg
@@ -2,9 +2,18 @@
 
 import platform
 import os
+import subprocess
 
 import lit.formats
 
+def which(cmd):
+    if platform.system() == 'Windows':
+        return subprocess.check_output("where " + cmd, shell=True)\
+            .split('\n')[0]\
+            .strip()\
+            .replace('\\', '\\\\')
+    else:
+        return subprocess.check_output(["which", cmd]).strip()
 # Configuration file for the 'lit' test runner.
 
 ###
@@ -91,6 +100,8 @@ config.substitutions.append( ('%{srcroot}', llbuild_src_root) )
 config.substitutions.append( ('%{swiftc-platform-flags}', "" if not config.osx_sysroot else "-sdk " + config.osx_sysroot) )
 config.substitutions.append( ('%{build-dir}', llbuild_obj_root) ) 
 config.substitutions.append( ('%{libllbuild}', 'libllbuild' if platform.system() == 'Windows' else 'llbuild') )
+config.substitutions.append( ('%{env}', which('env')) )
+config.substitutions.append( ('%{sort}', which('sort')) )
 
 ###
 

--- a/unittests/Basic/POSIXEnvironmentTest.cpp
+++ b/unittests/Basic/POSIXEnvironmentTest.cpp
@@ -18,15 +18,17 @@ using namespace llbuild;
 using namespace llbuild::basic;
 
 namespace {
-  TEST(POSIXEnvironmentTest, basic) {
-    POSIXEnvironment env;
-    env.setIfMissing("a", "aValue");
-    env.setIfMissing("b", "bValue");
-    env.setIfMissing("a", "NOT HERE");
+TEST(POSIXEnvironmentTest, basic) {
+  POSIXEnvironment env;
+  env.setIfMissing("a", "aValue");
+  env.setIfMissing("b", "bValue");
+  env.setIfMissing("a", "NOT HERE");
 
-    auto result = env.getEnvp();
-    EXPECT_EQ(StringRef(result[0]), "a=aValue");
-    EXPECT_EQ(StringRef(result[1]), "b=bValue");
-    EXPECT_EQ(result[2], nullptr);
+#if !defined(_WIN32)
+  auto result = env.getEnvp();
+  EXPECT_EQ(StringRef(result[0]), "a=aValue");
+  EXPECT_EQ(StringRef(result[1]), "b=bValue");
+  EXPECT_EQ(result[2], nullptr);
+#endif
   }
 }


### PR DESCRIPTION
- Properly set up the environment on Windows
- Fix tests which invoke `/usr/bin/env`
- Properly set up the thread array when using WFMO