### PR TITLE
Revert "build: adjust for Windows"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -235,13 +235,13 @@ endif()
 
 # Add an always out-of-date target to get the Swift compiler version.
 if (SWIFTC_FOUND)
-  execute_process(COMMAND ${SWIFTC_EXECUTABLE} -version
-      OUTPUT_FILE ${LLBUILD_OBJ_DIR}/swift-version
-      OUTPUT_STRIP_TRAILING_WHITESPACE)
-  add_custom_target(swiftversion
-                    DEPENDS
-                      ${LLBUILD_OBJ_DIR}/swift-version
-                      ${SWIFTC_EXECUTABLE})
+  set(SWIFT_VERSION ${LLBUILD_OBJ_DIR}/swift-version)
+  add_custom_target(
+      swiftversion ALL
+      COMMAND ${CMAKE_SOURCE_DIR}/utils/write-swift-version ${SWIFTC_EXECUTABLE} ${SWIFT_VERSION}
+      BYPRODUCTS ${SWIFT_VERSION}
+      COMMENT "Checking Swift compiler version"
+  )
 endif()
 
 ###

--- a/products/llbuildSwift/CMakeLists.txt
+++ b/products/llbuildSwift/CMakeLists.txt
@@ -4,11 +4,7 @@ set(SOURCES
   CoreBindings.swift)
 
 # Link C API.
-if(CMAKE_SYSTEM_NAME STREQUAL Windows)
-  list(APPEND additional_args -I ${CMAKE_CURRENT_SOURCE_DIR}/../libllbuild/include -llibllbuild)
-else()
-  list(APPEND additional_args -I ${CMAKE_CURRENT_SOURCE_DIR}/../libllbuild/include -lllbuild)
-endif()
+list(APPEND additional_args -I ${CMAKE_CURRENT_SOURCE_DIR}/../libllbuild/include -lllbuild)
  
 if(APPLE)
   list(APPEND additional_args -target x86_64-apple-macosx10.10)
@@ -28,30 +24,22 @@ else()
   if(LIBDISPATCH_SOURCE_DIR)
     list(APPEND additional_args -I${LIBDISPATCH_SOURCE_DIR})
   endif()
-  if(CMAKE_SYSTEM_NAME STREQUAL Linux)
-    list(APPEND additional_args -Xcc;-DDEPLOYMENT_TARGET_LINUX)
-  elseif(CMAKE_SYSTEM_NAME STREQUAL Darwin)
-    list(APPEND additional_args -Xcc;-DDEPLOYMENT_TARGET_MACOSX)
-  elseif(CMAKE_SYSTEM_NAME STREQUAL Windows)
-    list(APPEND additional_args -Xcc;-DDEPLOYMENT_TARGET_WINDOWS)
-  else()
-    message(SEND_ERROR "unknown deployment target: ${CMAKE_SYSTEM_NAME}")
-  endif()
-  if(LLBUILD_PATH_TO_SQLITE_SOURCE)
-    list(APPEND additional_args -I${LLBUILD_PATH_TO_SQLITE_SOURCE})
-  endif()
-  if(LLBUILD_PATH_TO_SQLITE_BUILD)
-    list(APPEND additional_args -L${LLBUILD_PATH_TO_SQLITE_BUILD})
-  endif()
 endif()
 
 # Add swift bindings target if swift compiler is present.
 if (SWIFTC_FOUND)
   add_swift_module(libllbuildSwift llbuildSwift libllbuild "${SOURCES}" "${additional_args}")
 
+  # Install the library.
+  if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+    set(DYLIB_EXT dylib)
+  else()
+    set(DYLIB_EXT so)
+  endif()
+
   # Install both libllbuild and libllbuildSwift.
-  list(APPEND LLBUILD_LIBRARIES "${LLBUILD_LIBRARY_OUTPUT_INTDIR}/libllbuild${CMAKE_SHARED_LIBRARY_SUFFIX}")
-  list(APPEND LLBUILD_LIBRARIES "${LLBUILD_LIBRARY_OUTPUT_INTDIR}/libllbuildSwift${CMAKE_SHARED_LIBRARY_SUFFIX}")
+  list(APPEND LLBUILD_LIBRARIES "${LLBUILD_LIBRARY_OUTPUT_INTDIR}/libllbuild.${DYLIB_EXT}")
+  list(APPEND LLBUILD_LIBRARIES "${LLBUILD_LIBRARY_OUTPUT_INTDIR}/libllbuildSwift.${DYLIB_EXT}")
   
   install(FILES ${LLBUILD_LIBRARIES}
     DESTINATION lib/swift/pm/llbuild

--- a/utils/write-swift-version
+++ b/utils/write-swift-version
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+set -e
+
+# This script writes the Swift compiler version to a file. If the file is
+# already present, it'll only update if the version has changed.
+
+if ! [ $# -eq 2 ]; then
+    echo "Usage: <compiler-path> <file-path>"
+    exit
+fi
+
+SWIFTC=$1
+FILEPATH=$2
+
+VERSION="$($SWIFTC -version | tr -d '\n')"
+
+if [[ -f $FILEPATH ]]; then
+    FILECONTENT="$(cat $FILEPATH)"
+    if [[ "$FILECONTENT" != "$VERSION" ]]; then
+        echo $VERSION > $FILEPATH
+    fi
+else
+    echo $VERSION > $FILEPATH
+fi


### PR DESCRIPTION
Reverts apple/swift-llbuild#453

Version check is failing to catch changes in Swift-CI, thus not rebuilding the module and causing import failures in SPM.  See apple/swift#24079