### PR TITLE
Added basic Swift interface for build database

### DIFF
--- a/include/llbuild/Core/BuildDB.h
+++ b/include/llbuild/Core/BuildDB.h
@@ -138,9 +138,10 @@ public:
 /// \param clientSchemaVersion An uninterpreted version number for use by the
 /// client to allow batch changes to the stored build results; if the stored
 /// schema does not match the provided version the database will be cleared upon
-/// opening.
+/// opening; to avoid this behavior, use `createNondestructiveSQLiteBuildDB`.
 std::unique_ptr<BuildDB> createSQLiteBuildDB(StringRef path,
                                              uint32_t clientSchemaVersion,
+                                             bool recreateUnmatchedVersion,
                                              std::string* error_out);
 
 }

--- a/lib/BuildSystem/BuildSystem.cpp
+++ b/lib/BuildSystem/BuildSystem.cpp
@@ -363,8 +363,7 @@ public:
     // FIXME: How do we pass the client schema version here, if we haven't
     // loaded the file yet.
     std::unique_ptr<core::BuildDB> db(
-        core::createSQLiteBuildDB(filename, getMergedSchemaVersion(),
-                                  error_out));
+                                      core::createSQLiteBuildDB(filename, getMergedSchemaVersion(), /* recreateUnmatchedVersion = */ true, error_out));
     if (!db)
       return false;
 

--- a/lib/Commands/BuildSystemCommand.cpp
+++ b/lib/Commands/BuildSystemCommand.cpp
@@ -677,7 +677,7 @@ static int executeDBCommand(std::vector<std::string> args) {
 
   // Load database
   std::string error;
-  std::unique_ptr<BuildDB> buildDB = createSQLiteBuildDB(dbPath, BuildSystem::getSchemaVersion(), &error);
+  std::unique_ptr<BuildDB> buildDB = createSQLiteBuildDB(dbPath, BuildSystem::getSchemaVersion(), /* recreateUnmatchedVersion = */ true, &error);
   if (!buildDB) {
     fprintf(stderr, "error: failed to load build db: %s\n\n", error.c_str());
     ::exit(1);

--- a/lib/Commands/NinjaBuildCommand.cpp
+++ b/lib/Commands/NinjaBuildCommand.cpp
@@ -1842,6 +1842,7 @@ int commands::executeNinjaBuildCommand(std::vector<std::string> args) {
       std::unique_ptr<core::BuildDB> db(
         core::createSQLiteBuildDB(dbFilename,
                                   BuildValue::currentSchemaVersion,
+                                  /* recreateUnmatchedVersion = */ true,
                                   &error));
       if (!db || !context.engine.attachDB(std::move(db), &error)) {
         context.emitError("unable to open build database: %s", error.c_str());

--- a/lib/Core/BuildEngine.cpp
+++ b/lib/Core/BuildEngine.cpp
@@ -1306,6 +1306,8 @@ public:
     return currentTimestamp;
   }
 
+  // When changing the implementation of those, do also copy
+  // the changes to CAPIBuildDB.
   virtual const KeyID getKeyID(const KeyType& key) override {
     std::lock_guard<std::mutex> guard(keyTableMutex);
 

--- a/llbuild.xcodeproj/project.pbxproj
+++ b/llbuild.xcodeproj/project.pbxproj
@@ -110,6 +110,10 @@
 		9DB047BC1DF9D4AA006CDF52 /* libllvmSupport.a in Frameworks */ = {isa = PBXBuildFile; fileRef = E1B838A21B52E7DE00DB876B /* libllvmSupport.a */; };
 		9DB047BD1DF9D4B0006CDF52 /* libllbuildBuildSystem.a in Frameworks */ = {isa = PBXBuildFile; fileRef = E1B839571B541BFD00DB876B /* libllbuildBuildSystem.a */; };
 		9DDD8BE11DDCAB9A00FB62D2 /* SQLiteBuildDBTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 9DDD8BDF1DDCAB9A00FB62D2 /* SQLiteBuildDBTest.cpp */; };
+		B505BFB3228FCB3E00255BD7 /* BuildDB-C-API.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B505BFB1228FCB3000255BD7 /* BuildDB-C-API.cpp */; };
+		B505BFB4228FCB3F00255BD7 /* BuildDB-C-API.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B505BFB1228FCB3000255BD7 /* BuildDB-C-API.cpp */; };
+		B505BFB8228FCFEE00255BD7 /* BuildDBBindings.swift in Sources */ = {isa = PBXBuildFile; fileRef = B505BFB6228FCFAF00255BD7 /* BuildDBBindings.swift */; };
+		B5A84D0C22943F9200A59064 /* db.h in Headers */ = {isa = PBXBuildFile; fileRef = B505BFB5228FCBAB00255BD7 /* db.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BC669C54205A2C2000942C3B /* BuildSystemBindings.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC8DEF0620300AAF00E9EF0C /* BuildSystemBindings.swift */; };
 		BC669C55205A2C2000942C3B /* CoreBindings.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC8DEF0720300AAF00E9EF0C /* CoreBindings.swift */; };
 		C5740D091E03523100567DD8 /* BuildSystemFrontendTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C5740D081E03523100567DD8 /* BuildSystemFrontendTest.cpp */; };
