### PR TITLE
build: add missing dependencies

### DIFF
--- a/unittests/CAPI/CMakeLists.txt
+++ b/unittests/CAPI/CMakeLists.txt
@@ -8,6 +8,8 @@ add_llbuild_unittest(CAPITests
   )
 
 target_link_libraries(CAPITests PRIVATE
+  llvmSupport
+  llbuildBasic
   libllbuild
   SQLite::SQLite3)
 


### PR DESCRIPTION
This fixes building CAPITests on Windows.  Unlike Unix, Windows does not
permit undefined references to symbols at link time.  Add the missing
link dependencies to ensure that we can resolve all symbols.  This
permits building CAPITests on Windows.