### PR TITLE
Made KeyID usages in BuildDBDelegate const

### DIFF
--- a/include/llbuild/Core/BuildDB.h
+++ b/include/llbuild/Core/BuildDB.h
@@ -42,12 +42,12 @@ public:
   /// implementations may (and do) cache these values for future use.
   ///
   /// \param key [out] The key whose unique ID is being returned.
-  virtual KeyID getKeyID(const KeyType& key) = 0;
+  virtual const KeyID getKeyID(const KeyType& key) = 0;
 
   /// Get the key corresponding to a key ID.
   ///
   /// This method must be thread safe, and must not fail.
-  virtual KeyType getKeyForID(KeyID key) = 0;
+  virtual KeyType getKeyForID(const KeyID key) = 0;
 };
 
 

--- a/lib/Commands/BuildSystemCommand.cpp
+++ b/lib/Commands/BuildSystemCommand.cpp
@@ -627,12 +627,12 @@ class KeyMapDelegate : public BuildDBDelegate {
 public:
   llvm::StringMap<KeyID> keyTable;
 
-  KeyID getKeyID(const KeyType& key) override {
+  const KeyID getKeyID(const KeyType& key) override {
     auto it = keyTable.insert(std::make_pair(key, 0)).first;
     return (KeyID)(uintptr_t)it->getKey().data();
   }
 
-  KeyType getKeyForID(KeyID key) override {
+  KeyType getKeyForID(const KeyID key) override {
     // Note that we don't need to lock `keyTable` here because the key entries
     // themselves don't change once created.
     return llvm::StringMapEntry<KeyID>::GetStringMapEntryFromKeyData(

--- a/lib/Core/BuildEngine.cpp
+++ b/lib/Core/BuildEngine.cpp
@@ -1306,7 +1306,7 @@ public:
     return currentTimestamp;
   }
 
-  virtual KeyID getKeyID(const KeyType& key) override {
+  virtual const KeyID getKeyID(const KeyType& key) override {
     std::lock_guard<std::mutex> guard(keyTableMutex);
 
     // The RHS of the mapping is actually ignored, we use the StringMap's ptr
@@ -1316,7 +1316,7 @@ public:
     return (KeyID)(uintptr_t)it->getKey().data();
   }
 
-  virtual KeyType getKeyForID(KeyID key) override {
+  virtual KeyType getKeyForID(const KeyID key) override {
     // Note that we don't need to lock `keyTable` here because the key entries
     // themselves don't change once created.
     return llvm::StringMapEntry<KeyID>::GetStringMapEntryFromKeyData(


### PR DESCRIPTION
KeyID used in the methods for BuildDBDelegates should be const.