### PR TITLE
Explicitly declare static linking dependencies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,8 @@ else()
   set(cmake_3_2_USES_TERMINAL USES_TERMINAL)
 endif()
 
+option(BUILD_SHARED_LIBS "Build Shared Libraries" ON)
+
 # Configure the default set of bindings to build.
 if(NOT DEFINED LLBUILD_SUPPORT_BINDINGS)
   set(LLBUILD_SUPPORT_BINDINGS "")

--- a/lib/Basic/CMakeLists.txt
+++ b/lib/Basic/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_llbuild_library(llbuildBasic
+add_llbuild_library(llbuildBasic STATIC
   ExecutionQueue.cpp
   FileInfo.cpp
   FileSystem.cpp
@@ -11,6 +11,8 @@ add_llbuild_library(llbuildBasic
   Version.cpp
   ShellUtility.cpp
   )
+
+target_link_libraries(llbuildBasic PRIVATE llvmSupport)
 
 if(${CMAKE_SYSTEM_NAME} MATCHES ".*BSD" OR ${CMAKE_SYSTEM_NAME} MATCHES "Linux")
   target_link_libraries(llbuildBasic pthread)

--- a/lib/BuildSystem/CMakeLists.txt
+++ b/lib/BuildSystem/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_llbuild_library(llbuildBuildSystem
+add_llbuild_library(llbuildBuildSystem STATIC
   BuildDescription.cpp
   BuildFile.cpp
   BuildKey.cpp
@@ -10,3 +10,5 @@ add_llbuild_library(llbuildBuildSystem
   ExternalCommand.cpp
   ShellCommand.cpp
   )
+
+target_link_libraries(llbuildBuildSystem PRIVATE llbuildCore llbuildBasic llvmSupport)

--- a/lib/Commands/CMakeLists.txt
+++ b/lib/Commands/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_llbuild_library(llbuildCommands
+add_llbuild_library(llbuildCommands STATIC
   BuildEngineCommand.cpp
   BuildSystemCommand.cpp
   CommandLineStatusOutput.cpp
@@ -6,3 +6,5 @@ add_llbuild_library(llbuildCommands
   NinjaBuildCommand.cpp
   NinjaCommand.cpp
   )
+
+target_link_libraries(llbuildCommands PRIVATE llbuildBuildSystem llbuildCore llbuildNinja)

--- a/lib/Core/CMakeLists.txt
+++ b/lib/Core/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_llbuild_library(llbuildCore
+add_llbuild_library(llbuildCore STATIC
   BuildDB.cpp
   BuildEngine.cpp
   BuildEngineTrace.cpp
@@ -6,3 +6,5 @@ add_llbuild_library(llbuildCore
   MakefileDepsParser.cpp
   SQLiteBuildDB.cpp
 )
+
+target_link_libraries(llbuildCore PRIVATE llbuildBasic llvmSupport sqlite3)

--- a/lib/Ninja/CMakeLists.txt
+++ b/lib/Ninja/CMakeLists.txt
@@ -1,8 +1,8 @@
-add_llbuild_library(llbuildNinja
+add_llbuild_library(llbuildNinja STATIC
   Lexer.cpp
   Manifest.cpp
   ManifestLoader.cpp
   Parser.cpp
   )
 
-target_link_libraries(llbuildNinja llvmSupport)
+target_link_libraries(llbuildNinja PRIVATE llbuildBasic llvmSupport)

--- a/lib/llvm/Demangle/CMakeLists.txt
+++ b/lib/llvm/Demangle/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_llbuild_library(LLVMDemangle
+add_llbuild_library(LLVMDemangle STATIC
     ItaniumDemangle.cpp
     MicrosoftDemangle.cpp
 )

--- a/lib/llvm/Support/CMakeLists.txt
+++ b/lib/llvm/Support/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Disable implicit-fallthrough, if used.
 append_if(CXX_SUPPORTS_IMPLICIT_FALLTHROUGH_FLAG "-Wno-implicit-fallthrough" CMAKE_CXX_FLAGS)
 
-add_llbuild_library(llvmSupport
+add_llbuild_library(llvmSupport STATIC
 APFloat.cpp
 APInt.cpp
 APSInt.cpp

--- a/utils/unittest/CMakeLists.txt
+++ b/utils/unittest/CMakeLists.txt
@@ -35,7 +35,7 @@ if(MSVC AND MSVC_VERSION EQUAL 1700)
   add_definitions(-D_VARIADIC_MAX=10)
 endif ()
 
-add_llbuild_library(gtest
+add_llbuild_library(gtest STATIC
   googletest/src/gtest-all.cc
   )
 

--- a/utils/unittest/UnitTestMain/CMakeLists.txt
+++ b/utils/unittest/UnitTestMain/CMakeLists.txt
@@ -1,3 +1,3 @@
-add_llbuild_library(gtest_main TestMain.cpp)
+add_llbuild_library(gtest_main STATIC TestMain.cpp)
 
-target_link_libraries(gtest_main gtest)
+target_link_libraries(gtest_main PRIVATE gtest)


### PR DESCRIPTION
- Explicitly list out the libraries to link the target against
- Explicitly declare that we're linking static

This allows us to set BUILD_SHARED_LIBS to build shared swift libraries for Windows.