### PR TITLE
Fix Build Warnings on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -146,44 +146,40 @@ if (XCODE)
   # Disable headermaps.
   set(CMAKE_XCODE_ATTRIBUTE_USE_HEADERMAP "NO") 
 elseif(MSVC)
-  # Disable unknown pragma warnings (e.g. for #pragma mark).
-  add_compile_options(-wd4068)
-
-  # TODO: these warnings come from llvmSupport. Since we don't want to diverge from llvmSupport by
-  # addressing these warnings , disable these for now to clean the build log.
-  # If/when we move to use LLVM's own llvmSupport, we should reenable these warnings.
-  # Unfortunately, the headers are intermingled into the public headers
-  # directory so we cannot mark the include search path as a SYSTEM directory
-  # and avoid the warnings.
   add_compile_options(
-    -wd4141 # 'inline' used more than once
-    -wd4146 # Unary minus applied to unsigned type
-    -wd4244 # Signed conversion
-    -wd4267 # Possible loss of data conversions
-    -wd4291 # operator new with no matching delete found
-    -wd4800 # Forcing value to bool 'true' or 'false'
-    -wd4996 # POSIX name for this item is deprecated
-  )
+    # Disable unknown pragma warnings (e.g. for #pragma mark).
+    "-wd4068"
+
+    # TODO: these warnings come from llvmSupport. Since we don't want to diverge from llvmSupport by
+    # addressing these warnings , disable these for now to clean the build log.
+    # If/when we move to use LLVM's own llvmSupport, we should reenable these warnings.
+    "-wd4141" # 'inline' used more than once.
+    "-wd4146" # Unary minus applied to unsigned type.
+    "-wd4244" # Signed conversion.
+    "-wd4267" # Possible loss of data conversions.
+    "-wd4291" # Operator new with no matching delete found.
+    "-wd4800" # Forcing value to bool 'true' or 'false'.
+    "-wd4996" # POSIX name for this item is deprecated.
+    "/EHsc")
 else ()
-  # Compile with C++14, without RTTI or exceptions.
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-rtti -fno-exceptions")
-  # Enable additional Clang warnings.
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wmost")
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wdocumentation  -Woverloaded-virtual")
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wparentheses -Wswitch")
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wunused-function -Wunused-variable")
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wunused-value -Wempty-body")
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wuninitialized -Wconstant-conversion")
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wint-conversion -Wbool-conversion")
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wenum-conversion -Wsign-compare")
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wnewline-eof -Wdeprecated-declarations")
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Winvalid-offsetof")
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wnon-virtual-dtor")
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wimplicit-fallthrough")
+  add_compile_options(
+    # Enable additional Clang warnings.
+   "-Wmost"
+   "-Wdocumentation" "-Woverloaded-virtual"
+   "-Wparentheses" "-Wswitch"
+   "-Wunused-function" "-Wunused-variable"
+   "-Wunused-value" "-Wempty-body"
+   "-Wuninitialized" "-Wconstant-conversion"
+   "-Wint-conversion" "-Wbool-conversion"
+   "-Wenum-conversion" "-Wsign-compare"
+   "-Wnewline-eof" "-Wdeprecated-declarations"
+   "-Winvalid-offsetof"
+   "-Wnon-virtual-dtor"
+   "-Wimplicit-fallthrough")
 endif ()
 
 if (${CMAKE_SYSTEM_NAME} STREQUAL "Windows")
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DLLVM_ON_WIN32")
+  add_compile_definitions("LLVM_ON_WIN32")
 endif()
 
 # On Linux, we may need to include a workaround for legacy libstdc++.

--- a/cmake/modules/Utility.cmake
+++ b/cmake/modules/Utility.cmake
@@ -88,6 +88,11 @@ macro(add_llbuild_library name)
 
   set_output_directory(${name} ${LLBUILD_EXECUTABLE_OUTPUT_INTDIR} ${LLBUILD_LIBRARY_OUTPUT_INTDIR})
 
