### PR TITLE
First draft for BuildDB bindings

### DIFF
--- a/BuildDBSwiftBindingTest/main.swift
+++ b/BuildDBSwiftBindingTest/main.swift
@@ -10,24 +10,12 @@ import Foundation
 
 let path = "/Users/benjaminherzog/Library/Developer/Xcode/DerivedData/TEMPApp-bairfqxgkpxvqbglrdmnhebkyovk/Build/Intermediates.noindex/XCBuildData/build.db"
 
-class Delegate: BuildDBDelegate {
-  var allKeys: BuildDBFetchKeysResult?
-  
-  func getKey(id: KeyID) -> KeyType {
-    return allKeys?.getKey(id: id) ?? ""
-  }
-  func getKeyID(key: KeyType) -> KeyID {
-    return allKeys?.getKeyID(key: key) ?? 0
-  }
-}
-
 do {
-  let delegate = Delegate()
-  try Database(path: path, clientSchemaVersion: 9, delegate: delegate)
-    .startSession { db in
-      delegate.allKeys = try db.getKeys()
-      dump(try db.lookupRuleResult(keyID: 2))
-    }
+  let db = try BuildDB(path: path, clientSchemaVersion: 9)
+  
+  for key in try db.getKeys() {
+    print(key)
+  }
   
 } catch {
   dump(error)

--- a/BuildDBSwiftBindingTest/main.swift
+++ b/BuildDBSwiftBindingTest/main.swift
@@ -2,14 +2,13 @@
 //  main.swift
 //  BuildDBSwiftBindingTest
 //
-//  Created by Benjamin Herzog on 4/5/19.
 //  Copyright © 2019 Apple Inc. All rights reserved.
 //
 
 import llbuild
 import Foundation
 
-let path = "/Users/benjaminherzog/Library/Developer/Xcode/DerivedData/Xcode-dsrbecsbudaaencdxnuiisivqcqe/Build/Intermediates.noindex/XCBuildData/build.db"
+let path = "/Users/benjaminherzog/Library/Developer/Xcode/DerivedData/TEMPApp-bairfqxgkpxvqbglrdmnhebkyovk/Build/Intermediates.noindex/XCBuildData/build.db"
 
 class Delegate: BuildDBDelegate {
   var allKeys: BuildDBFetchKeysResult?

--- a/BuildDBSwiftBindingTest/main.swift
+++ b/BuildDBSwiftBindingTest/main.swift
@@ -7,28 +7,29 @@
 //
 
 import llbuild
+import Foundation
 
-class DBDelegate: BuildDBDelegate {
-  func getKeyID(key: KeyType) -> KeyID {
-    return 1
-  }
+let path = "/Users/benjaminherzog/Library/Developer/Xcode/DerivedData/Xcode-dsrbecsbudaaencdxnuiisivqcqe/Build/Intermediates.noindex/XCBuildData/build.db"
+
+class Delegate: BuildDBDelegate {
+  var allKeys: BuildDBFetchKeysResult?
   
   func getKey(id: KeyID) -> KeyType {
-    return "foobar"
+    return allKeys?.getKey(id: id) ?? ""
+  }
+  func getKeyID(key: KeyType) -> KeyID {
+    return allKeys?.getKeyID(key: key) ?? 0
   }
 }
 
-
-let delegate = DBDelegate()
-
-let path = "/Users/benjaminherzog/Library/Developer/Xcode/DerivedData/MyLibrary-dlfxkvgmyqjkrzewapdqjktwlglm/Build/Intermediates.noindex/XCBuildData/build.db"
-
 do {
-  let db = try BuildDB(path: path, clientSchemaVersion: 9, delegate: delegate)
+  let delegate = Delegate()
+  try Database(path: path, clientSchemaVersion: 9, delegate: delegate)
+    .startSession { db in
+      delegate.allKeys = try db.getKeys()
+      dump(try db.lookupRuleResult(keyID: 2))
+    }
   
-  for element in try db.getKeys() {
-    dump(element)
-  }
 } catch {
   dump(error)
 }

--- a/BuildDBSwiftBindingTest/main.swift
+++ b/BuildDBSwiftBindingTest/main.swift
@@ -1,0 +1,36 @@
+//
+//  main.swift
+//  BuildDBSwiftBindingTest
+//
+//  Created by Benjamin Herzog on 4/5/19.
+//  Copyright © 2019 Apple Inc. All rights reserved.
+//
+
+import llbuild
+
+class DBDelegate: BuildDBDelegate {
+  func getKeyID(key: KeyType) -> KeyID {
+    return 1
+  }
+  
+  func getKey(id: KeyID) -> KeyType {
+    return "foobar"
+  }
+}
+
+
+let delegate = DBDelegate()
+
+let path = "/Users/benjaminherzog/Library/Developer/Xcode/DerivedData/MyLibrary-dlfxkvgmyqjkrzewapdqjktwlglm/Build/Intermediates.noindex/XCBuildData/build.db"
+
+do {
+  let db = try BuildDB(path: path, clientSchemaVersion: 9, delegate: delegate)
+  
+  for element in try db.getKeys() {
+    dump(element)
+  }
+} catch {
+  dump(error)
+}
+
+

--- a/include/llbuild/Core/BuildDB.h
+++ b/include/llbuild/Core/BuildDB.h
@@ -21,6 +21,7 @@
 #include <cstdint>
 #include <memory>
 #include <string>
+#include <map>
 
 namespace llbuild {
 namespace core {
@@ -127,8 +128,8 @@ public:
   ///
   /// \param keys_out [out] The known keys will be appended to this vector.
   /// \param error_out [out] Error string if return value is false.
-  virtual bool getKeys(std::vector<KeyType>& keys_out, std::string* error_out) = 0;
-
+  virtual bool getKeys(std::map<KeyID, KeyType>& keys_out, std::string* error_out) = 0;
+  
   /// Dump a debug view of the database contents
   virtual void dump(raw_ostream& os) { (void)os; }
 };

--- a/include/llbuild/Core/BuildDB.h
+++ b/include/llbuild/Core/BuildDB.h
@@ -128,8 +128,8 @@ public:
   ///
   /// \param keys_out [out] The known keys will be appended to this vector.
   /// \param error_out [out] Error string if return value is false.
-  virtual bool getKeys(std::map<KeyID, KeyType>& keys_out, std::string* error_out) = 0;
-  
+  virtual bool getKeys(std::vector<KeyType>& keys_out, std::string* error_out) = 0;
+
   /// Dump a debug view of the database contents
   virtual void dump(raw_ostream& os) { (void)os; }
 };

--- a/lib/Commands/BuildSystemCommand.cpp
+++ b/lib/Commands/BuildSystemCommand.cpp
@@ -718,15 +718,14 @@ static int executeDBCommand(std::vector<std::string> args) {
     }
   } else if (action == "list-keys") {
     std::string error;
-    std::map<KeyID, KeyType> keys;
-    
+    std::vector<KeyType> keys;
     if (!buildDB->getKeys(keys, &error)) {
       fprintf(stderr, "error: failed to get keys: %s\n\n", error.c_str());
       ::exit(1);
     }
 
     for (auto key: keys) {
-      printf("%llu: %s\n", std::get<0>(key), std::get<1>(key).c_str());
+      printf("%s\n", key.c_str());
     }
   } else if (action == "dump") {
     buildDB->dump(llvm::outs());

--- a/lib/Commands/BuildSystemCommand.cpp
+++ b/lib/Commands/BuildSystemCommand.cpp
@@ -718,14 +718,15 @@ static int executeDBCommand(std::vector<std::string> args) {
     }
   } else if (action == "list-keys") {
     std::string error;
-    std::vector<KeyType> keys;
+    std::map<KeyID, KeyType> keys;
+    
     if (!buildDB->getKeys(keys, &error)) {
       fprintf(stderr, "error: failed to get keys: %s\n\n", error.c_str());
       ::exit(1);
     }
 
     for (auto key: keys) {
-      printf("%s\n", key.c_str());
+      printf("%llu: %s\n", std::get<0>(key), std::get<1>(key).c_str());
     }
   } else if (action == "dump") {
     buildDB->dump(llvm::outs());

--- a/lib/Core/SQLiteBuildDB.cpp
+++ b/lib/Core/SQLiteBuildDB.cpp
@@ -660,7 +660,7 @@ public:
     close();
   }
 
-  virtual bool getKeys(std::vector<KeyType>& keys_out, std::string* error_out) override {
+  virtual bool getKeys(std::map<KeyID, KeyType>& keys_out, std::string* error_out) override {
     std::lock_guard<std::mutex> guard(dbMutex);
 
     if (!open(error_out))
@@ -669,17 +669,18 @@ public:
     // Search for the key in the database
     int result;
     sqlite3_stmt* stmt;
-    result = sqlite3_prepare_v2(db, "SELECT key FROM key_names;",
+    result = sqlite3_prepare_v2(db, "SELECT id, key FROM key_names;",
                                 -1, &stmt, nullptr);
     checkSQLiteResultOKReturnFalse(result);
 
     while (sqlite3_step(stmt) == SQLITE_ROW) {
-      assert(sqlite3_column_count(stmt) == 1);
+      assert(sqlite3_column_count(stmt) == 2);
 
-      auto size = sqlite3_column_bytes(stmt, 0);
-      auto text = (const char*) sqlite3_column_text(stmt, 0);
-
-      keys_out.push_back(KeyType(text, size));
+      auto id = sqlite3_column_int64(stmt, 0);
+      auto size = sqlite3_column_bytes(stmt, 1);
+      auto text = (const char*) sqlite3_column_text(stmt, 1);
+      
+      keys_out[id] = KeyType(text, size);
     }
 
     sqlite3_finalize(stmt);
@@ -706,7 +707,7 @@ public:
 
     os << "keys:\n";
     while (sqlite3_step(stmt) == SQLITE_ROW) {
-      assert(sqlite3_column_count(stmt) == 1);
+      assert(sqlite3_column_count(stmt) == 2);
 
       auto size = sqlite3_column_bytes(stmt, 0);
       auto text = (const char*) sqlite3_column_text(stmt, 0);
@@ -726,7 +727,7 @@ public:
 
     os << "\nresults:\n";
     while (sqlite3_step(stmt) == SQLITE_ROW) {
-      assert(sqlite3_column_count(stmt) == 1);
+      assert(sqlite3_column_count(stmt) == 3);
 
       auto id = sqlite3_column_int64(stmt, 0);
       auto built = sqlite3_column_int64(stmt, 1);

--- a/llbuild.xcodeproj/project.pbxproj
+++ b/llbuild.xcodeproj/project.pbxproj
@@ -116,6 +116,12 @@
 		C5740D0A1E03527B00567DD8 /* libllbuildCore.a in Frameworks */ = {isa = PBXBuildFile; fileRef = E1A2243E19F997150059043E /* libllbuildCore.a */; };
 		C5740D0B1E03528600567DD8 /* libllbuildBasic.a in Frameworks */ = {isa = PBXBuildFile; fileRef = E1A2242519F991B40059043E /* libllbuildBasic.a */; };
 		C5740D0C1E03529300567DD8 /* libsqlite3.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = E1E221081A00B82100957481 /* libsqlite3.tbd */; };
+		E033BA782257BA1E0046E0F4 /* BuildDB-C-API.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E033BA772257BA1E0046E0F4 /* BuildDB-C-API.cpp */; };
+		E033BA792257BA230046E0F4 /* BuildDB-C-API.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E033BA772257BA1E0046E0F4 /* BuildDB-C-API.cpp */; };
+		E0E37CA42257BE9B001F2B00 /* BuildDBBindings.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0E37CA32257BE9B001F2B00 /* BuildDBBindings.swift */; };
+		E0E37CA52257DADD001F2B00 /* db.h in Headers */ = {isa = PBXBuildFile; fileRef = E080BE432256DD970047E3F7 /* db.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		E0E37CAD2257EFE5001F2B00 /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0E37CAC2257EFE5001F2B00 /* main.swift */; };
+		E0E37CB12257F001001F2B00 /* llbuild.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E1D191BE1B47232B000C4E95 /* llbuild.framework */; };
 		E104FAF71B655A97005C68A0 /* BuildSystemPerfTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = E104FAF61B655A97005C68A0 /* BuildSystemPerfTests.mm */; };
 		E104FAFA1B655BBA005C68A0 /* libllbuildBuildSystem.a in Frameworks */ = {isa = PBXBuildFile; fileRef = E1B839571B541BFD00DB876B /* libllbuildBuildSystem.a */; };
 		E104FAFB1B655C33005C68A0 /* libllvmSupport.a in Frameworks */ = {isa = PBXBuildFile; fileRef = E1B838A21B52E7DE00DB876B /* libllvmSupport.a */; };
@@ -337,6 +343,13 @@
 			proxyType = 1;
 			remoteGlobalIDString = 9DB047A71DF9D43D006CDF52;
 			remoteInfo = BuildSystemTests;
+		};
+		E0E37CB22257F006001F2B00 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = E1A223E919F98F1C0059043E /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = E1D191BD1B47232B000C4E95;
+			remoteInfo = "llbuild-framework";
 		};
 		E104FAF81B655BB2005C68A0 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -723,6 +736,15 @@
 			);
 			runOnlyForDeploymentPostprocessing = 1;
 		};
