### PR TITLE
Respect schedulerLanes when using the C API.

### DIFF
--- a/products/libllbuild/BuildSystem-C-API.cpp
+++ b/products/libllbuild/BuildSystem-C-API.cpp
@@ -574,6 +574,7 @@ public:
     invocation.environment = cAPIInvocation.environment;
     invocation.useSerialBuild = cAPIInvocation.useSerialBuild;
     invocation.showVerboseStatus = cAPIInvocation.showVerboseStatus;
+    invocation.schedulerLanes = cAPIInvocation.schedulerLanes;
 
     // Register a custom diagnostic handler with the source manager.
     sourceMgr.setDiagHandler([](const llvm::SMDiagnostic& diagnostic,


### PR DESCRIPTION
Very simple change to respect `schedulerLanes` when using the C API.