+  if(NOT ARG_OUTPUT_NAME)
+    set(ARG_OUTPUT_NAME ${name})
+  endif()
+  set_target_properties(${name} PROPERTIES PDB_NAME lib${ARG_OUTPUT_NAME})
+
   if(ARG_OUTPUT_NAME)
     set_target_properties(${name}
       PROPERTIES
@@ -187,7 +192,7 @@ function(add_swift_module target name deps sources additional_args)
   )
   
   # Link and create dynamic framework.
-  set(DYLIB_OUTPUT ${LLBUILD_LIBRARY_OUTPUT_INTDIR}/${target}${CMAKE_SHARED_LIBRARY_SUFFIX})
+  set(DYLIB_OUTPUT ${LLBUILD_LIBRARY_OUTPUT_INTDIR}/${CMAKE_SHARED_LIBRARY_PREFIX}${name}${CMAKE_SHARED_LIBRARY_SUFFIX})
   
   if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
     list(APPEND DYLYB_ARGS -sdk ${CMAKE_OSX_SYSROOT})

--- a/products/libllbuild/CMakeLists.txt
+++ b/products/libllbuild/CMakeLists.txt
@@ -3,16 +3,10 @@ set(SOURCES
   C-API.cpp
   Core-C-API.cpp)
 
-if(${CMAKE_SYSTEM_NAME} STREQUAL "Windows")
-set(LIBLLBUILD_NAME libllbuild)
-else()
-set(LIBLLBUILD_NAME llbuild)
-endif()
-
 add_llbuild_library(libllbuild
   ${SOURCES}
   SHARED
-  OUTPUT_NAME ${LIBLLBUILD_NAME})
+  OUTPUT_NAME llbuild)
 
 set_property(TARGET libllbuild PROPERTY MACOSX_RPATH ON)
 
@@ -22,6 +16,11 @@ target_link_libraries(libllbuild PRIVATE
   llbuildBasic
   llvmSupport
   SQLite::SQLite3)
+
+if(CMAKE_SYSTEM_NAME STREQUAL Windows)
+    set_target_properties(libllbuild PROPERTIES LINK_FLAGS "/INCREMENTAL:NO")
+endif()
+
 if(NOT CMAKE_SYSTEM_NAME STREQUAL Windows)
   target_link_libraries(libllbuild PRIVATE
     curses)

--- a/products/llbuild/CMakeLists.txt
+++ b/products/llbuild/CMakeLists.txt
@@ -10,6 +10,10 @@ target_link_libraries(llbuild PRIVATE
   llvmSupport
   SQLite::SQLite3)
 
+if(CMAKE_SYSTEM_NAME STREQUAL Windows)
+    set_target_properties(llbuild PROPERTIES LINK_FLAGS "/INCREMENTAL:NO")
+endif()
+
 if(NOT ${CMAKE_SYSTEM_NAME} STREQUAL "Windows")
   target_link_libraries(llbuild PRIVATE
     curses)

--- a/products/llbuildSwift/CMakeLists.txt
+++ b/products/llbuildSwift/CMakeLists.txt
@@ -4,15 +4,9 @@ set(SOURCES
   CoreBindings.swift)
 
 # Link C API.
-if(CMAKE_SYSTEM_NAME STREQUAL Windows)
-  list(APPEND additional_args
-    -I ${CMAKE_CURRENT_SOURCE_DIR}/../libllbuild/include
-    -llibllbuild)
-else()
-  list(APPEND additional_args
-    -I ${CMAKE_CURRENT_SOURCE_DIR}/../libllbuild/include
-    -lllbuild)
-endif()
+list(APPEND additional_args
+  -I ${CMAKE_CURRENT_SOURCE_DIR}/../libllbuild/include
+  -lllbuild)
  
 if(APPLE)
   list(APPEND additional_args -target x86_64-apple-macosx10.10)
@@ -39,6 +33,10 @@ else()
     foreach(library ${SQLite3_LIBRARIES})
       list(APPEND additional_args -l${library})
     endforeach()
+    if(${CMAKE_SYSTEM_NAME} STREQUAL "Windows")
+      list(APPEND additional_args -Xcc;-D_DLL;-Xlinker;/NODEFAULTLIB:libcmt)
+      list(APPEND additional_args -Xcc;-D_CRT_NONSTDC_NO_DEPRECATE)
+    endif()
   endif()
 endif()
 
