### PR TITLE
Fix ArchiveShellCommand's verbose description output.

### DIFF
--- a/lib/BuildSystem/BuildSystem.cpp
+++ b/lib/BuildSystem/BuildSystem.cpp
@@ -3234,11 +3234,11 @@ class ArchiveShellCommand : public ExternalCommand {
     llvm::raw_svector_ostream stream(result);
     bool first = true;
     for (const auto& arg: getArgs()) {
-      stream << arg;
       if (!first) {
         stream << " ";
-        first = false;
       }
+      first = false;
+      stream << arg;
     }
   }
   


### PR DESCRIPTION
`ArchiveShellCommand::getVerboseDescription()` had wasn't correctly using the `bool first` variable it created. It was set to `true`,  but the loop only ever checked if it was `false` and, if so, it would insert a space and set it to false. Since it never was false, the verbose description would never contain spaces between arguments.

This change makes this code do what I imagine was the intent: insert a space _before_ all arguments except the first.