@@ -918,6 +922,9 @@
 		9DADBBAC1E256C52005B4869 /* PlatformUtility.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = PlatformUtility.cpp; sourceTree = "<group>"; };
 		9DB047A81DF9D43D006CDF52 /* BuildSystemTests */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = BuildSystemTests; sourceTree = BUILT_PRODUCTS_DIR; };
 		9DDD8BDF1DDCAB9A00FB62D2 /* SQLiteBuildDBTest.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = SQLiteBuildDBTest.cpp; sourceTree = "<group>"; };
+		B505BFB1228FCB3000255BD7 /* BuildDB-C-API.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "BuildDB-C-API.cpp"; sourceTree = "<group>"; };
+		B505BFB5228FCBAB00255BD7 /* db.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = db.h; sourceTree = "<group>"; };
+		B505BFB6228FCFAF00255BD7 /* BuildDBBindings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BuildDBBindings.swift; sourceTree = "<group>"; };
 		B563CEA620A6252500276198 /* CrossPlatformCompatibility.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CrossPlatformCompatibility.h; sourceTree = "<group>"; };
 		BC8DEF0520300AAF00E9EF0C /* CMakeLists.txt */ = {isa = PBXFileReference; fileEncoding = 4; indentWidth = 2; lastKnownFileType = text; path = CMakeLists.txt; sourceTree = "<group>"; tabWidth = 2; };
 		BC8DEF0620300AAF00E9EF0C /* BuildSystemBindings.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BuildSystemBindings.swift; sourceTree = "<group>"; };
@@ -1666,6 +1673,7 @@
 				BC8DEF0520300AAF00E9EF0C /* CMakeLists.txt */,
 				BC8DEF0620300AAF00E9EF0C /* BuildSystemBindings.swift */,
 				BC8DEF0720300AAF00E9EF0C /* CoreBindings.swift */,
+				B505BFB6228FCFAF00255BD7 /* BuildDBBindings.swift */,
 			);
 			indentWidth = 4;
 			path = llbuildSwift;
@@ -2133,6 +2141,7 @@
 				E1ADC2321A85923800D5387C /* Public API */,
 				E1ADC2301A85922F00D5387C /* CMakeLists.txt */,
 				E1DD22761C472A3F00555A5D /* BuildSystem-C-API.cpp */,
+				B505BFB1228FCB3000255BD7 /* BuildDB-C-API.cpp */,
 				E1ADC2311A85922F00D5387C /* C-API.cpp */,
 				E1DD22741C47259900555A5D /* Core-C-API.cpp */,
 			);
@@ -2156,6 +2165,7 @@
 				E1192CEC1C49D84500F85890 /* buildsystem.h */,
 				E1BE0AAD1C46F93000AD0883 /* core.h */,
 				E1ADC2351A8592AA00D5387C /* llbuild.h */,
+				B505BFB5228FCBAB00255BD7 /* db.h */,
 			);
 			path = llbuild;
 			sourceTree = "<group>";