@@ -46,17 +44,10 @@ endif()
 if (SWIFTC_FOUND)
   add_swift_module(libllbuildSwift llbuildSwift libllbuild "${SOURCES}" "${additional_args}")
 
-  # Install the library.
   # Install both libllbuild and libllbuildSwift.
-  if(CMAKE_SYSTEM_NAME STREQUAL Windows)
-    list(APPEND LLBUILD_LIBRARIES
-      "${LLBUILD_LIBRARY_OUTPUT_INTDIR}/${CMAKE_IMPORT_LIBRARY_PREFIX}llbuild${CMAKE_IMPORT_LIBRARY_SUFFIX}"
-      "${LLBUILD_LIBRARY_OUTPUT_INTDIR}/libllbuildSwift${CMAKE_IMPORT_LIBRARY_SUFFIX}")
-  else()
-    list(APPEND LLBUILD_LIBRARIES
-      "${LLBUILD_LIBRARY_OUTPUT_INTDIR}/libllbuild${CMAKE_SHARED_LIBRARY_SUFFIX}"
-      "${LLBUILD_LIBRARY_OUTPUT_INTDIR}/libllbuildSwift${CMAKE_SHARED_LIBRARY_SUFFIX}")
-  endif()
+  list(APPEND LLBUILD_LIBRARIES
+    "${LLBUILD_LIBRARY_OUTPUT_INTDIR}/${CMAKE_SHARED_LIBRARY_PREFIX}llbuild${CMAKE_SHARED_LIBRARY_SUFFIX}"
+    "${LLBUILD_LIBRARY_OUTPUT_INTDIR}/${CMAKE_SHARED_LIBRARY_PREFIX}llbuildSwift${CMAKE_SHARED_LIBRARY_SUFFIX}")
   
   if(CMAKE_SYSTEM_NAME STREQUAL Windows)
     install(FILES ${LLBUILD_EXECUTABLE_OUTPUT_INTDIR}/libllbuild${CMAKE_SHARED_LIBRARY_SUFFIX}

--- a/tests/Examples/buildsystem-capi.llbuild
+++ b/tests/Examples/buildsystem-capi.llbuild
@@ -1,6 +1,6 @@
 # Check that the BuildSystem C API example builds and runs correctly.
 #
-# RUN: cc -o %t.exe %{srcroot}/examples/c-api/buildsystem/main.c -I %{srcroot}/products/libllbuild/include -l%{libllbuild} -L %{llbuild-lib-dir} -Werror
+# RUN: cc -o %t.exe %{srcroot}/examples/c-api/buildsystem/main.c -I %{srcroot}/products/libllbuild/include -lllbuild -L %{llbuild-lib-dir} -Werror
 # RUN: env LD_LIBRARY_PATH=%{llbuild-lib-dir} %t.exe %s > %t.out
 # RUN: %{FileCheck} %s --input-file %t.out
 #

--- a/tests/lit.cfg
+++ b/tests/lit.cfg
@@ -99,7 +99,6 @@ config.substitutions.append( ('%{llbuild-tools-dir}', llbuild_tools_dir) )
 config.substitutions.append( ('%{srcroot}', llbuild_src_root) )
 config.substitutions.append( ('%{swiftc-platform-flags}', "" if not config.osx_sysroot else "-sdk " + config.osx_sysroot) )
 config.substitutions.append( ('%{build-dir}', llbuild_obj_root) ) 
-config.substitutions.append( ('%{libllbuild}', 'libllbuild' if platform.system() == 'Windows' else 'llbuild') )
 config.substitutions.append( ('%{env}', which('env')) )
 config.substitutions.append( ('%{sort}', which('sort')) )
 


### PR DESCRIPTION
- Properly link against msvcrt by not overriding the /MD in
  CMAKE_CXX_FLAGS_RELWITHDEBINFO
- Rename libllbuild.lib back to llbuild.lib
- Rename libllbuildSwift.lib back to llbuildSwift.lib
- Disable incremental linking so llbuild.ilk's don't conflict