+		E0E37CA82257EFE5001F2B00 /* CopyFiles */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = /usr/share/man/man1/;
+			dstSubfolderSpec = 0;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 1;
+		};
 		E147DF111BA81D330032D08E /* CopyFiles */ = {
 			isa = PBXCopyFilesBuildPhase;
 			buildActionMask = 2147483647;
@@ -924,6 +946,11 @@
 		BC8DEF0720300AAF00E9EF0C /* CoreBindings.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CoreBindings.swift; sourceTree = "<group>"; };
 		C5740D081E03523100567DD8 /* BuildSystemFrontendTest.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = BuildSystemFrontendTest.cpp; sourceTree = "<group>"; };
 		C5740D0D1E0352D800567DD8 /* CMakeLists.txt */ = {isa = PBXFileReference; lastKnownFileType = text; path = CMakeLists.txt; sourceTree = "<group>"; };
+		E033BA772257BA1E0046E0F4 /* BuildDB-C-API.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "BuildDB-C-API.cpp"; sourceTree = "<group>"; };
+		E080BE432256DD970047E3F7 /* db.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = db.h; sourceTree = "<group>"; };
+		E0E37CA32257BE9B001F2B00 /* BuildDBBindings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BuildDBBindings.swift; sourceTree = "<group>"; };
+		E0E37CAA2257EFE5001F2B00 /* BuildDBSwiftBindingTest */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = BuildDBSwiftBindingTest; sourceTree = BUILT_PRODUCTS_DIR; };
+		E0E37CAC2257EFE5001F2B00 /* main.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; };
 		E104FAF61B655A97005C68A0 /* BuildSystemPerfTests.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = BuildSystemPerfTests.mm; sourceTree = "<group>"; };
 		E104FAFF1B6568E0005C68A0 /* BuildSystem.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = BuildSystem.cpp; sourceTree = "<group>"; };
 		E1066C091BC5BCE700B892CE /* LLVM.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = LLVM.h; sourceTree = "<group>"; };
@@ -1241,6 +1268,14 @@
 				9DB047BC1DF9D4AA006CDF52 /* libllvmSupport.a in Frameworks */,
 				9DB047BA1DF9D4A4006CDF52 /* libgtest_main.a in Frameworks */,
 				9DB047BB1DF9D4A4006CDF52 /* libgtest.a in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		E0E37CA72257EFE5001F2B00 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				E0E37CB12257F001001F2B00 /* llbuild.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1666,11 +1701,20 @@
 				BC8DEF0520300AAF00E9EF0C /* CMakeLists.txt */,
 				BC8DEF0620300AAF00E9EF0C /* BuildSystemBindings.swift */,
 				BC8DEF0720300AAF00E9EF0C /* CoreBindings.swift */,
+				E0E37CA32257BE9B001F2B00 /* BuildDBBindings.swift */,
 			);
 			indentWidth = 4;
 			path = llbuildSwift;
 			sourceTree = "<group>";
 			tabWidth = 4;
+		};
+		E0E37CAB2257EFE5001F2B00 /* BuildDBSwiftBindingTest */ = {
+			isa = PBXGroup;
+			children = (
+				E0E37CAC2257EFE5001F2B00 /* main.swift */,
+			);
+			path = BuildDBSwiftBindingTest;
+			sourceTree = "<group>";
 		};
 		E10D5CDB19FEBF6A00211ED4 /* LitXCTestAdaptor */ = {
 			isa = PBXGroup;
@@ -1766,6 +1810,7 @@
 				1484D1DA2094509E00D3830F /* LICENSE.txt */,
 				E1A223FC19F990E60059043E /* README.md */,
 				1484D1DB209450A600D3830F /* Vagrantfile */,
+				E0E37CAB2257EFE5001F2B00 /* BuildDBSwiftBindingTest */,
 				E1A223F219F98F1C0059043E /* Products */,
 				E13B5E411A00395300EA0405 /* Frameworks */,
 			);
@@ -1795,6 +1840,7 @@
 				E1604CB11BB9E01D001153A1 /* swift-build-tool */,
 				9DB047A81DF9D43D006CDF52 /* BuildSystemTests */,
 				40B3C91A20D3AEC9007C5847 /* CAPITests */,
+				E0E37CAA2257EFE5001F2B00 /* BuildDBSwiftBindingTest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -2133,6 +2179,7 @@
 				E1ADC2321A85923800D5387C /* Public API */,
 				E1ADC2301A85922F00D5387C /* CMakeLists.txt */,
 				E1DD22761C472A3F00555A5D /* BuildSystem-C-API.cpp */,
+				E033BA772257BA1E0046E0F4 /* BuildDB-C-API.cpp */,
 				E1ADC2311A85922F00D5387C /* C-API.cpp */,
 				E1DD22741C47259900555A5D /* Core-C-API.cpp */,
 			);
@@ -2156,6 +2203,7 @@
 				E1192CEC1C49D84500F85890 /* buildsystem.h */,
 				E1BE0AAD1C46F93000AD0883 /* core.h */,
 				E1ADC2351A8592AA00D5387C /* llbuild.h */,
+				E080BE432256DD970047E3F7 /* db.h */,
 			);
 			path = llbuild;
 			sourceTree = "<group>";
@@ -2548,6 +2596,7 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				E0E37CA52257DADD001F2B00 /* db.h in Headers */,
 				E1D191CA1B472440000C4E95 /* llbuild.h in Headers */,
 				E1BE0AAE1C46F94000AD0883 /* core.h in Headers */,
 				E1192CED1C49D84500F85890 /* buildsystem.h in Headers */,
@@ -2598,6 +2647,24 @@
 			name = BuildSystemTests;
 			productName = BuildSystemTests;
 			productReference = 9DB047A81DF9D43D006CDF52 /* BuildSystemTests */;
+			productType = "com.apple.product-type.tool";
+		};
+		E0E37CA92257EFE5001F2B00 /* BuildDBSwiftBindingTest */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = E0E37CAE2257EFE5001F2B00 /* Build configuration list for PBXNativeTarget "BuildDBSwiftBindingTest" */;
+			buildPhases = (
+				E0E37CA62257EFE5001F2B00 /* Sources */,
+				E0E37CA72257EFE5001F2B00 /* Frameworks */,
+				E0E37CA82257EFE5001F2B00 /* CopyFiles */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				E0E37CB32257F006001F2B00 /* PBXTargetDependency */,
+			);
+			name = BuildDBSwiftBindingTest;
+			productName = BuildDBSwiftBindingTest;
+			productReference = E0E37CAA2257EFE5001F2B00 /* BuildDBSwiftBindingTest */;
 			productType = "com.apple.product-type.tool";
 		};
 		E10D5CD919FEBF6A00211ED4 /* LitXCTestAdaptor */ = {
@@ -2945,11 +3012,16 @@
 			isa = PBXProject;
 			attributes = {
 				DefaultBuildSystemTypeForWorkspace = Latest;
+				LastSwiftUpdateCheck = 1100;
 				LastUpgradeCheck = 9900;
 				ORGANIZATIONNAME = "Apple Inc.";
 				TargetAttributes = {
 					9DB047A71DF9D43D006CDF52 = {
 						CreatedOnToolsVersion = 8.3;
+						ProvisioningStyle = Automatic;
+					};
+					E0E37CA92257EFE5001F2B00 = {
+						CreatedOnToolsVersion = 11.0;
 						ProvisioningStyle = Automatic;
 					};
 					E10D5CD919FEBF6A00211ED4 = {
@@ -3069,6 +3141,7 @@
 				E1A2254219F9A20D0059043E /* test */,
 				E10D5CD919FEBF6A00211ED4 /* LitXCTestAdaptor */,
 				E1C404AB1A0308F3003392BA /* PerfTests */,
+				E0E37CA92257EFE5001F2B00 /* BuildDBSwiftBindingTest */,
 			);
 		};
 /* End PBXProject section */
@@ -3273,6 +3346,14 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		E0E37CA62257EFE5001F2B00 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				E0E37CAD2257EFE5001F2B00 /* main.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		E10D5CD619FEBF6A00211ED4 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -3408,6 +3489,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				E1ADC23E1A85938C00D5387C /* C-API.cpp in Sources */,
+				E033BA782257BA1E0046E0F4 /* BuildDB-C-API.cpp in Sources */,
 				E1DD22771C472A3F00555A5D /* BuildSystem-C-API.cpp in Sources */,
 				E1DD22751C47259900555A5D /* Core-C-API.cpp in Sources */,
 			);
@@ -3506,7 +3588,9 @@
 				E1D191C91B472437000C4E95 /* C-API.cpp in Sources */,
 				E1192CEE1C49DBA600F85890 /* BuildSystem-C-API.cpp in Sources */,
 				E1192CEF1C49DBA900F85890 /* Core-C-API.cpp in Sources */,
+				E033BA792257BA230046E0F4 /* BuildDB-C-API.cpp in Sources */,
 				BC669C54205A2C2000942C3B /* BuildSystemBindings.swift in Sources */,
+				E0E37CA42257BE9B001F2B00 /* BuildDBBindings.swift in Sources */,
 				BC669C55205A2C2000942C3B /* CoreBindings.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -3563,6 +3647,11 @@
 			isa = PBXTargetDependency;
 			target = 9DB047A71DF9D43D006CDF52 /* BuildSystemTests */;
 			targetProxy = 9DB047BE1DF9D4B8006CDF52 /* PBXContainerItemProxy */;
+		};
+		E0E37CB32257F006001F2B00 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = E1D191BD1B47232B000C4E95 /* llbuild-framework */;
+			targetProxy = E0E37CB22257F006001F2B00 /* PBXContainerItemProxy */;
 		};
 		E104FAF91B655BB2005C68A0 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
@@ -3854,6 +3943,60 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				USER_HEADER_SEARCH_PATHS = "$(SRCROOT)/include $(SRCROOT)/utils/unittest/googletest/include";
+			};
+			name = Release;
+		};
+		E0E37CAF2257EFE5001F2B00 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_IDENTITY = "-";
+				CODE_SIGN_STYLE = Automatic;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				MACOSX_DEPLOYMENT_TARGET = 10.14;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+			};
+			name = Debug;
+		};
+		E0E37CB02257EFE5001F2B00 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_IDENTITY = "-";
+				CODE_SIGN_STYLE = Automatic;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				MACOSX_DEPLOYMENT_TARGET = 10.14;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				SWIFT_VERSION = 5.0;
 			};
 			name = Release;
 		};
