### PR TITLE
Update manifest to tools version 5

### DIFF
--- a/Package@swift-4.2.swift
+++ b/Package@swift-4.2.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.0
+// swift-tools-version:4.2.0
 
 // This file defines Swift package manager support for llbuild. See:
 //  https://github.com/apple/swift-package-manager/tree/master/Documentation
@@ -55,8 +55,7 @@ let package = Package(
         .target(
             name: "llbuildCore",
             dependencies: ["llbuildBasic"],
-            path: "lib/Core",
-            linkerSettings: [.linkedLibrary("sqlite3")]
+            path: "lib/Core"
         ),
         .target(
             name: "llbuildBuildSystem",
@@ -117,8 +116,7 @@ let package = Package(
         .target(
             name: "llvmSupport",
             dependencies: ["llvmDemangle"],
-            path: "lib/llvm/Support",
-            linkerSettings: [.linkedLibrary("ncurses")]
+            path: "lib/llvm/Support"
         ),
     ],
     cxxLanguageStandard: .cxx14


### PR DESCRIPTION
This updates the manifest to tools version 5 so we can use the new API
for setting linker flags. There is also a version-specific manifest for
older Swift 4.2 clients.