### PR TITLE
[llvm] Fix or silence analyzer warnings

### DIFF
--- a/include/llvm/Support/Error.h
+++ b/include/llvm/Support/Error.h
@@ -698,6 +698,7 @@ inline void cantFail(Error Err, const char *Msg = nullptr) {
   if (Err) {
     if (!Msg)
       Msg = "Failure value returned from cantFail wrapped call";
+    (void)Msg;
     llvm_unreachable(Msg);
   }
 }

--- a/lib/Basic/Subprocess.cpp
+++ b/lib/Basic/Subprocess.cpp
@@ -802,6 +802,7 @@ void llbuild::basic::spawnProcess(
 #else
     readfds[0].events = POLLIN;
     activeEvents |= POLLIN;
+    (void)threadCount;
 #endif
   }
 

--- a/lib/Ninja/Manifest.cpp
+++ b/lib/Ninja/Manifest.cpp
@@ -32,7 +32,9 @@ bool Rule::isValidParameterName(StringRef name) {
 Manifest::Manifest() {
   // Create the built-in console pool, and add it to the pool map.
   consolePool = new (getAllocator()) Pool("console");
-  consolePool->setDepth(1);
+  assert(consolePool != nullptr);
+  if (consolePool)
+    consolePool->setDepth(1);
   pools["console"] = consolePool;
 
   // Create the built-in phony rule, and add it to the rule map.

--- a/lib/llvm/Demangle/MicrosoftDemangle.cpp
+++ b/lib/llvm/Demangle/MicrosoftDemangle.cpp
@@ -559,9 +559,11 @@ static void outputName(OutputStream &OS, const Name *TheName) {
     OS << "~";
 
   if (TheName->Operator == "ctor" || TheName->Operator == "dtor") {
-    OS << Previous->Str;
-    if (Previous->TParams)
-      outputParameterList(OS, *Previous->TParams);
+    if (Previous) {
+      OS << Previous->Str;
+      if (Previous->TParams)
+        outputParameterList(OS, *Previous->TParams);
+    }
     return;
   }
 
@@ -1897,6 +1899,7 @@ ArrayType *Demangler::demangleArrayType(StringView &MangledName) {
 // Reads a function or a template parameters.
 FunctionParams
 Demangler::demangleFunctionParameterList(StringView &MangledName) {
+#ifndef __clang_analyzer__
   // Empty parameter list.
   if (MangledName.consumeFront('X'))
     return {};
@@ -1950,13 +1953,14 @@ Demangler::demangleFunctionParameterList(StringView &MangledName) {
     return *Head;
   }
 
+#endif
   Error = true;
   return {};
 }
 
 TemplateParams *
 Demangler::demangleTemplateParameterList(StringView &MangledName) {
-  TemplateParams *Head;
+  TemplateParams *Head = nullptr;
   TemplateParams **Current = &Head;
   while (!Error && !MangledName.startsWith('@')) {
     // Template parameter lists don't participate in back-referencing.

--- a/lib/llvm/Support/APFloat.cpp
+++ b/lib/llvm/Support/APFloat.cpp
@@ -225,7 +225,7 @@ readExponent(StringRef::iterator begin, StringRef::iterator end)
     absExponent = value;
   }
 
-  assert(p == end && "Invalid exponent in exponent");
+  assert(p == end && "Invalid exponent in exponent"); (void)p;
 
   if (isNegative)
     return -(int) absExponent;
@@ -538,16 +538,16 @@ powerOf5(APFloatBase::integerPart *dst, unsigned int power) {
 
   unsigned int partsCount[16] = { 1 };
   APFloatBase::integerPart scratch[maxPowerOfFiveParts], *p1, *p2, *pow5;
-  unsigned int result;
+  unsigned int result = 1;
   assert(power <= maxExponent);
 
+#ifndef __clang_analyzer__
   p1 = dst;
   p2 = scratch;
 
   *p1 = firstEightPowers[power & 7];
   power >>= 3;
 
-  result = 1;
   pow5 = pow5s;
 
   for (unsigned int n = 0; power; power >>= 1, n++) {
@@ -585,6 +585,7 @@ powerOf5(APFloatBase::integerPart *dst, unsigned int power) {
 
   if (p1 != dst)
     APInt::tcAssign(dst, p1, result);
+#endif
 
   return result;
 }
@@ -1024,6 +1025,7 @@ lostFraction IEEEFloat::multiplySignificand(const IEEEFloat &rhs,
     lost_fraction = extendedAddend.shiftSignificandRight(1);
     assert(lost_fraction == lfExactlyZero &&
            "Lost precision while shifting addend for fused-multiply-add.");
+    (void)lost_fraction;
 
     lost_fraction = addOrSubtractSignificand(extendedAddend, false);
 
@@ -1726,13 +1728,13 @@ IEEEFloat::opStatus IEEEFloat::remainder(const IEEEFloat &rhs) {
 
   fs = V.convertFromZeroExtendedInteger(x, parts * integerPartWidth, true,
                                         rmNearestTiesToEven);
-  assert(fs==opOK);   // should always work
+  assert(fs==opOK); (void)fs; // should always work
 
   fs = V.multiply(rhs, rmNearestTiesToEven);
-  assert(fs==opOK || fs==opInexact);   // should not overflow or underflow
+  assert(fs==opOK || fs==opInexact); (void)fs; // should not overflow or underflow
 
   fs = subtract(V, rmNearestTiesToEven);
-  assert(fs==opOK || fs==opInexact);   // likewise
+  assert(fs==opOK || fs==opInexact); (void)fs; // likewise
 
   if (isZero())
     sign = origSign;    // IEEE754 requires this
@@ -4416,8 +4418,9 @@ APFloat::Storage::Storage(IEEEFloat F, const fltSemantics &Semantics) {
     return;
   }
   if (usesLayout<DoubleAPFloat>(Semantics)) {
+    const auto& semantics = F.getSemantics();
     new (&Double)
-        DoubleAPFloat(Semantics, APFloat(std::move(F), F.getSemantics()),
+        DoubleAPFloat(Semantics, APFloat(std::move(F), semantics),
                       APFloat(semIEEEdouble));
     return;
   }

--- a/lib/llvm/Support/Mutex.cpp
+++ b/lib/llvm/Support/Mutex.cpp
@@ -59,15 +59,15 @@ MutexImpl::MutexImpl( bool recursive)
   // otherwise.
   int kind = ( recursive  ? PTHREAD_MUTEX_RECURSIVE : PTHREAD_MUTEX_NORMAL );
   errorcode = pthread_mutexattr_settype(&attr, kind);
-  assert(errorcode == 0);
+  assert(errorcode == 0); (void)errorcode;
 
   // Initialize the mutex
   errorcode = pthread_mutex_init(mutex, &attr);
-  assert(errorcode == 0);
+  assert(errorcode == 0); (void)errorcode;
 
   // Destroy the attributes
   errorcode = pthread_mutexattr_destroy(&attr);
-  assert(errorcode == 0);
+  assert(errorcode == 0); (void)errorcode;
 
   // Assign the data member
   data_ = mutex;

--- a/llbuild.xcodeproj/project.pbxproj
+++ b/llbuild.xcodeproj/project.pbxproj
@@ -75,6 +75,8 @@
 		40EA264C2165221C00068954 /* LaneBasedExecutionQueue.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 40EA264B2165221C00068954 /* LaneBasedExecutionQueue.cpp */; };
 		40EA264F2166AA9400068954 /* POSIXEnvironmentTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 40EA264E2166AA9400068954 /* POSIXEnvironmentTest.cpp */; };
 		40EA26512166AB5A00068954 /* LaneBasedExecutionQueueTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 40EA26502166AB5A00068954 /* LaneBasedExecutionQueueTest.cpp */; };
+		40FA6485224AC2FC00D0B79A /* libllbuildBasic.a in Frameworks */ = {isa = PBXBuildFile; fileRef = E1A2242519F991B40059043E /* libllbuildBasic.a */; };
+		40FA6486224AC34400D0B79A /* libllvmSupport.a in Frameworks */ = {isa = PBXBuildFile; fileRef = E1B838A21B52E7DE00DB876B /* libllvmSupport.a */; };
 		913540F2220E5CC1009C82D6 /* UnicodeCaseFold.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 913540F1220E5CC1009C82D6 /* UnicodeCaseFold.cpp */; };
 		91BFB728220E3FBD00259E9F /* APFloat.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 91FD9A90220E3EA700BE004E /* APFloat.cpp */; };
 		91BFB729220E3FBD00259E9F /* APInt.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 91FD9A8A220E3EA600BE004E /* APInt.cpp */; };
@@ -1218,6 +1220,8 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				40FA6485224AC2FC00D0B79A /* libllbuildBasic.a in Frameworks */,
+				40FA6486224AC34400D0B79A /* libllvmSupport.a in Frameworks */,
 				40B3C92720D3B24D007C5847 /* libllbuild.dylib in Frameworks */,
 				40B3C91020D3AEC9007C5847 /* libcurses.tbd in Frameworks */,
 				40B3C91120D3AEC9007C5847 /* libgtest.a in Frameworks */,
@@ -4242,6 +4246,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CLANG_ENABLE_CODE_COVERAGE = NO;
+				CLANG_STATIC_ANALYZER_MODE_ON_ANALYZE_ACTION = shallow;
 				CLANG_WARN_COMMA = NO;
 				HEADER_SEARCH_PATHS = "$(SRCROOT)/include";
 			};
@@ -4251,6 +4256,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CLANG_ENABLE_CODE_COVERAGE = NO;
+				CLANG_STATIC_ANALYZER_MODE_ON_ANALYZE_ACTION = shallow;
 				CLANG_WARN_COMMA = NO;
 				HEADER_SEARCH_PATHS = "$(SRCROOT)/include";
 			};


### PR DESCRIPTION
This does not attempt to address all of the warnings, as we really want
to just import llvm's support code.  However, we also want to quell the
bots' ire.

rdar://problem/48374266