### PR TITLE
Use a platform-dependent uintptr_t process id

### DIFF
--- a/include/llbuild/Basic/Subprocess.h
+++ b/include/llbuild/Basic/Subprocess.h
@@ -58,7 +58,7 @@ namespace llbuild {
     /// Handle used to communicate information about a launched process.
     struct ProcessHandle {
       /// Opaque ID.
-      uint64_t id;
+      uintptr_t id;
     };
 
     struct ProcessInfo {


### PR DESCRIPTION
This is what BuildSystemFrontendDelegate::ProcessHandle expects, right now this uint64_t pid will break the build on all the 32bit platforms.