### PR TITLE
build: adjust for new build layout

### DIFF
--- a/products/llbuildSwift/CMakeLists.txt
+++ b/products/llbuildSwift/CMakeLists.txt
@@ -13,8 +13,8 @@ else()
   if(FOUNDATION_BUILD_DIR)
     list(APPEND additional_args
       -L${FOUNDATION_BUILD_DIR}
-      -Fsystem
-      ${FOUNDATION_BUILD_DIR}/CoreFoundation-prefix/System/Library/Frameworks
+      -Fsystem ${FOUNDATION_BUILD_DIR}
+      -Fsystem ${FOUNDATION_BUILD_DIR}/CoreFoundation-prefix/System/Library/Frameworks
       -I${FOUNDATION_BUILD_DIR}/swift)
   endif()
   if(LIBDISPATCH_BUILD_DIR)


### PR DESCRIPTION
Moving CoreFoundation into the root is needed to actually get the proper
dependency tracking for Foundation builds. This adjusts the use of it
in llbuild.