### PR TITLE
Adding fatal command result

### DIFF
--- a/include/llbuild/Basic/Subprocess.h
+++ b/include/llbuild/Basic/Subprocess.h
@@ -112,6 +112,7 @@ namespace llbuild {
       Failed,
       Cancelled,
       Skipped,
+      Fatal,
     };
 
     /// Result of a process execution.

--- a/include/llbuild/Basic/Subprocess.h
+++ b/include/llbuild/Basic/Subprocess.h
@@ -112,6 +112,7 @@ namespace llbuild {
       Failed,
       Cancelled,
       Skipped,
+      /// A fatal status should fail its related process as well
       Fatal,
     };
 

--- a/lib/BuildSystem/BuildSystem.cpp
+++ b/lib/BuildSystem/BuildSystem.cpp
@@ -2170,7 +2170,7 @@ public:
             // If we were unable to process the dependencies output, report a
             // failure.
             if (completionFn.hasValue())
-              completionFn.getValue()(ProcessStatus::Failed);
+              completionFn.getValue()(ProcessStatus::Fatal);
             return;
           }
           if (completionFn.hasValue())
@@ -2787,7 +2787,7 @@ public:
       for (const auto& depsPath: depsFiles) {
         if (!processDiscoveredDependencies(bsci, task, depsPath)) {
           if (completionFn.hasValue())
-            completionFn.getValue()(ProcessStatus::Failed);
+            completionFn.getValue()(ProcessStatus::Fatal);
           return;
         }
       }

--- a/lib/BuildSystem/ExternalCommand.cpp
+++ b/lib/BuildSystem/ExternalCommand.cpp
@@ -388,6 +388,7 @@ void ExternalCommand::execute(BuildSystemCommandInterface& bsci,
     // Process the result.
     switch (result.status) {
     case ProcessStatus::Failed:
+    case ProcessStatus::Fatal:
       resultFn(BuildValue::makeFailedCommand());
       return;
     case ProcessStatus::Cancelled:

--- a/lib/BuildSystem/ShellCommand.cpp
+++ b/lib/BuildSystem/ShellCommand.cpp
@@ -351,7 +351,7 @@ void ShellCommand::executeExternalCommand(
               // If we were unable to process the dependencies output, report a
               // failure.
               if (completionFn.hasValue())
-                completionFn.getValue()(ProcessStatus::Failed);
+                completionFn.getValue()(ProcessStatus::Fatal);
               return;
             }
             if (completionFn.hasValue())

--- a/products/libllbuild/BuildSystem-C-API.cpp
+++ b/products/libllbuild/BuildSystem-C-API.cpp
@@ -753,7 +753,7 @@ class CAPIExternalCommand : public ExternalCommand {
         // If we were unable to process the dependencies output, report a
         // failure.
         if (completionFn.hasValue())
-          completionFn.getValue()(ProcessStatus::Failed);
+          completionFn.getValue()(ProcessStatus::Fatal);
         return;
       }
     }

--- a/products/libllbuild/BuildSystem-C-API.cpp
+++ b/products/libllbuild/BuildSystem-C-API.cpp
@@ -148,6 +148,8 @@ class CAPIBuildSystemFrontendDelegate : public BuildSystemFrontendDelegate {
         return llb_buildsystem_command_result_failed;
       case ProcessStatus::Skipped:
         return llb_buildsystem_command_result_skipped;
+      case ProcessStatus::Fatal:
+        return llb_buildsystem_command_result_fatal;
       default:
         assert(0 && "unknown command result");
         break;

--- a/products/libllbuild/include/llbuild/buildsystem.h
+++ b/products/libllbuild/include/llbuild/buildsystem.h
@@ -111,6 +111,7 @@ typedef enum LLBUILD_ENUM_ATTRIBUTES {
   llb_buildsystem_command_result_failed = 1,
   llb_buildsystem_command_result_cancelled = 2,
   llb_buildsystem_command_result_skipped = 3,
+  llb_buildsystem_command_result_fatal = 4,
 } llb_buildsystem_command_result_t LLBUILD_SWIFT_NAME(CommandResult);
 
 /// Extended result of a command execution

--- a/products/libllbuild/include/llbuild/buildsystem.h
+++ b/products/libllbuild/include/llbuild/buildsystem.h
@@ -111,6 +111,7 @@ typedef enum LLBUILD_ENUM_ATTRIBUTES {
   llb_buildsystem_command_result_failed = 1,
   llb_buildsystem_command_result_cancelled = 2,
   llb_buildsystem_command_result_skipped = 3,
+  /// if a command fails with a fatal error, its related command process should fail independent from its state
   llb_buildsystem_command_result_fatal = 4,
 } llb_buildsystem_command_result_t LLBUILD_SWIFT_NAME(CommandResult);
 


### PR DESCRIPTION
This adds a new enum case to the result of a command, `fatal`. If a command fails fatally, its command process should also fail.
This is used (also included in this PR) for dependency file parsing. This is started as a separate job next to the external command. Before this change, the build (and process) doesn't fail if the dependency parsing fails. With this change, the fail of parsing will be propagated up and the build fails (in addition to the errors that get emitted in `MakefileDepsParser` or its counterpart).

rdar://51069563

There is a related bug that made us think about doing that change in the first place: https://bugs.swift.org/browse/SR-10735