### PR TITLE
Add Shared Library Tool

### DIFF
--- a/docs/buildsystem.rst
+++ b/docs/buildsystem.rst
@@ -785,6 +785,28 @@ A typical use for this tool is creating static libraries.
    preferable in future to correctly update/delete/create the archive file
    as required.
 
+Shared Library Tool
+------------
+
+**Identifier**: *shared-library*
+
+A tool used to create a shared library (``.so``, ``.dll``)
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 80
+
+   * - Name
+     - Description
+
+   * - executable
+     - A string indicating the path to a compiler that will be used to link
+       the objects
+
+   * - compiler-style
+     - The type of compiler pass, one of: ``swiftc``, ``clang``, ``cl``
+
+
 Stale File Removal Tool
 -----------------------
 

--- a/tests/SwiftBuildTool/Inputs/pseudo-swiftc
+++ b/tests/SwiftBuildTool/Inputs/pseudo-swiftc
@@ -12,6 +12,7 @@ def main():
     parser.add_argument('-module-name', type=str)
     parser.add_argument('-output-file-map', type=str)
     parser.add_argument('-incremental', action='store_true')
+    parser.add_argument('-emit-library', dest='emit_library', action='store_true')
     parser.add_argument('-emit-module', action='store_true')
     parser.add_argument('-emit-module-path', type=str)
     parser.add_argument('-emit-dependencies', action='store_true')
@@ -20,6 +21,7 @@ def main():
     parser.add_argument('-num-threads', type=int) 
     parser.add_argument('-I', type=str)
     parser.add_argument('-O', type=str)
+    parser.add_argument('-o', dest='output_file', type=str)
     parser.add_argument('-c', dest="compile", action='store_true')
     parser.add_argument('-###', dest="show_commands", action='store_true')
     parser.add_argument('-v', dest="verbose", action='store_true')
@@ -75,6 +77,8 @@ def main():
             if writeAllDeps:
                 deps = item["dependencies"]
             writeDeps(object, deps, args.add_dep, not writeAllDeps)
+    if args.emit_library:
+        writeObject(args.output_file)
 
 def writeDeps(object, deps, add_dep, append):
     with open(deps, "a" if append else "w") as f:

--- a/tests/SwiftBuildTool/swift-shared-library.swift-build
+++ b/tests/SwiftBuildTool/swift-shared-library.swift-build
@@ -1,0 +1,36 @@
+# Check the shared libraryu tool.
+#
+# RUN: rm -rf %t.build
+# RUN: mkdir -p %t.build
+# RUN: sed -e "s#SOURCEDIR#%S#g" -e "s#TMPDIR#%t#g" < %s > %t.build/build.swift-build
+# RUN: echo "" > %t.build/s1.swift
+# RUN: echo "" > %t.build/s2.swift
+#
+# RUN: %{swift-build-tool} -v --chdir %t.build > %t3.out
+# RUN: %{FileCheck} --check-prefix=CHECK-CONTENTS --input-file=%t.build/Foo.so %s
+# CHECK-CONTENTS: <dummy>
+
+client:
+  name: swift-build
+
+targets:
+  "": ["Foo.so"]
+
+commands:
+  C1.makeObjects:
+    tool: swift-compiler
+    sources: ["s1.swift", "s2.swift"]
+    inputs: ["s1.swift", "s2.swift"]
+    objects: ["s1.o", "s2.o"]
+    outputs: ["s1.o", "s2.o"]
+    executable: SOURCEDIR/Inputs/pseudo-swiftc
+    module-name: Foo
+    module-output-path: Foo.swiftmodule
+    temps-path: temps
+    is-library: true
+  C2.sharedlib:
+    tool: shared-library
+    executable: SOURCEDIR/Inputs/pseudo-swiftc
+    compiler-style: swiftc
+    inputs: ["s1.o", "s2.o"]
+    outputs: ["Foo.so"]


### PR DESCRIPTION
Added a tool to link and produce .dll/.so outputs.

I'm planning on using this in SwiftPM for linking Windows Swift code since Windows Swift currently doesn't support static linking. It currently works for that purpose and produces .dlls and import libs on Windows which I've used to (partially) compile SwiftPM.