@@ -4361,6 +4504,15 @@
 			buildConfigurations = (
 				9DB047AD1DF9D43D006CDF52 /* Debug */,
 				9DB047AE1DF9D43D006CDF52 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		E0E37CAE2257EFE5001F2B00 /* Build configuration list for PBXNativeTarget "BuildDBSwiftBindingTest" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				E0E37CAF2257EFE5001F2B00 /* Debug */,
+				E0E37CB02257EFE5001F2B00 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/llbuild.xcodeproj/xcshareddata/xcschemes/BuildDBSwiftBindingTest.xcscheme
+++ b/llbuild.xcodeproj/xcshareddata/xcschemes/BuildDBSwiftBindingTest.xcscheme
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1100"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "E0E37CA92257EFE5001F2B00"
+               BuildableName = "BuildDBSwiftBindingTest"
+               BlueprintName = "BuildDBSwiftBindingTest"
+               ReferencedContainer = "container:llbuild.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "E0E37CA92257EFE5001F2B00"
+            BuildableName = "BuildDBSwiftBindingTest"
+            BlueprintName = "BuildDBSwiftBindingTest"
+            ReferencedContainer = "container:llbuild.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "E0E37CA92257EFE5001F2B00"
+            BuildableName = "BuildDBSwiftBindingTest"
+            BlueprintName = "BuildDBSwiftBindingTest"
+            ReferencedContainer = "container:llbuild.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/products/libllbuild/BuildDB-C-API.cpp
+++ b/products/libllbuild/BuildDB-C-API.cpp
@@ -2,7 +2,6 @@
 //  BuildDB-C-API.c
 //  libllbuild
 //
-//  Created by Benjamin Herzog on 4/5/19.
 //  Copyright © 2019 Apple Inc. All rights reserved.
 //
 
@@ -34,15 +33,18 @@ public:
     }
   }
   
-  uint32_t size() {
+  CAPIBuildDBResultKeys(const CAPIBuildDBResultKeys&) LLBUILD_DELETED_FUNCTION;
+  CAPIBuildDBResultKeys& operator=(const CAPIBuildDBResultKeys&) LLBUILD_DELETED_FUNCTION;
+  
+  const uint32_t size() {
     return keys.get()->size();
   }
   
-  KeyType keyForID(KeyID index) {
+  const KeyType keyForID(KeyID index) {
     return (*keys.get())[index];
   }
   
-  KeyID idForKey(KeyType key) {
+  const KeyID idForKey(KeyType key) {
     return (*ids.get())[key];
   }
 };
@@ -71,10 +73,6 @@ public:
     
     return cAPIDelegate.get_key_id(cAPIDelegate.context, (char *)key.c_str());
   }
-  
-  llb_database_delegate_t getCAPIDelegate() {
-    return cAPIDelegate;
-  }
 };
   
 class CAPIBuildDB {
@@ -88,7 +86,7 @@ public:
     _db.get()->attachDelegate(&cAPIDelegate);
   }
   
-  uint64_t getCurrentIteration(bool *success_out, std::string *error_out) {
+  const uint64_t getCurrentIteration(bool *success_out, std::string *error_out) {
     return _db.get()->getCurrentIteration(success_out, error_out);
   }
   
@@ -96,11 +94,11 @@ public:
     _db.get()->setCurrentIteration(value, error_out);
   }
   