@@ -2548,6 +2558,7 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				B5A84D0C22943F9200A59064 /* db.h in Headers */,
 				E1D191CA1B472440000C4E95 /* llbuild.h in Headers */,
 				E1BE0AAE1C46F94000AD0883 /* core.h in Headers */,
 				E1192CED1C49D84500F85890 /* buildsystem.h in Headers */,
@@ -3410,6 +3421,7 @@
 				E1ADC23E1A85938C00D5387C /* C-API.cpp in Sources */,
 				E1DD22771C472A3F00555A5D /* BuildSystem-C-API.cpp in Sources */,
 				E1DD22751C47259900555A5D /* Core-C-API.cpp in Sources */,
+				B505BFB4228FCB3F00255BD7 /* BuildDB-C-API.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -3508,6 +3520,8 @@
 				E1192CEF1C49DBA900F85890 /* Core-C-API.cpp in Sources */,
 				BC669C54205A2C2000942C3B /* BuildSystemBindings.swift in Sources */,
 				BC669C55205A2C2000942C3B /* CoreBindings.swift in Sources */,
+				B505BFB8228FCFEE00255BD7 /* BuildDBBindings.swift in Sources */,
+				B505BFB3228FCB3E00255BD7 /* BuildDB-C-API.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/products/libllbuild/BuildDB-C-API.cpp
+++ b/products/libllbuild/BuildDB-C-API.cpp
@@ -1,0 +1,156 @@
+//===-- BuildDB-C-API.cpp ---------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2019 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#include <llbuild/llbuild.h>
+
+#include "llbuild/Core/BuildDB.h"
+
+#include <mutex>
+
+using namespace llbuild;
+using namespace llbuild::core;
+
+namespace {
+  
+  class CAPIBuildDBKeysResult {
+  private:
+    std::vector<KeyType> keys;
+    
+  public:
+    CAPIBuildDBKeysResult(std::vector<KeyType> keys): keys(keys) { }
+    
+    CAPIBuildDBKeysResult(const CAPIBuildDBKeysResult&) LLBUILD_DELETED_FUNCTION;
+    CAPIBuildDBKeysResult& operator=(const CAPIBuildDBKeysResult&) LLBUILD_DELETED_FUNCTION;
+    
+    const uint32_t size() {
+      return keys.size();
+    }
+    
+    const KeyType keyAtIndex(KeyID index) {
+      return keys[index];
+    }
+  };
+  
+  class CAPIBuildDB: public BuildDBDelegate {
+    /// The key table, for memory caching of key to key id mapping.
+    llvm::StringMap<KeyID> keyTable;
+    
+    /// The mutex that protects the key table.
+    std::mutex keyTableMutex;
+    
+    std::unique_ptr<BuildDB> _db;
+    
+  public:
+    CAPIBuildDB(StringRef path, uint32_t clientSchemaVersion, std::string *error_out) {
+      _db = createSQLiteBuildDB(path, clientSchemaVersion, /* recreateUnmatchedVersion = */ false, error_out);
+      if (error_out != NULL) {
+        return;
+      }
+      // The delegate  caches keys for key ids
+      _db.get()->attachDelegate(this);
+      
+      if (!buildStarted(error_out)) {
+        buildComplete();
+        return;
+      }
+    }
+    
+    virtual const KeyID getKeyID(const KeyType& key) override {
+      std::lock_guard<std::mutex> guard(keyTableMutex);
+      
+      // The RHS of the mapping is actually ignored, we use the StringMap's ptr
+      // identity because it allows us to efficiently map back to the key string
+      // in `getRuleInfoForKey`.
+      auto it = keyTable.insert(std::make_pair(key, 0)).first;
+      return (KeyID)(uintptr_t)it->getKey().data();
+    }
+    
+    virtual KeyType getKeyForID(const KeyID key) override {
+      // Note that we don't need to lock `keyTable` here because the key entries
+      // themselves don't change once created.
+      return llvm::StringMapEntry<KeyID>::GetStringMapEntryFromKeyData(
+                                                                       (const char*)(uintptr_t)key).getKey();
+    }
+    
+    const bool buildStarted(std::string *error_out) {
+      return _db.get()->buildStarted(error_out);
+    }
+    
+    void buildComplete() {
+      _db.get()->buildComplete();
+    }
+    
+    const bool getKeys(std::vector<KeyType>& keys_out, std::string *error_out) {
+      return _db.get()->getKeys(keys_out, error_out);
+    }
+  };
+  
+}
+
+const llb_database_t* llb_database_open(
+                                          char *path,
+                                          uint32_t clientSchemaVersion,
+                                          llb_data_t *error_out) {
+  std::string error;
+  
+  auto database = new CAPIBuildDB(StringRef(path), clientSchemaVersion, &error);
+  
+  if (!error.empty() && error_out) {
+    error_out->length = error.size();
+    error_out->data = (const uint8_t*)strdup(error.c_str());
+  }
+  
+  return (llb_database_t *)database;
+}
+
+void llb_database_destroy(llb_database_t *database) {
+  auto db = (CAPIBuildDB *)database;
+  db->buildComplete();
+  delete db;
+}
+
+const llb_database_key_id llb_database_result_keys_get_count(llb_database_result_keys_t *result) {
+  auto resultKeys = (CAPIBuildDBKeysResult *)result;
+  return resultKeys->size();
+}
+
+void llb_database_result_keys_get_key_at_index(llb_database_result_keys_t *result, llb_database_key_id keyID, llb_data_t *key_out) {
+  auto resultKeys = (CAPIBuildDBKeysResult *)result;
+  auto key = resultKeys->keyAtIndex(keyID);
+  key_out->length = key.size();
+  key_out->data = (const uint8_t*) strdup(key.data());
+}
+
+void llb_database_destroy_result_keys(llb_database_result_keys_t *result) {
+  delete (CAPIBuildDBKeysResult *)result;
+}
+
+const bool llb_database_get_keys(llb_database_t *database, llb_database_result_keys_t **keysResult_out, llb_data_t *error_out) {
+  auto db = (CAPIBuildDB *)database;
+  
+  std::vector<KeyType> keys;
+  std::string error;
+  
+  auto success = db->getKeys(keys, &error);
+  
+  if (!error.empty() && error_out) {
+    error_out->length = error.size();
+    error_out->data = (const uint8_t*)strdup(error.c_str());
+    return success;
+  }
+  
+  auto resultKeys = new CAPIBuildDBKeysResult(keys);
+  *keysResult_out = (llb_database_result_keys_t *)resultKeys;
+  
+  return success;
+}
+

