### PR TITLE
[BuildSystem] Enable fast cancellation

### DIFF
--- a/lib/BuildSystem/BuildSystem.cpp
+++ b/lib/BuildSystem/BuildSystem.cpp
@@ -394,8 +394,13 @@ public:
 
     isCancelled_ = true;
     // Cancel jobs if we actually have a queue.
-    if (executionQueue.get() != nullptr)
+    if (executionQueue.get() != nullptr) {
+      // Ask the engine to cancel all pending work.
+      getBuildEngine().cancelBuild();
+
+      // Ask the execution queue to cancel currently running jobs.
       getExecutionQueue().cancelAllJobs();
+    }
   }
 
   /// Check if the build has been cancelled.


### PR DESCRIPTION
Re-enable use of engine support for fast cancellation. This time,
updating BuildSystemFrontend to mark the build as unsuccessful when
cancelled.

rdar://problem/31792710