### PR TITLE
Revert macOS posix_spawn_fileaction_chdir_np() adoption

### DIFF
--- a/lib/Basic/Subprocess.cpp
+++ b/lib/Basic/Subprocess.cpp
@@ -87,7 +87,7 @@ static int posix_spawn_file_actions_addchdir(posix_spawn_file_actions_t * __rest
 #if HAVE_POSIX_SPAWN_CHDIR
   return ::posix_spawn_file_actions_addchdir_np(file_actions, path);
 #else
-#if defined(__APPLE__) && __MAC_OS_X_VERSION_MAX_ALLOWED >= 101500
+#ifdef __APPLE__
   if (__builtin_available(macOS 10.15, *)) {
     return ::posix_spawn_file_actions_addchdir_np(file_actions, path);
   }

--- a/lib/Basic/Subprocess.cpp
+++ b/lib/Basic/Subprocess.cpp
@@ -73,7 +73,6 @@ int pthread_fchdir_np(int fd)
 
 #ifndef HAVE_POSIX_SPAWN_CHDIR
 #if defined(__sun) || \
-  (defined(__MAC_OS_X_VERSION_MIN_REQUIRED) && __MAC_OS_X_VERSION_MIN_REQUIRED >= 101500) || \
   __GLIBC_PREREQ(2, 29)
 #define HAVE_POSIX_SPAWN_CHDIR 1
 #else
@@ -87,12 +86,6 @@ static int posix_spawn_file_actions_addchdir(posix_spawn_file_actions_t * __rest
 #if HAVE_POSIX_SPAWN_CHDIR
   return ::posix_spawn_file_actions_addchdir_np(file_actions, path);
 #else
-#ifdef __APPLE__
-  if (__builtin_available(macOS 10.15, *)) {
-    return ::posix_spawn_file_actions_addchdir_np(file_actions, path);
-  }
-#endif
-
   // Any other POSIX platform returns ENOSYS (Function not implemented),
   // to simplify the fallback logic around the call site.
   return ENOSYS;


### PR DESCRIPTION
Availability macros are not properly guarding use on 10.14 hosts.

rdar://problem/51793107