-  bool lookupRuleResult(KeyID keyID, KeyType ruleKey, Result *result_out, std::string *error_out) {
+  const bool lookupRuleResult(KeyID keyID, KeyType ruleKey, Result *result_out, std::string *error_out) {
     return _db.get()->lookupRuleResult(keyID, ruleKey, result_out, error_out);
   }
   
-  bool buildStarted(std::string *error_out) {
+  const bool buildStarted(std::string *error_out) {
     return _db.get()->buildStarted(error_out);
   }
   
@@ -108,7 +106,7 @@ public:
     _db.get()->buildComplete();
   }
   
-  bool getKeys(std::map<KeyID, KeyType>& keys_out, std::string *error_out) {
+  const bool getKeys(std::map<KeyID, KeyType>& keys_out, std::string *error_out) {
     return _db.get()->getKeys(keys_out, error_out);
   }
   
@@ -119,7 +117,7 @@ public:
 
 }
 
-llb_data_t mapData(std::vector<uint8_t> input) {
+const llb_data_t mapData(std::vector<uint8_t> input) {
   const auto data = input.data();
   const auto size = sizeof(data) * input.size();
   const auto newData = (uint8_t *)malloc(size);
@@ -131,7 +129,7 @@ llb_data_t mapData(std::vector<uint8_t> input) {
   };
 }
 
-llb_database_result_t mapResult(Result result) {
+const llb_database_result_t mapResult(Result result) {
   
   auto count = result.dependencies.size();
   auto data = result.dependencies.data();
@@ -153,7 +151,7 @@ void llb_database_destroy_result(llb_database_result_t *result) {
   delete result->dependencies;
 }
 
-llb_database_t* llb_database_create(
+const llb_database_t* llb_database_create(
                                     char *path,
                                     uint32_t clientSchemaVersion,
                                     llb_database_delegate_t delegate,
@@ -177,7 +175,7 @@ void llb_database_destroy(llb_database_t *database) {
   delete (CAPIBuildDB *)database;
 }
 
-uint64_t llb_database_get_current_iteration(llb_database_t *database, bool *success_out, llb_data_t *error_out) {
+const uint64_t llb_database_get_current_iteration(llb_database_t *database, bool *success_out, llb_data_t *error_out) {
   auto db = (CAPIBuildDB *)database;
   std::string error;
   
@@ -203,7 +201,7 @@ void llb_database_set_current_iteration(llb_database_t *database, uint64_t value
   }
 }
 
-bool llb_database_lookup_rule_result(llb_database_t *database, llb_database_key_id keyID, llb_database_key_type ruleKey, llb_database_result_t *result_out, llb_data_t *error_out) {
+const bool llb_database_lookup_rule_result(llb_database_t *database, llb_database_key_id keyID, llb_database_key_type ruleKey, llb_database_result_t *result_out, llb_data_t *error_out) {
   
   auto db = (CAPIBuildDB *)database;
   
@@ -223,7 +221,7 @@ bool llb_database_lookup_rule_result(llb_database_t *database, llb_database_key_
   return stored;
 }
 
-bool llb_database_build_started(llb_database_t *database, llb_data_t *error_out) {
+const bool llb_database_build_started(llb_database_t *database, llb_data_t *error_out) {
   auto db = (CAPIBuildDB *)database;
   
   std::string error;
@@ -242,7 +240,7 @@ void llb_database_build_complete(llb_database_t *database) {
   db->buildComplete();
 }
 
-llb_database_key_id llb_database_result_keys_get_count(llb_database_result_keys_t *result) {
+const llb_database_key_id llb_database_result_keys_get_count(llb_database_result_keys_t *result) {
   auto resultKeys = (CAPIBuildDBResultKeys *)result;
   return resultKeys->size();
 }
@@ -254,7 +252,7 @@ void llb_database_result_keys_get_key_for_id(llb_database_result_keys_t *result,
   key_out->data = (const uint8_t*) strdup(key.data());
 }
 
-llb_database_key_id llb_database_result_keys_get_id_for_key(llb_database_result_keys_t *result, llb_database_key_type key) {
+const llb_database_key_id llb_database_result_keys_get_id_for_key(llb_database_result_keys_t *result, llb_database_key_type key) {
   auto resultKeys = (CAPIBuildDBResultKeys *)result;
   return resultKeys->idForKey(std::string(key));
 }
@@ -263,7 +261,7 @@ void llb_database_destroy_result_keys(llb_database_result_keys_t *result) {
   delete (CAPIBuildDBResultKeys *)result;
 }
 
-bool llb_database_get_keys(llb_database_t *database, llb_database_result_keys_t **keysResult_out, llb_data_t *error_out) {
+const bool llb_database_get_keys(llb_database_t *database, llb_database_result_keys_t **keysResult_out, llb_data_t *error_out) {
   auto db = (CAPIBuildDB *)database;
   
   std::map<KeyID, KeyType> keys;

--- a/products/libllbuild/BuildDB-C-API.cpp
+++ b/products/libllbuild/BuildDB-C-API.cpp
@@ -1,0 +1,261 @@
+//
+//  BuildDB-C-API.c
+//  libllbuild
+//
+//  Created by Benjamin Herzog on 4/5/19.
+//  Copyright © 2019 Apple Inc. All rights reserved.
+//
+
+#include <llbuild/llbuild.h>
+
+#include "llbuild/Core/BuildDB.h"
+
+#include "llvm/Support/raw_ostream.h"
+
+#include <algorithm>
+#include <cassert>
+#include <memory>
+
+using namespace llbuild;
+using namespace llbuild::core;
+
+namespace {
+
+class CAPIBuildDBResultKeys {
+private:
+  std::unique_ptr<std::map<KeyID, KeyType>> keys;
+  std::unique_ptr<std::map<KeyType, KeyID>> ids;
+  
+public:
+  CAPIBuildDBResultKeys(std::map<KeyID, KeyType> keys): keys(llvm::make_unique<std::map<KeyID, KeyType>>(keys)) {
+    ids = llvm::make_unique<std::map<KeyType, KeyID>>();
+    for (const auto &pair : keys) {
+      (*ids.get())[std::get<1>(pair)] = std::get<0>(pair);
+    }
+  }
+  
+  uint32_t size() {
+    return keys.get()->size();
+  }
+  
+  KeyType keyForID(KeyID index) {
+    return (*keys.get())[index];
+  }
+  
+  KeyID idForKey(KeyType key) {
+    return (*ids.get())[key];
+  }
+};
+  
+class CAPIBuildDBDelegate: public BuildDBDelegate {
+  llb_database_delegate_t cAPIDelegate;
+  
+public:
+  CAPIBuildDBDelegate(llb_database_delegate_t delegate): cAPIDelegate(delegate) { }
+  
+  KeyType getKeyForID(KeyID key) override {
+    if (!cAPIDelegate.get_key_for_id) {
+      return nullptr;
+    }
+    
+    return std::string(cAPIDelegate.get_key_for_id(cAPIDelegate.context, key));
+  }
+  
+  KeyID getKeyID(const KeyType &key) override {
+    if (!cAPIDelegate.get_key_id) {
+      return 0;
+    }
+    
+    return cAPIDelegate.get_key_id(cAPIDelegate.context, (char *)key.c_str());
+  }
+  
+  llb_database_delegate_t getCAPIDelegate() {
+    return cAPIDelegate;
+  }
+};
+  
+class CAPIBuildDB {
+  CAPIBuildDBDelegate cAPIDelegate;
+  
+  std::unique_ptr<BuildDB> _db;
+  
+public:
+  CAPIBuildDB(StringRef path, uint32_t clientSchemaVersion, CAPIBuildDBDelegate delegate, std::string *error_out): cAPIDelegate(delegate) {
+    _db = createSQLiteBuildDB(path, clientSchemaVersion, error_out);
+    _db.get()->attachDelegate(&cAPIDelegate);
+  }
+  
+  uint64_t getCurrentIteration(bool *success_out, std::string *error_out) {
+    return _db.get()->getCurrentIteration(success_out, error_out);
+  }
+  
+  void setCurrentIteration(uint64_t value, std::string *error_out) {
+    _db.get()->setCurrentIteration(value, error_out);
+  }
+  
+  bool lookupRuleResult(KeyID keyID, KeyType ruleKey, Result *result_out, std::string *error_out) {
+    return _db.get()->lookupRuleResult(keyID, ruleKey, result_out, error_out);
+  }
+  
+  bool buildStarted(std::string *error_out) {
+    return _db.get()->buildStarted(error_out);
+  }
+  
+  void buildComplete() {
+    _db.get()->buildComplete();
+  }
+  
+  bool getKeys(std::map<KeyID, KeyType>& keys_out, std::string *error_out) {
+    return _db.get()->getKeys(keys_out, error_out);
+  }
+  
+  void dump() {
+    _db.get()->dump(llvm::outs());
+  }
+};
+
+}
+
+llb_data_t mapData(std::vector<uint8_t> input) {
+  return llb_data_t {
+    input.size(),
+    input.data()
+  };
+}
+
+llb_database_result_t mapResult(Result result) {
+  return llb_database_result_t {
+    mapData(result.value),
+    result.signature.value,
+    result.computedAt,
+    result.builtAt,
+    result.dependencies.data(),
+    static_cast<uint32_t>(result.dependencies.size())
+  };
+}
+
+llb_database_t* llb_database_create(
+                                    char *path,
+                                    uint32_t clientSchemaVersion,
+                                    llb_database_delegate_t delegate,
+                                    char **error_out) {
+  assert(delegate.get_key_for_id);
+  assert(delegate.get_key_id);
+  
+  std::string error;
+  
+  auto database = new CAPIBuildDB(StringRef(path), clientSchemaVersion, delegate, &error);
+  
+  if (!error.empty() && error_out) {
+    strcpy(*error_out, error.c_str());
+  }
+  
+  return (llb_database_t *)database;
+}
+
+void llb_database_destroy(llb_database_t *database) {
+  delete (CAPIBuildDB *)database;
+}
+
+uint64_t llb_database_get_current_iteration(llb_database_t *database, bool *success_out, char **error_out) {
+  auto db = (CAPIBuildDB *)database;
+  std::string error;
+  
+  auto iteration = db->getCurrentIteration(success_out, &error);
+  
+  if (!error.empty() && error_out) {
+    strcpy(*error_out, error.c_str());
+  }
+  
+  return iteration;
+}
+
+void llb_database_set_current_iteration(llb_database_t *database, uint64_t value, char **error_out) {
+  auto db = (CAPIBuildDB *)database;
+  std::string error;
+  
+  db->setCurrentIteration(value, &error);
+  
+  if (!error.empty() && error_out) {
+    strcpy(*error_out, error.c_str());
+  }
+}
+
+bool llb_database_lookup_rule_result(llb_database_t *database, llb_database_key_id keyID, llb_database_key_type ruleKey, llb_database_result_t *result_out, char **error_out) {
+  
+  auto db = (CAPIBuildDB *)database;
+  
+  std::string error;
+  Result result;
+  auto stored = db->lookupRuleResult(keyID, KeyType(ruleKey), &result, &error);
+  
+  if (result_out) {
+    *result_out = mapResult(result);
+  }
+  
+  if (!error.empty() && error_out) {
+    strcpy(*error_out, error.c_str());
+  }
+  
+  return stored;
+}
+
+bool llb_database_build_started(llb_database_t *database, char **error_out) {
+  auto db = (CAPIBuildDB *)database;
+  
+  std::string error;
+  auto success = db->buildStarted(&error);
+  
+  if (!error.empty() && error_out) {
+    strcpy(*error_out, error.c_str());
+  }
+  
+  return success;
+}
+
+void llb_database_build_complete(llb_database_t *database) {
+  auto db = (CAPIBuildDB *)database;
+  db->buildComplete();
+}
+
+uint32_t llb_database_result_keys_get_count(llb_database_result_keys_t *result) {
+  auto resultKeys = (CAPIBuildDBResultKeys *)result;
+  return resultKeys->size();
+}
+
+llb_database_key_type llb_database_result_keys_get_key_for_id(llb_database_result_keys_t *result, llb_database_key_id key_id) {
+  auto resultKeys = (CAPIBuildDBResultKeys *)result;
+  return resultKeys->keyForID(key_id).c_str();
+}
+
+llb_database_key_id llb_database_result_keys_get_id_for_key(llb_database_result_keys_t *result, llb_database_key_type key) {
+  auto resultKeys = (CAPIBuildDBResultKeys *)result;
+  return resultKeys->idForKey(std::string(key));
+}
+
+void llb_database_destroy_result_keys(llb_database_result_keys_t *result) {
+  delete (CAPIBuildDBResultKeys *)result;
+}
+
+bool llb_database_get_keys(llb_database_t *database, llb_database_result_keys_t **keysResult_out, char **error_out) {
+  auto db = (CAPIBuildDB *)database;
+  
+  std::map<KeyID, KeyType> keys;
+  std::string error;
+  
+  auto success = db->getKeys(keys, &error);
+  
+  if (!error.empty() && error_out) {
+    strcpy(*error_out, error.c_str());
+    return success;
+  }
+  
+  auto resultKeys = new CAPIBuildDBResultKeys(keys);
+  *keysResult_out = (llb_database_result_keys_t *)resultKeys;
+  
+  return success;
+}
+
+void llb_database_dump(llb_database_t *database) {
+  ((CAPIBuildDB *)database)->dump();
+}

--- a/products/libllbuild/BuildDB-C-API.cpp
+++ b/products/libllbuild/BuildDB-C-API.cpp
@@ -72,14 +72,6 @@ public:
                                                                      (const char*)(uintptr_t)key).getKey();
   }
   
-  const uint64_t getCurrentIteration(bool *success_out, std::string *error_out) {
-    return _db.get()->getCurrentIteration(success_out, error_out);
-  }
-  
-  void setCurrentIteration(uint64_t value, std::string *error_out) {
-    _db.get()->setCurrentIteration(value, error_out);
-  }
-  
   const bool lookupRuleResult(KeyID keyID, Result *result_out, std::string *error_out) {
     auto ruleKey = this->getKeyForID(keyID);
     return _db.get()->lookupRuleResult(keyID, ruleKey, result_out, error_out);
@@ -95,10 +87,6 @@ public:
   
   const bool getKeys(std::vector<KeyType>& keys_out, std::string *error_out) {
     return _db.get()->getKeys(keys_out, error_out);
-  }
-  
-  void dump() {
-    _db.get()->dump(llvm::outs());
   }
 };
 
@@ -156,32 +144,6 @@ const llb_database_t* llb_database_create(
 
 void llb_database_destroy(llb_database_t *database) {
   delete (CAPIBuildDB *)database;
-}
-
-const uint64_t llb_database_get_current_iteration(llb_database_t *database, bool *success_out, llb_data_t *error_out) {
-  auto db = (CAPIBuildDB *)database;
-  std::string error;
-  
-  auto iteration = db->getCurrentIteration(success_out, &error);
-  
-  if (!error.empty() && error_out) {
-    error_out->length = error.size();
-    error_out->data = (const uint8_t*)strdup(error.c_str());
-  }
-  
-  return iteration;
-}
-
-void llb_database_set_current_iteration(llb_database_t *database, uint64_t value, llb_data_t *error_out) {
-  auto db = (CAPIBuildDB *)database;
-  std::string error;
-  
-  db->setCurrentIteration(value, &error);
-  
-  if (!error.empty() && error_out) {
-    error_out->length = error.size();
-    error_out->data = (const uint8_t*)strdup(error.c_str());
-  }
 }
 
 const bool llb_database_lookup_rule_result(llb_database_t *database, llb_database_key_id keyID, llb_database_result_t *result_out, llb_data_t *error_out) {
@@ -258,8 +220,4 @@ const bool llb_database_get_keys(llb_database_t *database, llb_database_result_k
   *keysResult_out = (llb_database_result_keys_t *)resultKeys;
   
   return success;
-}
-
-void llb_database_dump(llb_database_t *database) {
-  ((CAPIBuildDB *)database)->dump();
 }

--- a/products/libllbuild/CMakeLists.txt
+++ b/products/libllbuild/CMakeLists.txt
@@ -1,7 +1,8 @@
 set(SOURCES 
   BuildSystem-C-API.cpp
   C-API.cpp
-  Core-C-API.cpp)
+  Core-C-API.cpp
+  BuildDB-C-API.cpp)
 set(DEPENDENCIES
   llbuildBuildSystem
   llbuildCore

--- a/products/libllbuild/include/llbuild/db.h
+++ b/products/libllbuild/include/llbuild/db.h
@@ -50,21 +50,9 @@ LLBUILD_EXPORT const llb_database_t* llb_database_create(char *path, uint32_t cl
 LLBUILD_EXPORT void
 llb_database_destroy(llb_database_t *database);
 
-/// Get the current build iteration from the database
-LLBUILD_EXPORT const uint64_t
-llb_database_get_current_iteration(llb_database_t *database, bool *success_out, llb_data_t *error_out);
-
-/// Set the current build iteration to the database
-LLBUILD_EXPORT void
-llb_database_set_current_iteration(llb_database_t *database, uint64_t value, llb_data_t *error_out);
-
 /// Lookup the result of a rule in the database. result_out needs to be destroyed by calling llb_database_destroy_result.
 LLBUILD_EXPORT const bool
 llb_database_lookup_rule_result(llb_database_t *database, llb_database_key_id keyID, llb_database_result_t *result_out, llb_data_t *error_out);
-
-// TODO: Rule is currently not supported
-//LLBUILD_EXPORT bool
-//llb_database_set_rule_result(llb_database_t *database, llb_database_key_id keyID, llb_rule_t rule, llb_database_result_t result, char **error_out);
 
 /// Start an exclusive session in the database
 LLBUILD_EXPORT const bool
@@ -92,9 +80,5 @@ llb_database_destroy_result_keys(llb_database_result_keys_t *result);
 /// Fetch all keys from the database. The keysResult_out object needs to be destroyed when not used anymore via \see llb_database_destroy_result_keys
 LLBUILD_EXPORT const bool
 llb_database_get_keys(llb_database_t *database, llb_database_result_keys_t **keysResult_out, llb_data_t *error_out);
-
-/// Dumps an overview of the database's content to stdout
-LLBUILD_EXPORT void
-llb_database_dump(llb_database_t *database);
 
 #endif /* db_h */

--- a/products/libllbuild/include/llbuild/db.h
+++ b/products/libllbuild/include/llbuild/db.h
@@ -2,7 +2,6 @@
 //  db.h
 //  llbuild
 //
-//  Created by Benjamin Herzog on 4/4/19.
 //  Copyright © 2019 Apple Inc. All rights reserved.
 //
 
@@ -58,14 +57,14 @@ typedef struct llb_database_delegate_t_ {
 typedef struct llb_database_t_ llb_database_t;
 
 /// Create a new build database instance
-LLBUILD_EXPORT llb_database_t* llb_database_create(char *path, uint32_t clientSchemaVersion, llb_database_delegate_t delegate, llb_data_t *error_out);
+LLBUILD_EXPORT const llb_database_t* llb_database_create(char *path, uint32_t clientSchemaVersion, llb_database_delegate_t delegate, llb_data_t *error_out);
 
 /// Destroy a build system instance
 LLBUILD_EXPORT void
 llb_database_destroy(llb_database_t *database);
 
 /// Get the current build iteration from the database
-LLBUILD_EXPORT uint64_t
+LLBUILD_EXPORT const uint64_t
 llb_database_get_current_iteration(llb_database_t *database, bool *success_out, llb_data_t *error_out);
 
 /// Set the current build iteration to the database
@@ -73,7 +72,7 @@ LLBUILD_EXPORT void
 llb_database_set_current_iteration(llb_database_t *database, uint64_t value, llb_data_t *error_out);
 
 /// Lookup the result of a rule in the database. result_out needs to be destroyed by calling llb_database_destroy_result.
-LLBUILD_EXPORT bool
+LLBUILD_EXPORT const bool
 llb_database_lookup_rule_result(llb_database_t *database, llb_database_key_id keyID, llb_database_key_type ruleKey, llb_database_result_t *result_out, llb_data_t *error_out);
 
 // TODO: Rule is currently not supported
@@ -81,7 +80,7 @@ llb_database_lookup_rule_result(llb_database_t *database, llb_database_key_id ke
 //llb_database_set_rule_result(llb_database_t *database, llb_database_key_id keyID, llb_rule_t rule, llb_database_result_t result, char **error_out);
 
 /// Start an exclusive session in the database
-LLBUILD_EXPORT bool
+LLBUILD_EXPORT const bool
 llb_database_build_started(llb_database_t *database, llb_data_t *error_out);
 
 /// End the previously started exclusive session in the database
@@ -92,7 +91,7 @@ llb_database_build_complete(llb_database_t *database);
 typedef struct llb_database_result_keys_t_ llb_database_result_keys_t;
 
 /// Method for getting the number of keys from a result keys object
-LLBUILD_EXPORT llb_database_key_id
+LLBUILD_EXPORT const llb_database_key_id
 llb_database_result_keys_get_count(llb_database_result_keys_t *result);
 
 /// Method for getting the key for a given id from a result keys object
@@ -100,7 +99,7 @@ LLBUILD_EXPORT void
 llb_database_result_keys_get_key_for_id(llb_database_result_keys_t *result, llb_database_key_id keyID, llb_data_t *key_out);
 
 /// Method for getting the id for a given key from a result keys object
-LLBUILD_EXPORT llb_database_key_id
+LLBUILD_EXPORT const llb_database_key_id
 llb_database_result_keys_get_id_for_key(llb_database_result_keys_t *result, llb_database_key_type key);
 
 /// Destroys the given result keys object, call this when the object is not used anymore
@@ -108,7 +107,7 @@ LLBUILD_EXPORT void
 llb_database_destroy_result_keys(llb_database_result_keys_t *result);
 
 /// Fetch all keys from the database. The keysResult_out object needs to be destroyed when not used anymore via \see llb_database_destroy_result_keys
-LLBUILD_EXPORT bool
+LLBUILD_EXPORT const bool
 llb_database_get_keys(llb_database_t *database, llb_database_result_keys_t **keysResult_out, llb_data_t *error_out);
 
 /// Dumps an overview of the database's content to stdout

--- a/products/libllbuild/include/llbuild/db.h
+++ b/products/libllbuild/include/llbuild/db.h
@@ -40,24 +40,11 @@ typedef struct llb_database_result_t_ {
 LLBUILD_EXPORT void
 llb_database_destroy_result(llb_database_result_t *result);
 
-/// C api for the delegate of a build database
-typedef struct llb_database_delegate_t_ {
-  /// User context pointer, used to associate the delegate with the database
-  void* context;
-  
-  /// Gets an identifier for a given key
-  llb_database_key_id (*get_key_id)(void *context, const llb_database_key_type key);
-  
-  /// Gets a key for a given identifier
-  void (*get_key_for_id)(void *context, llb_database_key_id keyID, llb_database_key_type *key_out);
-  
-} llb_database_delegate_t;
-
 /// Opaque handler to a database
 typedef struct llb_database_t_ llb_database_t;
 
 /// Create a new build database instance
-LLBUILD_EXPORT const llb_database_t* llb_database_create(char *path, uint32_t clientSchemaVersion, llb_database_delegate_t delegate, llb_data_t *error_out);
+LLBUILD_EXPORT const llb_database_t* llb_database_create(char *path, uint32_t clientSchemaVersion, llb_data_t *error_out);
 
 /// Destroy a build system instance
 LLBUILD_EXPORT void
@@ -73,7 +60,7 @@ llb_database_set_current_iteration(llb_database_t *database, uint64_t value, llb
 
 /// Lookup the result of a rule in the database. result_out needs to be destroyed by calling llb_database_destroy_result.
 LLBUILD_EXPORT const bool
-llb_database_lookup_rule_result(llb_database_t *database, llb_database_key_id keyID, llb_database_key_type ruleKey, llb_database_result_t *result_out, llb_data_t *error_out);
+llb_database_lookup_rule_result(llb_database_t *database, llb_database_key_id keyID, llb_database_result_t *result_out, llb_data_t *error_out);
 
 // TODO: Rule is currently not supported
 //LLBUILD_EXPORT bool
@@ -96,11 +83,7 @@ llb_database_result_keys_get_count(llb_database_result_keys_t *result);
 
 /// Method for getting the key for a given id from a result keys object
 LLBUILD_EXPORT void
-llb_database_result_keys_get_key_for_id(llb_database_result_keys_t *result, llb_database_key_id keyID, llb_data_t *key_out);
-
-/// Method for getting the id for a given key from a result keys object
-LLBUILD_EXPORT const llb_database_key_id
-llb_database_result_keys_get_id_for_key(llb_database_result_keys_t *result, llb_database_key_type key);
+llb_database_result_keys_get_key_at_index(llb_database_result_keys_t *result, llb_database_key_id keyID, llb_data_t *key_out);
 
 /// Destroys the given result keys object, call this when the object is not used anymore
 LLBUILD_EXPORT void

--- a/products/libllbuild/include/llbuild/db.h
+++ b/products/libllbuild/include/llbuild/db.h
@@ -1,0 +1,94 @@
+//
+//  db.h
+//  llbuild
+//
+//  Created by Benjamin Herzog on 4/4/19.
+//  Copyright © 2019 Apple Inc. All rights reserved.
+//
+
+#ifndef db_h
+#define db_h
+
+typedef uint64_t llb_database_key_id;
+typedef const char* llb_database_key_type;
+
+typedef struct llb_database_result_t_ {
+  
+  llb_data_t value;
+  
+  uint64_t signature;
+  
+  uint64_t computed_at;
+  
+  uint64_t built_at;
+  
+  llb_database_key_id *dependencies;
+  
+  uint32_t dependencies_count;
+} llb_database_result_t;
+
+typedef struct llb_database_key_t_ {
+  llb_database_key_type value;
+  uint32_t size;
+} llb_database_key_t;
+
+typedef struct llb_database_delegate_t_ {
+  /// User context pointer.
+  void* context;
+  
+  llb_database_key_id (*get_key_id)(void *context, const llb_database_key_type key);
+  
+  llb_database_key_type (*get_key_for_id)(void *context, llb_database_key_id key);
+  
+} llb_database_delegate_t;
+
+/// Opaque handler to a database
+typedef struct llb_database_t_ llb_database_t;
+
+/// Create a new build database instance
+LLBUILD_EXPORT llb_database_t* llb_database_create(char *path, uint32_t clientSchemaVersion, llb_database_delegate_t delegate, char **error_out);
+
+/// Destroy a build system instance
+LLBUILD_EXPORT void
+llb_database_destroy(llb_database_t *database);
+
+LLBUILD_EXPORT uint64_t
+llb_database_get_current_iteration(llb_database_t *database, bool *success_out, char **error_out);
+
+LLBUILD_EXPORT void
+llb_database_set_current_iteration(llb_database_t *database, uint64_t value, char **error_out);
+
+LLBUILD_EXPORT bool
+llb_database_lookup_rule_result(llb_database_t *database, llb_database_key_id keyID, llb_database_key_type ruleKey, llb_database_result_t *result_out, char **error_out);
+
+// TODO: Rule is currently not supported
+//LLBUILD_EXPORT bool
+//llb_database_set_rule_result(llb_database_t *database, llb_database_key_id keyID, llb_rule_t rule, llb_database_result_t result, char **error_out);
+
+LLBUILD_EXPORT bool
+llb_database_build_started(llb_database_t *database, char **error_out);
+
+LLBUILD_EXPORT void
+llb_database_build_complete(llb_database_t *database);
+
+typedef struct llb_database_result_keys_t_ llb_database_result_keys_t;
+
+LLBUILD_EXPORT uint32_t
+llb_database_result_keys_get_count(llb_database_result_keys_t *result);
+
+LLBUILD_EXPORT llb_database_key_type
+llb_database_result_keys_get_key_for_id(llb_database_result_keys_t *result, llb_database_key_id key_id);
+
+LLBUILD_EXPORT llb_database_key_id
+llb_database_result_keys_get_id_for_key(llb_database_result_keys_t *result, llb_database_key_type key);
+
+LLBUILD_EXPORT void
+llb_database_destroy_result_keys(llb_database_result_keys_t *result);
+
+LLBUILD_EXPORT bool
+llb_database_get_keys(llb_database_t *database, llb_database_result_keys_t **keysResult_out, char **error_out);
+
+LLBUILD_EXPORT void
+llb_database_dump(llb_database_t *database);
+
+#endif /* db_h */

--- a/products/libllbuild/include/llbuild/llbuild.h
+++ b/products/libllbuild/include/llbuild/llbuild.h
@@ -85,4 +85,7 @@ LLBUILD_EXPORT int llb_get_api_version(void);
 // The BuildSystem component.
 #include "buildsystem.h"
 
+// The DataBase component
+#include "db.h"
+
 #endif

--- a/products/llbuildSwift/BuildDBBindings.swift
+++ b/products/llbuildSwift/BuildDBBindings.swift
@@ -25,14 +25,9 @@ import llbuild
 public typealias KeyID = UInt64
 public typealias KeyType = String
 
-public protocol BuildDBDelegate {
-    func getKeyID(key: KeyType) -> KeyID
-    func getKey(id: KeyID) -> KeyType
-}
-
 /// Defines the result of a call to fetch all keys from the database
 /// Wraps calls to the llbuild database, but all results are fetched and available with this result
-public class BuildDBFetchKeysResult {
+public class BuildDBKeysResult {
     /// Opaque pointer to the actual result object
     private let result: OpaquePointer?
     
@@ -46,19 +41,13 @@ public class BuildDBFetchKeysResult {
     
     private lazy var _count: Int = result.map { Int(llb_database_result_keys_get_count($0)) } ?? 0
     
-    /// Get the key identifier for a given key (is unique)
-    public func getKeyID(key: KeyType) -> KeyID {
-        assert(result != nil, "Can't get key identifier without fetching the data first.")
-        return llb_database_result_keys_get_id_for_key(result, key.cString(using: .utf8))
-    }
-    
     /// Get the key for a given key identifier (might be unique)
-    public func getKey(id: KeyID) -> KeyType {
+    public func getKey(at index: KeyID) -> KeyType {
         assert(result != nil, "Can't get key without fetching the data first.")
         
         var data = llb_data_t()
         withUnsafeMutablePointer(to: &data) { ptr in
-            llb_database_result_keys_get_key_for_id(self.result, id, ptr)
+            llb_database_result_keys_get_key_at_index(self.result, index, ptr)
         }
         defer { data.data?.deallocate() }
         return stringFromData(data)
@@ -69,31 +58,29 @@ public class BuildDBFetchKeysResult {
     }
 }
 
-extension BuildDBFetchKeysResult: Collection {
+extension BuildDBKeysResult: Collection {
     public typealias Index = KeyID
-    public typealias Element = (keyID: KeyID, key: KeyType)
+    public typealias Element = KeyType
 
     public var startIndex: Index {
         return 1 as UInt64
     }
     
     public var endIndex: Index {
-        return UInt64(self.count) + startIndex
+        return UInt64(self._count) + startIndex
     }
     
     public subscript(index: Index) -> Iterator.Element {
         guard (startIndex..<endIndex).contains(index) else {
             fatalError("Index \(index) is out of bounds (\(startIndex)..<\(endIndex))")
         }
-        return (index, getKey(id: index))
+        return getKey(at: index)
     }
     
     public func index(after i: KeyID) -> KeyID {
         return i + 1
     }
 }
-
-extension BuildDBFetchKeysResult: BuildDBDelegate {}
 
 /// Defines the result of a built task
 public class RuleResult {
@@ -127,7 +114,7 @@ public class RuleResult {
     }
     
     /// Fetch result information about all dependencies via the given database
-    public func fetchDependencies(database: Database.BuildDB) throws -> [RuleResult] {
+    public func fetchDependencies(database: BuildDB) throws -> [RuleResult] {
         var result = [RuleResult]()
         
         for dep in dependencies {
@@ -172,7 +159,7 @@ private class MutableStringPointer {
 }
 
 /// Database object that defines a connection to a llbuild database
-public final class Database {
+public final class BuildDB {
     
     /// Errors that can happen when opening the database or performing operations on it
     public enum Error: Swift.Error {
@@ -184,131 +171,102 @@ public final class Database {
         case unknownError
     }
     
-    public private(set) var delegate: BuildDBDelegate
     /// The opaque pointer to the database object
     private var _database: OpaquePointer? = nil
     
     /// Initializes the build database at a given path
     /// If the database at this path doesn't exist, it will created
     /// If the clientSchemaVersion is different to the one in the database at this path, its content will be automatically erased!
-    public init(path: String, clientSchemaVersion: UInt32, delegate: BuildDBDelegate) throws {
+    public init(path: String, clientSchemaVersion: UInt32) throws {
         // Safety check that we have linked against a compatibile llbuild framework version
         if llb_get_api_version() != LLBUILD_C_API_VERSION {
             fatalError("llbuild C API version mismatch, found \(llb_get_api_version()), expect \(LLBUILD_C_API_VERSION)")
         }
         
-        self.delegate = delegate
-        
-        var _delegate = llb_database_delegate_t()
-        _delegate.context = Unmanaged.passUnretained(self).toOpaque()
-        _delegate.get_key_for_id = { Database.toDB($0!).get_key_for_id($1, $2) }
-        _delegate.get_key_id = { Database.toDB($0!).get_key_id($1!) }
-        
         let errorPtr = MutableStringPointer()
-        _database = llb_database_create(strdup(path), clientSchemaVersion, _delegate, &errorPtr.ptr)
+        _database = llb_database_create(strdup(path), clientSchemaVersion, &errorPtr.ptr)
         
         if let error = errorPtr.msg {
             throw Error.couldNotOpenDB(error)
         }
+        
+        try buildStarted()
     }
     
     deinit {
+        buildComplete()
         llb_database_destroy(_database)
     }
-    
-    public final class BuildDB {
-    
-        /// The opaque pointer to the database object
-        private var _database: OpaquePointer? = nil
         
-        private let delegate: BuildDBDelegate
+    /// Returns the current iteration of the build
+    public func getCurrentIteration() throws -> UInt64 {
+        var success = false
         
-        fileprivate init(database: OpaquePointer?, delegate: BuildDBDelegate) {
-            self._database = database
-            self.delegate = delegate
+        let errorPtr = MutableStringPointer()
+        let iteration = llb_database_get_current_iteration(_database, &success, &errorPtr.ptr)
+        if let error = errorPtr.msg {
+            throw Error.operationDidFail(error)
         }
-        
-        /// Returns the current iteration of the build
-        public func getCurrentIteration() throws -> UInt64 {
-            var success = false
-            
-            let errorPtr = MutableStringPointer()
-            let iteration = llb_database_get_current_iteration(_database, &success, &errorPtr.ptr)
-            if let error = errorPtr.msg {
-                throw Error.operationDidFail(error)
-            }
-            if !success {
-                throw Error.unknownError
-            }
-            return iteration
+        if !success {
+            throw Error.unknownError
         }
-        
-        /// Saves the current build iteration to the database
-        public func setCurrentIteration(_ iteration: UInt64) throws {
-            let errorPtr = MutableStringPointer()
-            llb_database_set_current_iteration(_database, iteration, &errorPtr.ptr)
-            if let error = errorPtr.msg {
-                throw Error.operationDidFail(error)
-            }
-        }
-        
-        /// Get the result for a given keyID
-        public func lookupRuleResult(keyID: KeyID) throws -> RuleResult? {
-            let errorPtr = MutableStringPointer()
-            var result = llb_database_result_t()
-            
-            let ruleKey = delegate.getKey(id: keyID)
-            
-            let stored = ruleKey.withCString { ruleKey in
-                return llb_database_lookup_rule_result(_database, keyID, ruleKey, &result, &errorPtr.ptr)
-            }
-            
-            if let error = errorPtr.msg {
-                throw Error.operationDidFail(error)
-            }
-            
-            if !stored {
-                return nil
-            }
-            
-            return RuleResult(result: result)
-        }
-        
-        /// Fetches all keys from the database, returns it and saves if as \see allKeys on the database object
-        public func getKeys() throws -> BuildDBFetchKeysResult {
-            let errorPtr = MutableStringPointer()
-            
-            let keys = UnsafeMutablePointer<OpaquePointer?>.allocate(capacity: 1)
-            
-            let success = llb_database_get_keys(_database, keys, &errorPtr.ptr)
-            
-            if let error = errorPtr.msg {
-                throw Error.operationDidFail(error)
-            }
-            if !success {
-                throw Error.unknownError
-            }
-            
-            guard let resultKeys = keys.pointee else {
-                throw Error.unknownError
-            }
-            
-            return BuildDBFetchKeysResult(result: resultKeys)
-        }
-        
-        /// Dumps an overview of the database to stdout
-        public func dump() {
-            llb_database_dump(_database)
-        }
-        
+        return iteration
     }
     
-    public func startSession(_ operations: (BuildDB) throws -> Void) throws {
-        try buildStarted()
-        defer { buildComplete() }
+    /// Saves the current build iteration to the database
+    public func setCurrentIteration(_ iteration: UInt64) throws {
+        let errorPtr = MutableStringPointer()
+        llb_database_set_current_iteration(_database, iteration, &errorPtr.ptr)
+        if let error = errorPtr.msg {
+            throw Error.operationDidFail(error)
+        }
+    }
+    
+    /// Get the result for a given keyID
+    public func lookupRuleResult(keyID: KeyID) throws -> RuleResult? {
+        let errorPtr = MutableStringPointer()
+        var result = llb_database_result_t()
         
-        let buildDB = BuildDB(database: _database, delegate: delegate)
-        try operations(buildDB)
+        let stored = "ruleKey".withCString { ruleKey in
+            return llb_database_lookup_rule_result(_database, keyID, &result, &errorPtr.ptr)
+        }
+        
+        if let error = errorPtr.msg {
+            throw Error.operationDidFail(error)
+        }
+        
+        if !stored {
+            return nil
+        }
+        
+        return RuleResult(result: result)
+    }
+    
+    /// Fetches all keys from the database, returns it and saves if as \see allKeys on the database object
+    public func getKeys() throws -> BuildDBKeysResult {
+        let errorPtr = MutableStringPointer()
+        
+        let keys = UnsafeMutablePointer<OpaquePointer?>.allocate(capacity: 1)
+        
+        let success = llb_database_get_keys(_database, keys, &errorPtr.ptr)
+        
+        if let error = errorPtr.msg {
+            throw Error.operationDidFail(error)
+        }
+        if !success {
+            throw Error.unknownError
+        }
+        
+        guard let resultKeys = keys.pointee else {
+            throw Error.unknownError
+        }
+        
+        return BuildDBKeysResult(result: resultKeys)
+    }
+    
+    /// Dumps an overview of the database to stdout
+    public func dump() {
+        llb_database_dump(_database)
     }
     
     /// Starts an exclusive build session
@@ -331,15 +289,7 @@ public final class Database {
     
     // MARK: - Private functions for wrapping C++ API
     
-    static private func toDB(_ context: UnsafeMutableRawPointer) -> Database {
-        return Unmanaged<Database>.fromOpaque(UnsafeRawPointer(context)).takeUnretainedValue()
-    }
-    
-    private func get_key_for_id(_ id: llb_database_key_id, _ key_out: UnsafeMutablePointer<llb_database_key_type?>?) {
-        key_out?.pointee = UnsafePointer(strdup(self.delegate.getKey(id: id)))
-    }
-    
-    private func get_key_id(_ key: llb_database_key_type) -> llb_database_key_id {
-        return self.delegate.getKeyID(key: KeyType(cString: key))
+    static private func toDB(_ context: UnsafeMutableRawPointer) -> BuildDB {
+        return Unmanaged<BuildDB>.fromOpaque(UnsafeRawPointer(context)).takeUnretainedValue()
     }
 }

--- a/products/llbuildSwift/BuildDBBindings.swift
+++ b/products/llbuildSwift/BuildDBBindings.swift
@@ -1,0 +1,238 @@
+//
+//  BuildDBBindings.swift
+//  llbuild-framework
+//
+//  Created by Benjamin Herzog on 4/5/19.
+//  Copyright © 2019 Apple Inc. All rights reserved.
+//
+
+#if os(Linux)
+import Glibc
+#elseif os(Windows)
+import MSVCRT
+import WinSDK
+#else
+import Darwin.C
+#endif
+
+import Foundation
+
+// We don't need this import if we're building
+// this file as part of the llbuild framework.
+#if !LLBUILD_FRAMEWORK
+import llbuild
+#endif
+
+public typealias KeyID = UInt64
+public typealias KeyType = String
+
+public class BuildDBFetchResult: Sequence {
+    private var result: OpaquePointer? = nil
+    
+    public typealias Element = (id: KeyID, key: KeyType)
+    
+    fileprivate init(result: OpaquePointer) {
+        self.result = result
+    }
+    
+    public var count: Int {
+        return Int(llb_database_result_keys_get_count(result))
+    }
+    
+    public func id(key: KeyType) -> KeyID {
+        return llb_database_result_keys_get_id_for_key(result, key.cString(using: .utf8))
+    }
+    
+    public func key(id: KeyID) -> KeyType {
+        return String(cString: llb_database_result_keys_get_key_for_id(result, id))
+    }
+    
+    deinit {
+        llb_database_destroy_result_keys(result)
+    }
+    
+    public __consuming func makeIterator() -> AnyIterator<Element> {
+        var index: UInt64 = 0
+        let count = self.count
+        return AnyIterator {
+            if index >= count { return nil }
+            defer { index += 1 }
+            return (index, self.key(id: index))
+        }
+    }
+}
+
+public struct RuleResult {
+    let value: Data
+    let signature: UInt64
+    let computedAt: UInt64
+    let builtAt: UInt64
+    let dependencies: [KeyID]
+    
+    fileprivate init(result: llb_database_result_t) {
+        
+        value = Data(bytes: UnsafeRawPointer(result.value.data), count: Int(result.value.length))
+        signature = result.signature
+        computedAt = result.computed_at
+        builtAt = result.built_at
+        
+        dependencies = UnsafeBufferPointer(start: result.dependencies, count: Int(result.dependencies_count)).map { KeyID($0) }
+    }
+}
+
+public protocol BuildDBDelegate {
+    func getKeyID(key: KeyType) -> KeyID
+    func getKey(id: KeyID) -> KeyType
+}
+
+fileprivate class StringPointer {
+    let ptr: UnsafeMutablePointer<UnsafeMutablePointer<Int8>?>
+    init() {
+        ptr = .allocate(capacity: 1)
+    }
+    
+    deinit {
+        ptr.deallocate()
+    }
+    
+    var msg: String? {
+        if let errorPointee = ptr.pointee {
+            defer { errorPointee.deallocate() }
+            return String(cString: errorPointee)
+        }
+        return nil
+    }
+}
+
+public class BuildDB {
+    
+    public enum Error: Swift.Error {
+        case couldNotOpenDB(String)
+        case operationDidFail(String)
+        case unknownError
+    }
+    
+    public let delegate: BuildDBDelegate
+    private var _database: OpaquePointer? = nil
+    
+    public init(path: String, clientSchemaVersion: UInt32, delegate: BuildDBDelegate) throws {
+        // Safety check that we have linked against a compatibile llbuild framework version
+        if llb_get_api_version() != LLBUILD_C_API_VERSION {
+            fatalError("llbuild C API version mismatch, found \(llb_get_api_version()), expect \(LLBUILD_C_API_VERSION)")
+        }
+        
+        self.delegate = delegate
+        
+        var _delegate = llb_database_delegate_t()
+        _delegate.context = Unmanaged.passUnretained(self).toOpaque()
+        _delegate.get_key_for_id = { BuildDB.toDB($0!).get_key_for_id($1) }
+        _delegate.get_key_id = { BuildDB.toDB($0!).get_key_id($1!) }
+        
+        let errorPtr = StringPointer()
+        _database = llb_database_create(strdup(path), clientSchemaVersion, _delegate, errorPtr.ptr)
+        if let error = errorPtr.msg {
+            throw Error.couldNotOpenDB(error)
+        }
+        
+    }
+    
+    deinit {
+        llb_database_destroy(_database)
+    }
+    
+    public func getCurrentIteration() throws -> UInt64 {
+        var success = false
+        
+        let errorPtr = StringPointer()
+        let iteration = llb_database_get_current_iteration(_database, &success, errorPtr.ptr)
+        if let error = errorPtr.msg {
+            throw Error.operationDidFail(error)
+        }
+        if !success {
+            throw Error.unknownError
+        }
+        return iteration
+    }
+    
+    public func setCurrentIteration(_ iteration: UInt64) throws {
+        let errorPtr = StringPointer()
+        llb_database_set_current_iteration(_database, iteration, errorPtr.ptr)
+        if let error = errorPtr.msg {
+            throw Error.operationDidFail(error)
+        }
+    }
+    
+    public func lookupRuleResult(keyID: KeyID, ruleKey: KeyType) throws -> RuleResult? {
+        let errorPtr = StringPointer()
+        var result = llb_database_result_t()
+        
+        let stored = ruleKey.withCString { ruleKey in
+            return llb_database_lookup_rule_result(_database, keyID, ruleKey, &result, errorPtr.ptr)
+        }
+        
+        if let error = errorPtr.msg {
+            throw Error.operationDidFail(error)
+        }
+        
+        if !stored {
+            return nil
+        }
+        
+        return RuleResult(result: result)
+    }
+    
+    public func buildStarted() throws {
+        let errorPtr = StringPointer()
+        let success = llb_database_build_started(_database, errorPtr.ptr)
+        
+        if let error = errorPtr.msg {
+            throw Error.operationDidFail(error)
+        }
+        if !success {
+            throw Error.unknownError
+        }
+    }
+    
+    public func buildComplete() {
+        llb_database_build_complete(_database)
+    }
+    
+    public func getKeys() throws -> BuildDBFetchResult {
+        let errorPtr = StringPointer()
+        
+        let keys = UnsafeMutablePointer<OpaquePointer?>.allocate(capacity: 1)
+        
+        let success = llb_database_get_keys(_database, keys, errorPtr.ptr)
+        
+        if let error = errorPtr.msg {
+            throw Error.operationDidFail(error)
+        }
+        if !success {
+            throw Error.unknownError
+        }
+        
+        guard let resultKeys = keys.pointee else {
+            throw Error.unknownError
+        }
+        
+        return BuildDBFetchResult(result: resultKeys)
+    }
+    
+    public func dump() {
+        llb_database_dump(_database)
+    }
+    
+    // MARK: - Private functions for wrapping C++ API
+    
+    static private func toDB(_ context: UnsafeMutableRawPointer) -> BuildDB {
+        return Unmanaged<BuildDB>.fromOpaque(UnsafeRawPointer(context)).takeUnretainedValue()
+    }
+    
+    private func get_key_for_id(_ id: llb_database_key_id) -> llb_database_key_type? {
+        return UnsafePointer(strdup(self.delegate.getKey(id: id)))
+    }
+    
+    private func get_key_id(_ key: llb_database_key_type) -> llb_database_key_id {
+        return self.delegate.getKeyID(key: KeyType(cString: key))
+    }
+}

--- a/products/llbuildSwift/BuildDBBindings.swift
+++ b/products/llbuildSwift/BuildDBBindings.swift
@@ -26,95 +26,172 @@ import llbuild
 public typealias KeyID = UInt64
 public typealias KeyType = String
 
-public class BuildDBFetchResult: Sequence {
-    private var result: OpaquePointer? = nil
+public protocol BuildDBDelegate {
+    func getKeyID(key: KeyType) -> KeyID
+    func getKey(id: KeyID) -> KeyType
+}
+
+/// Defines the result of a call to fetch all keys from the database
+/// Wraps calls to the llbuild database, but all results are fetched and available with this result
+public class BuildDBFetchKeysResult {
+    /// Opaque pointer to the actual result object
+    private let result: OpaquePointer?
     
-    public typealias Element = (id: KeyID, key: KeyType)
+    fileprivate init() {
+        self.result = nil
+    }
     
     fileprivate init(result: OpaquePointer) {
         self.result = result
     }
     
-    public var count: Int {
-        return Int(llb_database_result_keys_get_count(result))
-    }
+    private lazy var _count: Int = result.map { Int(llb_database_result_keys_get_count($0)) } ?? 0
     
-    public func id(key: KeyType) -> KeyID {
+    /// Get the key identifier for a given key (is unique)
+    public func getKeyID(key: KeyType) -> KeyID {
+        assert(result != nil, "Can't get key identifier without fetching the data first.")
         return llb_database_result_keys_get_id_for_key(result, key.cString(using: .utf8))
     }
     
-    public func key(id: KeyID) -> KeyType {
-        return String(cString: llb_database_result_keys_get_key_for_id(result, id))
+    /// Get the key for a given key identifier (might be unique)
+    public func getKey(id: KeyID) -> KeyType {
+        assert(result != nil, "Can't get key without fetching the data first.")
+        
+        var data = llb_data_t()
+        withUnsafeMutablePointer(to: &data) { ptr in
+            llb_database_result_keys_get_key_for_id(self.result, id, ptr)
+        }
+        defer { data.data?.deallocate() }
+        return stringFromData(data)
     }
     
     deinit {
         llb_database_destroy_result_keys(result)
     }
+}
+
+extension BuildDBFetchKeysResult: Collection {
+    public typealias Index = KeyID
+    public typealias Element = (keyID: KeyID, key: KeyType)
+
+    public var startIndex: Index {
+        return 1 as UInt64
+    }
     
-    public __consuming func makeIterator() -> AnyIterator<Element> {
-        var index: UInt64 = 0
-        let count = self.count
-        return AnyIterator {
-            if index >= count { return nil }
-            defer { index += 1 }
-            return (index, self.key(id: index))
+    public var endIndex: Index {
+        return UInt64(self.count) + startIndex
+    }
+    
+    public subscript(index: Index) -> Iterator.Element {
+        guard (startIndex..<endIndex).contains(index) else {
+            fatalError("Index \(index) is out of bounds (\(startIndex)..<\(endIndex))")
         }
+        return (index, getKey(id: index))
+    }
+    
+    public func index(after i: KeyID) -> KeyID {
+        return i + 1
     }
 }
 
-public struct RuleResult {
-    let value: Data
-    let signature: UInt64
-    let computedAt: UInt64
-    let builtAt: UInt64
-    let dependencies: [KeyID]
+extension BuildDBFetchKeysResult: BuildDBDelegate {}
+
+/// Defines the result of a built task
+public class RuleResult {
+    /// Reference to the C API result instance (for desctruction)
+    private var result: llb_database_result_t
+    /// The value of the result
+    public let value: Data
+    /// Signature of the node that generated the result
+    public let signature: UInt64
+    /// The build iteration this result was computed at
+    public let computedAt: UInt64
+    /// The build iteration this result was built at
+    public let builtAt: UInt64
+    /// A list of the dependencies of the computed task, use the database's allKeys to check for their key
+    public let dependencies: [KeyID]
     
     fileprivate init(result: llb_database_result_t) {
-        
-        value = Data(bytes: UnsafeRawPointer(result.value.data), count: Int(result.value.length))
+        self.result = result
+        value = Data(bytes: result.value.data, count: Int(result.value.length))
         signature = result.signature
         computedAt = result.computed_at
         builtAt = result.built_at
         
         dependencies = UnsafeBufferPointer(start: result.dependencies, count: Int(result.dependencies_count)).map { KeyID($0) }
     }
-}
-
-public protocol BuildDBDelegate {
-    func getKeyID(key: KeyType) -> KeyID
-    func getKey(id: KeyID) -> KeyType
-}
-
-fileprivate class StringPointer {
-    let ptr: UnsafeMutablePointer<UnsafeMutablePointer<Int8>?>
-    init() {
-        ptr = .allocate(capacity: 1)
-    }
     
     deinit {
-        ptr.deallocate()
+        withUnsafeMutablePointer(to: &result) { ptr in
+            llb_database_destroy_result(ptr)
+        }
+    }
+    
+    /// Fetch result information about all dependencies via the given database
+    public func fetchDependencies(database: Database.BuildDB) throws -> [RuleResult] {
+        var result = [RuleResult]()
+        
+        for dep in dependencies {
+            guard let res = try database.lookupRuleResult(keyID: dep) else {
+                continue
+            }
+            result.append(res)
+        }
+        
+        return result
+    }
+}
+
+extension RuleResult: CustomReflectable {
+    public var customMirror: Mirror {
+        // We exclude the result pointer from the reflection
+        let properties: DictionaryLiteral<String, Any> = [
+            "signature": signature,
+            "computedAt": computedAt,
+            "builtAt": builtAt,
+            "dependencies": dependencies,
+            "value": value
+        ]
+        
+        return Mirror(RuleResult.self, children: properties, displayStyle: .class, ancestorRepresentation: .generated)
+    }
+}
+
+/// Private class for easier handling of out-parameters
+private class MutableStringPointer {
+    var ptr = llb_data_t()
+    init() { }
+    
+    deinit {
+        ptr.data?.deallocate()
     }
     
     var msg: String? {
-        if let errorPointee = ptr.pointee {
-            defer { errorPointee.deallocate() }
-            return String(cString: errorPointee)
-        }
-        return nil
+        guard ptr.data != nil else { return nil }
+        return stringFromData(ptr)
     }
 }
 
-public class BuildDB {
+/// Database object that defines a connection to a llbuild database
+public final class Database {
     
+    /// Errors that can happen when opening the database or performing operations on it
     public enum Error: Swift.Error {
+        /// If the system can't open the database, this error is thrown at init
         case couldNotOpenDB(String)
+        /// If an operation on the database fails, this error is thrown
         case operationDidFail(String)
+        /// If the database didn't provide an error but the operation still failed, the unknownError is thrown
         case unknownError
     }
     
-    public let delegate: BuildDBDelegate
+    public private(set) var delegate: BuildDBDelegate
+    /// The opaque pointer to the database object
     private var _database: OpaquePointer? = nil
     
+    /// Initializes the build database at a given path
+    /// If the database at this path doesn't exist, it will created
+    /// If the clientSchemaVersion is different to the one in the database at this path, its content will be automatically erased!
     public init(path: String, clientSchemaVersion: UInt32, delegate: BuildDBDelegate) throws {
         // Safety check that we have linked against a compatibile llbuild framework version
         if llb_get_api_version() != LLBUILD_C_API_VERSION {
@@ -125,111 +202,142 @@ public class BuildDB {
         
         var _delegate = llb_database_delegate_t()
         _delegate.context = Unmanaged.passUnretained(self).toOpaque()
-        _delegate.get_key_for_id = { BuildDB.toDB($0!).get_key_for_id($1) }
-        _delegate.get_key_id = { BuildDB.toDB($0!).get_key_id($1!) }
+        _delegate.get_key_for_id = { Database.toDB($0!).get_key_for_id($1, $2) }
+        _delegate.get_key_id = { Database.toDB($0!).get_key_id($1!) }
         
-        let errorPtr = StringPointer()
-        _database = llb_database_create(strdup(path), clientSchemaVersion, _delegate, errorPtr.ptr)
+        let errorPtr = MutableStringPointer()
+        _database = llb_database_create(strdup(path), clientSchemaVersion, _delegate, &errorPtr.ptr)
+        
         if let error = errorPtr.msg {
             throw Error.couldNotOpenDB(error)
         }
-        
     }
     
     deinit {
         llb_database_destroy(_database)
     }
     
-    public func getCurrentIteration() throws -> UInt64 {
-        var success = false
+    public final class BuildDB {
+    
+        /// The opaque pointer to the database object
+        private var _database: OpaquePointer? = nil
         
-        let errorPtr = StringPointer()
-        let iteration = llb_database_get_current_iteration(_database, &success, errorPtr.ptr)
+        private let delegate: BuildDBDelegate
+        
+        fileprivate init(database: OpaquePointer?, delegate: BuildDBDelegate) {
+            self._database = database
+            self.delegate = delegate
+        }
+        
+        /// Returns the current iteration of the build
+        public func getCurrentIteration() throws -> UInt64 {
+            var success = false
+            
+            let errorPtr = MutableStringPointer()
+            let iteration = llb_database_get_current_iteration(_database, &success, &errorPtr.ptr)
+            if let error = errorPtr.msg {
+                throw Error.operationDidFail(error)
+            }
+            if !success {
+                throw Error.unknownError
+            }
+            return iteration
+        }
+        
+        /// Saves the current build iteration to the database
+        public func setCurrentIteration(_ iteration: UInt64) throws {
+            let errorPtr = MutableStringPointer()
+            llb_database_set_current_iteration(_database, iteration, &errorPtr.ptr)
+            if let error = errorPtr.msg {
+                throw Error.operationDidFail(error)
+            }
+        }
+        
+        /// Get the result for a given keyID
+        public func lookupRuleResult(keyID: KeyID) throws -> RuleResult? {
+            let errorPtr = MutableStringPointer()
+            var result = llb_database_result_t()
+            
+            let ruleKey = delegate.getKey(id: keyID)
+            
+            let stored = ruleKey.withCString { ruleKey in
+                return llb_database_lookup_rule_result(_database, keyID, ruleKey, &result, &errorPtr.ptr)
+            }
+            
+            if let error = errorPtr.msg {
+                throw Error.operationDidFail(error)
+            }
+            
+            if !stored {
+                return nil
+            }
+            
+            return RuleResult(result: result)
+        }
+        
+        /// Fetches all keys from the database, returns it and saves if as \see allKeys on the database object
+        public func getKeys() throws -> BuildDBFetchKeysResult {
+            let errorPtr = MutableStringPointer()
+            
+            let keys = UnsafeMutablePointer<OpaquePointer?>.allocate(capacity: 1)
+            
+            let success = llb_database_get_keys(_database, keys, &errorPtr.ptr)
+            
+            if let error = errorPtr.msg {
+                throw Error.operationDidFail(error)
+            }
+            if !success {
+                throw Error.unknownError
+            }
+            
+            guard let resultKeys = keys.pointee else {
+                throw Error.unknownError
+            }
+            
+            return BuildDBFetchKeysResult(result: resultKeys)
+        }
+        
+        /// Dumps an overview of the database to stdout
+        public func dump() {
+            llb_database_dump(_database)
+        }
+        
+    }
+    
+    public func startSession(_ operations: (BuildDB) throws -> Void) throws {
+        try buildStarted()
+        defer { buildComplete() }
+        
+        let buildDB = BuildDB(database: _database, delegate: delegate)
+        try operations(buildDB)
+    }
+    
+    /// Starts an exclusive build session
+    private func buildStarted() throws {
+        let errorPtr = MutableStringPointer()
+        let success = llb_database_build_started(_database, &errorPtr.ptr)
+        
         if let error = errorPtr.msg {
             throw Error.operationDidFail(error)
         }
         if !success {
             throw Error.unknownError
         }
-        return iteration
     }
     
-    public func setCurrentIteration(_ iteration: UInt64) throws {
-        let errorPtr = StringPointer()
-        llb_database_set_current_iteration(_database, iteration, errorPtr.ptr)
-        if let error = errorPtr.msg {
-            throw Error.operationDidFail(error)
-        }
-    }
-    
-    public func lookupRuleResult(keyID: KeyID, ruleKey: KeyType) throws -> RuleResult? {
-        let errorPtr = StringPointer()
-        var result = llb_database_result_t()
-        
-        let stored = ruleKey.withCString { ruleKey in
-            return llb_database_lookup_rule_result(_database, keyID, ruleKey, &result, errorPtr.ptr)
-        }
-        
-        if let error = errorPtr.msg {
-            throw Error.operationDidFail(error)
-        }
-        
-        if !stored {
-            return nil
-        }
-        
-        return RuleResult(result: result)
-    }
-    
-    public func buildStarted() throws {
-        let errorPtr = StringPointer()
-        let success = llb_database_build_started(_database, errorPtr.ptr)
-        
-        if let error = errorPtr.msg {
-            throw Error.operationDidFail(error)
-        }
-        if !success {
-            throw Error.unknownError
-        }
-    }
-    
-    public func buildComplete() {
+    /// Ends a previously started exclusive build session
+    private func buildComplete() {
         llb_database_build_complete(_database)
-    }
-    
-    public func getKeys() throws -> BuildDBFetchResult {
-        let errorPtr = StringPointer()
-        
-        let keys = UnsafeMutablePointer<OpaquePointer?>.allocate(capacity: 1)
-        
-        let success = llb_database_get_keys(_database, keys, errorPtr.ptr)
-        
-        if let error = errorPtr.msg {
-            throw Error.operationDidFail(error)
-        }
-        if !success {
-            throw Error.unknownError
-        }
-        
-        guard let resultKeys = keys.pointee else {
-            throw Error.unknownError
-        }
-        
-        return BuildDBFetchResult(result: resultKeys)
-    }
-    
-    public func dump() {
-        llb_database_dump(_database)
     }
     
     // MARK: - Private functions for wrapping C++ API
     
-    static private func toDB(_ context: UnsafeMutableRawPointer) -> BuildDB {
-        return Unmanaged<BuildDB>.fromOpaque(UnsafeRawPointer(context)).takeUnretainedValue()
+    static private func toDB(_ context: UnsafeMutableRawPointer) -> Database {
+        return Unmanaged<Database>.fromOpaque(UnsafeRawPointer(context)).takeUnretainedValue()
     }
     
-    private func get_key_for_id(_ id: llb_database_key_id) -> llb_database_key_type? {
-        return UnsafePointer(strdup(self.delegate.getKey(id: id)))
+    private func get_key_for_id(_ id: llb_database_key_id, _ key_out: UnsafeMutablePointer<llb_database_key_type?>?) {
+        key_out?.pointee = UnsafePointer(strdup(self.delegate.getKey(id: id)))
     }
     
     private func get_key_id(_ key: llb_database_key_type) -> llb_database_key_id {

--- a/products/llbuildSwift/BuildDBBindings.swift
+++ b/products/llbuildSwift/BuildDBBindings.swift
@@ -2,17 +2,16 @@
 //  BuildDBBindings.swift
 //  llbuild-framework
 //
-//  Created by Benjamin Herzog on 4/5/19.
 //  Copyright © 2019 Apple Inc. All rights reserved.
 //
 
-#if os(Linux)
-import Glibc
+#if os(macOS)
+import Darwin.C
 #elseif os(Windows)
 import MSVCRT
 import WinSDK
 #else
-import Darwin.C
+import Glibc
 #endif
 
 import Foundation

--- a/products/llbuildSwift/BuildDBBindings.swift
+++ b/products/llbuildSwift/BuildDBBindings.swift
@@ -197,30 +197,6 @@ public final class BuildDB {
         buildComplete()
         llb_database_destroy(_database)
     }
-        
-    /// Returns the current iteration of the build
-    public func getCurrentIteration() throws -> UInt64 {
-        var success = false
-        
-        let errorPtr = MutableStringPointer()
-        let iteration = llb_database_get_current_iteration(_database, &success, &errorPtr.ptr)
-        if let error = errorPtr.msg {
-            throw Error.operationDidFail(error)
-        }
-        if !success {
-            throw Error.unknownError
-        }
-        return iteration
-    }
-    
-    /// Saves the current build iteration to the database
-    public func setCurrentIteration(_ iteration: UInt64) throws {
-        let errorPtr = MutableStringPointer()
-        llb_database_set_current_iteration(_database, iteration, &errorPtr.ptr)
-        if let error = errorPtr.msg {
-            throw Error.operationDidFail(error)
-        }
-    }
     
     /// Get the result for a given keyID
     public func lookupRuleResult(keyID: KeyID) throws -> RuleResult? {
@@ -262,11 +238,6 @@ public final class BuildDB {
         }
         
         return BuildDBKeysResult(result: resultKeys)
-    }
-    
-    /// Dumps an overview of the database to stdout
-    public func dump() {
-        llb_database_dump(_database)
     }
     
     /// Starts an exclusive build session

--- a/products/llbuildSwift/BuildSystemBindings.swift
+++ b/products/llbuildSwift/BuildSystemBindings.swift
@@ -42,10 +42,9 @@ private func copiedDataFromBytes(_ bytes: [UInt8]) -> llb_data_t {
 }
 
 // FIXME: We should eventually eliminate the need for this.
-private func stringFromData(_ data: llb_data_t) -> String {
+internal func stringFromData(_ data: llb_data_t) -> String {
     return String(decoding: UnsafeBufferPointer(start: data.data, count: Int(data.length)), as: Unicode.UTF8.self)
 }
-
 
 public protocol Tool: class {
     /// Called to create a specific command instance of this tool.

--- a/products/llbuildSwift/CMakeLists.txt
+++ b/products/llbuildSwift/CMakeLists.txt
@@ -1,7 +1,8 @@
 # Set sources.
 set(SOURCES 
   BuildSystemBindings.swift
-  CoreBindings.swift)
+  CoreBindings.swift
+  BuildDBBindings.swift)
 
 # Link C API.
 list(APPEND additional_args -I ${CMAKE_CURRENT_SOURCE_DIR}/../libllbuild/include -lllbuild)

--- a/unittests/Core/BuildEngineTest.cpp
+++ b/unittests/Core/BuildEngineTest.cpp
@@ -453,7 +453,7 @@ TEST(BuildEngineTest, incrementalDependency) {
     }
     virtual bool buildStarted(std::string* error_out) override { return true; }
     virtual void buildComplete() override {}
-    virtual bool getKeys(std::vector<KeyType>& keys_out, std::string* error_out) override { return false; }
+    virtual bool getKeys(std::map<KeyID, KeyType>& keys_out, std::string* error_out) override { return false; }
   };
   CustomDB *db = new CustomDB();
   std::string error;


### PR DESCRIPTION
This is a first draft for low level Swift bindings to the database layer of llbuild.

**DO NOT MERGE**
The final form of this should be merged in multiple, smaller PRs. I just want to start an early discussion here already.

Missing:
- there may be some C/C++ memory management issues
- the encoding for the more higher level types that are encoded in the database is missing
    - it's up for discussion if I should reimplement or bridge the existing types (I prefer bridging but am open for arguments - reimplementing would be necessary anyway for additions)
- the BuildDBSwiftBindingTest target will be removed and replaced by unit tests
- the format needs to be adjusted (copyright line remove, clang-format, …)