--- a/products/libllbuild/Core-C-API.cpp
+++ b/products/libllbuild/Core-C-API.cpp
@@ -179,6 +179,7 @@ bool llb_buildengine_attach_db(llb_buildengine_t* engine_p,
                                   std::string((char*)path->data,
                                               path->length),
                                   schema_version,
+                                  /* recreateUnmatchedVersion = */ true,
                                   &error));
   if (!db) {
     *error_out = strdup(error.c_str());

--- a/products/libllbuild/include/llbuild/db.h
+++ b/products/libllbuild/include/llbuild/db.h
@@ -1,0 +1,49 @@
+//===- db.h --------------------------------------------------*- C -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2019 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// These are the C API interfaces to the llbuild library.
+//
+//===----------------------------------------------------------------------===//
+
+/// Defines a key identifier _(should match \see KeyID in BuildEngine.h)_
+typedef uint64_t llb_database_key_id;
+/// Defines a key _(should match \see KeyType in BuildEngine.h)_
+typedef const char* llb_database_key_type;
+
+/// Opaque handler to a database
+typedef struct llb_database_t_ llb_database_t;
+
+/// Open the database that's saved at the given path by creating a llb_database_t instance
+LLBUILD_EXPORT const llb_database_t* llb_database_open(char *path, uint32_t clientSchemaVersion, llb_data_t *error_out);
+
+/// Destroy a build system instance
+LLBUILD_EXPORT void
+llb_database_destroy(llb_database_t *database);
+
+/// Opaque pointer to a fetch result for getting all keys from the database
+typedef struct llb_database_result_keys_t_ llb_database_result_keys_t;
+
+/// Method for getting the number of keys from a result keys object
+LLBUILD_EXPORT const llb_database_key_id
+llb_database_result_keys_get_count(llb_database_result_keys_t *result);
+
+/// Method for getting the key for a given id from a result keys object
+LLBUILD_EXPORT void
+llb_database_result_keys_get_key_at_index(llb_database_result_keys_t *result, llb_database_key_id keyID, llb_data_t *key_out);
+
+/// Destroys the given result keys object, call this when the object is not used anymore
+LLBUILD_EXPORT void
+llb_database_destroy_result_keys(llb_database_result_keys_t *result);
+
+/// Fetch all keys from the database. The keysResult_out object needs to be destroyed when not used anymore via \see llb_database_destroy_result_keys
+LLBUILD_EXPORT const bool
+llb_database_get_keys(llb_database_t *database, llb_database_result_keys_t **keysResult_out, llb_data_t *error_out);

--- a/products/libllbuild/include/llbuild/llbuild.h
+++ b/products/libllbuild/include/llbuild/llbuild.h
@@ -85,4 +85,7 @@ LLBUILD_EXPORT int llb_get_api_version(void);
 // The BuildSystem component.
 #include "buildsystem.h"
 
+// The Database component.
+#include "db.h"
+
 #endif

--- a/products/llbuildSwift/BuildDBBindings.swift
+++ b/products/llbuildSwift/BuildDBBindings.swift
@@ -1,0 +1,173 @@
+// This source file is part of the Swift.org open source project
+//
+// Copyright 2019 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+
+// This file contains Swift bindings for the llbuild C API.
+
+#if os(macOS)
+import Darwin.C
+#elseif os(Windows)
+import MSVCRT
+import WinSDK
+#else
+import Glibc
+#endif
+
+import Foundation
+
+// We don't need this import if we're building
+// this file as part of the llbuild framework.
+#if !LLBUILD_FRAMEWORK
+import llbuild
+#endif
+
+public typealias KeyID = UInt64
+public typealias KeyType = [UInt8]
+
+/// Defines the result of a call to fetch all keys from the database
+/// Wraps calls to the llbuild database, but all results are fetched and available with this result
+public class BuildDBKeysResult {
+    /// Opaque pointer to the actual result object
+    private let result: OpaquePointer?
+    
+    fileprivate init() {
+        self.result = nil
+    }
+    
+    fileprivate init(result: OpaquePointer) {
+        self.result = result
+    }
+    
+    private lazy var _count: Int = result.map { Int(llb_database_result_keys_get_count($0)) } ?? 0
+    
+    /// Get the key for a given key identifier (might be unique)
+    public func getKey(at index: KeyID) -> KeyType {
+        assert(result != nil, "Can't get key without fetching the data first.")
+        
+        var data = llb_data_t()
+        withUnsafeMutablePointer(to: &data) { ptr in
+            llb_database_result_keys_get_key_at_index(self.result, index, ptr)
+        }
+        defer { data.data?.deallocate() }
+        
+        return KeyType(UnsafeBufferPointer(start: data.data, count: Int(data.length)))
+    }
+    
+    deinit {
+        llb_database_destroy_result_keys(result)
+    }
+}
+
+extension BuildDBKeysResult: Collection {
+    public typealias Index = KeyID
+    public typealias Element = KeyType
+    
+    public var startIndex: Index {
+        return 0 as UInt64
+    }
+    
+    public var endIndex: Index {
+        return UInt64(self._count) + startIndex
+    }
+    
+    public subscript(index: Index) -> Iterator.Element {
+        guard (startIndex..<endIndex).contains(index) else {
+            fatalError("Index \(index) is out of bounds (\(startIndex)..<\(endIndex))")
+        }
+        return getKey(at: index)
+    }
+    
+    public func index(after i: KeyID) -> KeyID {
+        return i + 1
+    }
+}
+
+extension BuildDBKeysResult: CustomReflectable {
+    public var customMirror: Mirror {
+        let keys = (startIndex..<endIndex).map { getKey(at: $0) }
+        return Mirror(BuildDBKeysResult.self, unlabeledChildren: keys, displayStyle: .collection)
+    }
+}
+
+/// Private class for easier handling of out-parameters
+private class MutableStringPointer {
+    var ptr = llb_data_t()
+    init() { }
+    
+    deinit {
+        ptr.data?.deallocate()
+    }
+    
+    var msg: String? {
+        guard ptr.data != nil else { return nil }
+        return stringFromData(ptr)
+    }
+}
+
+/// Database object that defines a connection to a llbuild database
+public final class BuildDB {
+    
+    /// Errors that can happen when opening the database or performing operations on it
+    public enum Error: Swift.Error {
+        /// If the system can't open the database, this error is thrown at init
+        case couldNotOpenDB(error: String)
+        /// If an operation on the database fails, this error is thrown
+        case operationDidFail(error: String)
+        /// If the database didn't provide an error but the operation still failed, the unknownError is thrown
+        case unknownError
+    }
+    
+    /// The opaque pointer to the database object
+    private var _database: OpaquePointer? = nil
+    
+    /// Initializes the build database at a given path
+    /// If the database at this path doesn't exist, it will created
+    /// If the clientSchemaVersion is different to the one in the database at this path, its content will be automatically erased!
+    public init(path: String, clientSchemaVersion: UInt32) throws {
+        // Safety check that we have linked against a compatibile llbuild framework version
+        if llb_get_api_version() != LLBUILD_C_API_VERSION {
+            throw Error.couldNotOpenDB(error: "llbuild C API version mismatch, found \(llb_get_api_version()), expect \(LLBUILD_C_API_VERSION)")
+        }
+        
+        let errorPtr = MutableStringPointer()
+        _database = llb_database_open(strdup(path), clientSchemaVersion, &errorPtr.ptr)
+        
+        if let error = errorPtr.msg {
+            throw Error.couldNotOpenDB(error: error)
+        }
+    }
+    
+    deinit {
+        llb_database_destroy(_database)
+    }
+    
+    /// Fetches all keys from the database
+    public func getKeys() throws -> BuildDBKeysResult {
+        let errorPtr = MutableStringPointer()
+        let keys = UnsafeMutablePointer<OpaquePointer?>.allocate(capacity: 1)
+        let success = llb_database_get_keys(_database, keys, &errorPtr.ptr)
+        
+        if let error = errorPtr.msg {
+            throw Error.operationDidFail(error: error)
+        }
+        if !success {
+            throw Error.unknownError
+        }
+        
+        guard let resultKeys = keys.pointee else {
+            throw Error.unknownError
+        }
+        
+        return BuildDBKeysResult(result: resultKeys)
+    }
+    
+    // MARK: - Private functions for wrapping C++ API
+    
+    static private func toDB(_ context: UnsafeMutableRawPointer) -> BuildDB {
+        return Unmanaged<BuildDB>.fromOpaque(UnsafeRawPointer(context)).takeUnretainedValue()
+    }
+}

--- a/products/llbuildSwift/BuildSystemBindings.swift
+++ b/products/llbuildSwift/BuildSystemBindings.swift
@@ -42,7 +42,7 @@ private func copiedDataFromBytes(_ bytes: [UInt8]) -> llb_data_t {
 }
 
 // FIXME: We should eventually eliminate the need for this.
-private func stringFromData(_ data: llb_data_t) -> String {
+internal func stringFromData(_ data: llb_data_t) -> String {
     return String(decoding: UnsafeBufferPointer(start: data.data, count: Int(data.length)), as: Unicode.UTF8.self)
 }
 

--- a/unittests/Core/BuildEngineTest.cpp
+++ b/unittests/Core/BuildEngineTest.cpp
@@ -848,7 +848,7 @@ TEST(BuildEngineTest, basicIncrementalSignatureChange) {
     // Attach the database.
     {
       std::string error;
-      auto db = createSQLiteBuildDB(dbPath, 1, &error);
+      auto db = createSQLiteBuildDB(dbPath, 1, /* recreateUnmatchedVersion = */ true, &error);
       EXPECT_EQ(bool(db), true);
       if (!db) {
         fprintf(stderr, "unable to open database: %s\n", error.c_str());

--- a/unittests/Core/DepsBuildEngineTest.cpp
+++ b/unittests/Core/DepsBuildEngineTest.cpp
@@ -253,7 +253,7 @@ TEST(DepsBuildEngineTest, KeysWithNull) {
     // Attach the database.
     {
       std::string error;
-      auto db = createSQLiteBuildDB(dbPath, 1, &error);
+      auto db = createSQLiteBuildDB(dbPath, 1, /* recreateUnmatchedVersion = */ true, &error);
       EXPECT_EQ(bool(db), true);
       if (!db) {
         fprintf(stderr, "unable to open database: %s\n", error.c_str());

--- a/unittests/Core/SQLiteBuildDBTest.cpp
+++ b/unittests/Core/SQLiteBuildDBTest.cpp
@@ -31,7 +31,7 @@ TEST(SQLiteBuildDBTest, ErrorHandling) {
     fprintf(stderr, "using db: %s\n", path);
 
     std::string error;
-    std::unique_ptr<BuildDB> buildDB = createSQLiteBuildDB(dbPath, 1, &error);
+    std::unique_ptr<BuildDB> buildDB = createSQLiteBuildDB(dbPath, 1, /* recreateUnmatchedVersion = */ true, &error);
     EXPECT_TRUE(buildDB != nullptr);
     EXPECT_EQ(error, "");
 
@@ -39,7 +39,7 @@ TEST(SQLiteBuildDBTest, ErrorHandling) {
     sqlite3_open(path, &db);
     sqlite3_exec(db, "PRAGMA locking_mode = EXCLUSIVE; BEGIN EXCLUSIVE;", nullptr, nullptr, nullptr);
 
-    buildDB = createSQLiteBuildDB(dbPath, 1, &error);
+    buildDB = createSQLiteBuildDB(dbPath, 1, /* recreateUnmatchedVersion = */ true, &error);
     EXPECT_FALSE(buildDB == nullptr);
 
     // The database is opened lazily, thus run an operation that will cause it
@@ -70,11 +70,11 @@ TEST(SQLiteBuildDBTest, LockedWhileBuilding) {
   fprintf(stderr, "using db: %s\n", path);
 
   std::string error;
-  std::unique_ptr<BuildDB> buildDB = createSQLiteBuildDB(dbPath, 1, &error);
+  std::unique_ptr<BuildDB> buildDB = createSQLiteBuildDB(dbPath, 1, /* recreateUnmatchedVersion = */ true, &error);
   EXPECT_TRUE(buildDB != nullptr);
   EXPECT_EQ(error, "");
 
-  std::unique_ptr<BuildDB> secondBuildDB = createSQLiteBuildDB(dbPath, 1, &error);
+  std::unique_ptr<BuildDB> secondBuildDB = createSQLiteBuildDB(dbPath, 1, /* recreateUnmatchedVersion = */ true, &error);
   EXPECT_TRUE(buildDB != nullptr);
   EXPECT_EQ(error, "");
 
@@ -90,7 +90,7 @@ TEST(SQLiteBuildDBTest, LockedWhileBuilding) {
   EXPECT_EQ(error, out.str());
 
   // Tests that we cannot create new connections while a build is running
-  std::unique_ptr<BuildDB> otherBuildDB = createSQLiteBuildDB(dbPath, 1, &error);
+  std::unique_ptr<BuildDB> otherBuildDB = createSQLiteBuildDB(dbPath, 1, /* recreateUnmatchedVersion = */ true, &error);
   EXPECT_FALSE(otherBuildDB == nullptr);
 
   // The database is opened lazily, thus run an operation that will cause it


### PR DESCRIPTION
The build database is not accessible from the Swift interface. While that's okay for building we might want to make it accessible to do calculations on the information we have in the database.
Added a non-destructive version of the sqlite database which doesn't re-create the database automatically if versions mismatch. In this case, an error is thrown instead.

**NOTE**: This change requires the changes in https://github.com/apple/swift-llbuild/pull/483.

This enables the following usage:
```Swift
import llbuild

let path = "path/to/build.db"

// if clientSchemaVersion is different than in the specified database, an error will be thrown
// we still want to explicitly set this version to avoid wrong expectations
let db = try BuildDB(path: path, clientSchemaVersion: 1)
let keys = try db.getKeys()
dump(keys)
```