### PR TITLE
build: remove a hack which is no longer needed

### DIFF
--- a/products/libllbuild/include/module.modulemap
+++ b/products/libllbuild/include/module.modulemap
@@ -1,9 +1,3 @@
 module "llbuild" {
   umbrella header "llbuild/llbuild.h"
-
-  // Hack: This allows the clients to autolink these system libraries when
-  // building using SwiftPM. We should declare this in the Package.swift
-  // manifest file once SwiftPM exposes an API for it.
-  link "sqlite3"
-  link "ncurses"
 }


### PR DESCRIPTION
This workaround was to force clients to link against the libraries.
This is no longer required.  Removing these enables building libllbuild
on Windows where ncurses is not available.