### PR TITLE
[perftests] Clean up after testSupprocessSpawnWorkingDirectory

### DIFF
--- a/lib/Commands/NinjaCommand.cpp
+++ b/lib/Commands/NinjaCommand.cpp
@@ -406,7 +406,7 @@ static int executeLoadManifestCommand(const std::vector<std::string>& args,
   if (pos != std::string::npos) {
     if (!sys::chdir(filename.substr(0, pos).c_str())) {
       fprintf(stderr, "error: %s: unable to chdir(): %s\n",
-              getProgramName(), strerror(errno));
+              getProgramName(), sys::strerror(errno).c_str());
       return 1;
     }
     filename = filename.substr(pos+1);

--- a/perftests/Xcode/PerfTests/BuildSystemPerfTests.mm
+++ b/perftests/Xcode/PerfTests/BuildSystemPerfTests.mm
@@ -18,6 +18,11 @@
 
 #import <XCTest/XCTest.h>
 
+extern "C" {
+    // Provided by System.framework's libsystem_kernel interface
+    extern int __pthread_fchdir(int fd);
+}
+
 using namespace llbuild;
 using namespace llbuild::basic;
 
@@ -109,6 +114,10 @@ class PerfTestProcessDelegate : public ProcessDelegate {
             spawnProcess(delegate, nullptr, pgrp, handle, cmd, environment, attr, std::move(releaseFn), std::move(completionFn));
         }
     }];
+
+    // Reset (remove) per-thread working directory in case it was set by the
+    // above process spawning.
+    __pthread_fchdir(-1);
 }
 
 


### PR DESCRIPTION
Spawning processes with a working directory may leave the thread working
directory set.  Clean up by resetting it to the process level working
dir.

rdar://problem/48978131