### PR TITLE
Do Proper Shell Escaping on Windows

### DIFF
--- a/include/llbuild/Basic/ShellUtility.h
+++ b/include/llbuild/Basic/ShellUtility.h
@@ -15,11 +15,19 @@
 
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/raw_ostream.h"
-
-using namespace llvm;
+#include <vector>
 
 namespace llbuild {
 namespace basic {
+
+#if defined(_WIN32)
+/// Formats a command line using the Windows command line escaping rules a la a
+/// reverse CommandLineToArgVW
+///
+/// \param args The arugments to escape
+///
+std::string formatWindowsCommandString(std::vector<std::string> args);
+#endif
 
 /// Appends a shell escaped string to an output stream.
 /// For e.g. hello -> hello, hello$world -> 'hello$world', input A -> 'input A'
@@ -27,15 +35,15 @@ namespace basic {
 /// \param os Reference of the output stream to append to.
 ///
 /// \param string The string to be escaped and appended.
-/// 
-void appendShellEscapedString(llvm::raw_ostream& os, StringRef string);
+///
+void appendShellEscapedString(llvm::raw_ostream& os, llvm::StringRef string);
 
 /// Creates and returns a shell escaped string of the input.
 ///
 /// \param string The string to be escaped.
 ///
 /// \returns escaped string.
-std::string shellEscaped(StringRef string);
+std::string shellEscaped(llvm::StringRef string);
 
 }
 }

--- a/lib/Basic/ShellUtility.cpp
+++ b/lib/Basic/ShellUtility.cpp
@@ -13,11 +13,82 @@
 #include "llbuild/Basic/ShellUtility.h"
 #include "llvm/ADT/SmallString.h"
 
+using namespace llvm;
 namespace llbuild {
 namespace basic {
 
-void appendShellEscapedString(llvm::raw_ostream& os, StringRef string) {
 
+#if defined(_WIN32)
+std::string formatWindowsCommandArg(StringRef string) {
+  // Windows escaping, adapted from Daniel Colascione's "Everyone quotes
+  // command line arguments the wrong way" - Microsoft Developer Blog
+  const std::string needsQuote = " \t\n\v\"";
+  if (string.find_first_of(needsQuote) == std::string::npos) {
+    return string;
+  }
+
+  // To escape the command line, we surround the argument with quotes. However
+  // the complication comes due to how the Windows command line parser treats
+  // backslashes (\) and quotes (")
+  //
+  // - \ is normally treated as a literal backslash
+  //     - e.g. foo\bar\baz => foo\bar\baz
+  // - However, the sequence \" is treated as a literal "
+  //     - e.g. foo\"bar => foo"bar
+  //
+  // But then what if we are given a path that ends with a \? Surrounding
+  // foo\bar\ with " would be "foo\bar\" which would be an unterminated string
+  // since it ends on a literal quote. To allow this case the parser treats:
+  //
+  // - \\" as \ followed by the " metachar
+  // - \\\" as \ followed by a literal "
+  // - In general:
+  //     - 2n \ followed by " => n \ followed by the " metachar
+  //     - 2n+1 \ followed by " => n \ followed by a literal "
+  std::string escaped = "\"";
+  for (auto i = std::begin(string); i != std::end(string); ++i) {
+    int numBackslashes = 0;
+    while (i != string.end() && *i == '\\') {
+      ++i;
+      ++numBackslashes;
+    }
+
+    if (i == string.end()) {
+      // String ends with a backslash e.g. foo\bar\, escape all the backslashes
+      // then add the metachar " below
+      escaped.append(numBackslashes * 2, '\\');
+      break;
+    } else if (*i == '"') {
+      // This is  a string of \ followed by a " e.g. foo\"bar. Escape the
+      // backslashes and the quote
+      escaped.append(numBackslashes * 2 + 1, '\\');
+      escaped.push_back(*i);
+    } else {
+      // These are just literal backslashes
+      escaped.append(numBackslashes, '\\');
+      escaped.push_back(*i);
+    }
+  }
+  escaped.push_back('"');
+
+  return escaped;
+}
+
+std::string formatWindowsCommandString(std::vector<std::string> args) {
+    std::string commandLine;
+    for (auto& arg : args)
+        commandLine += formatWindowsCommandArg(arg) + " ";
+    if (commandLine.size())
+      commandLine.pop_back();
+    return commandLine;
+}
+#endif
+
+void appendShellEscapedString(llvm::raw_ostream& os, StringRef string) {
+#if defined(_WIN32)
+  os << formatWindowsCommandArg(string);
+  return;
+#else
   static const std::string whitelist = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890-_/:@#%+=.,";
   auto pos = string.find_first_not_of(whitelist);
 
@@ -27,32 +98,27 @@ void appendShellEscapedString(llvm::raw_ostream& os, StringRef string) {
     return;
   }
 
-#if defined(_WIN32)
-  std::string escQuote = "\"";
-#else
   std::string escQuote = "'";
-#endif
   // We only need to escape the single quote, if it isn't present we can
   // escape using single quotes.
-  auto singleQuotePos = string.find_first_of(escQuote, pos);
+  auto singleQuotePos = string.find_first_of("'" , pos);
   if (singleQuotePos == std::string::npos) {
-    os << escQuote;
-    os << string;
-    os << escQuote;
+    os << "'" << string << "'";
     return;
   }
 
   // Otherwise iterate and escape all the single quotes.
-  os << escQuote;
+  os << "'";
   os << string.slice(0, singleQuotePos);
   for (auto idx = singleQuotePos; idx < string.size(); idx++) {
-    if (string[idx] == escQuote[0]) {
-      os << escQuote << "\\" << escQuote << escQuote;
+    if (string[idx] == '\'') {
+      os << "'\\''";
     } else {
       os << string[idx];
     }
   }
-  os << escQuote;
+  os << "'";
+#endif
 }
 
 std::string shellEscaped(StringRef string) {

--- a/lib/Basic/Subprocess.cpp
+++ b/lib/Basic/Subprocess.cpp
@@ -14,6 +14,7 @@
 
 #include "llbuild/Basic/CrossPlatformCompatibility.h"
 #include "llbuild/Basic/PlatformUtility.h"
+#include "llbuild/Basic/ShellUtility.h"
 
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/StringRef.h"
@@ -409,7 +410,7 @@ void llbuild::basic::spawnProcess(
   // Form the complete C string command line.
   std::vector<std::string> argsStorage(commandLine.begin(), commandLine.end());
 #if defined(_WIN32)
-  std::string args = llvm::sys::flattenWindowsCommandLine(commandLine);
+  std::string args = llbuild::basic::formatWindowsCommandString(argsStorage);
 
   // Convert the command line string to utf16
   llvm::SmallVector<llvm::UTF16, 20> u16Executable;

--- a/lib/BuildSystem/BuildSystem.cpp
+++ b/lib/BuildSystem/BuildSystem.cpp
@@ -62,6 +62,7 @@
 #include <unistd.h>
 #endif
 
+using namespace llvm;
 using namespace llbuild;
 using namespace llbuild::basic;
 using namespace llbuild::core;

--- a/lib/BuildSystem/ShellCommand.cpp
+++ b/lib/BuildSystem/ShellCommand.cpp
@@ -22,6 +22,7 @@
 #include "llvm/Support/MemoryBuffer.h"
 #include "llvm/Support/Path.h"
 
+using namespace llvm;
 using namespace llbuild;
 using namespace llbuild::basic;
 using namespace llbuild::core;

--- a/tests/BuildSystem/Build/windows-shell-parsing.llbuild
+++ b/tests/BuildSystem/Build/windows-shell-parsing.llbuild
@@ -1,0 +1,80 @@
+# REQUIRES: platform=Windows
+#
+# RUN: rm -rf %t.build
+# RUN: mkdir -p %t.build
+# RUN: mkdir -p "%t.build/dir with space"
+# RUN: touch "%t.build/dir with space/file with space"
+# RUN: cp %s %t.build/build.llbuild
+# RUN: %{llbuild} buildsystem build --serial --chdir %t.build > %t.out
+# RUN: %{FileCheck} --input-file=%t.out %s
+#
+# CHECK: fake\1\
+# CHECK: fake\2\
+# CHECK: %FOO%
+# CHECK: BAZ
+# CHECK: BUZZ
+# CHECK: \"wonky quote\\\"
+# CHECK-NEXT: next\"
+# CHECK: file\ with\ space
+# CHECK: foo"
+
+client:
+  name: basic
+
+targets:
+  "": ["<fake8>"]
+
+commands:
+  path:
+    tool: shell
+    outputs: ["<fake1>"]
+    args: echo fake\1\
+  path-end:
+    tool: shell
+    inputs: ["<fake1>"]
+    outputs: ["<fake2>"]
+    args: ["echo", "fake\\2\\"]
+# Directly invoking echo should not parse the environment variable
+  escape1:
+    tool: shell
+    inputs: ["<fake2>"]
+    outputs: ["<fake3>"]
+    env:
+        FOO: BAR
+    inherit-env: false
+    args: ["echo", "%FOO%"]
+# But invoking through cmd.exe should parse the environment variable
+  escape2:
+    tool: shell
+    inputs: ["<fake3>"]
+    outputs: ["<fake4>"]
+    inherit-env: false
+    env:
+        FOO: BAZ
+    args: echo %FOO%
+  escape3:
+    tool: shell
+    inputs: ["<fake4>"]
+    outputs: ["<fake5>"]
+    inherit-env: false
+    env:
+        FOO: BUZZ
+    args: ["cmd.exe", "/C", "echo %FOO%"]
+  escape4:
+    tool: shell
+    inputs: ["<fake5>"]
+    outputs: ["<fake6>"]
+    inherit-env: false
+    env:
+        INPUT1: quote
+    args: echo "wonky %INPUT1%\"&echo next"
+  spaces:
+    tool: shell
+    inputs: ["<fake6>"]
+    outputs: ["<fake7>"]
+    args: ["dir", "dir with space"]
+  quote:
+    tool: shell
+    inputs: ["<fake7>"]
+    outputs: ["<fake8>"]
+    args: ["echo", "foo\""]


### PR DESCRIPTION
If the comments are too much/over the top, I can remove/reduce them. They were mostly there for my own benefit, but I left them in because exactly what it's doing is a bit cryptic otherwise.