### PR TITLE
Revert swift version changes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -205,13 +205,12 @@ endif()
 # Add an always out-of-date target to get the Swift compiler version.
 if (SWIFTC_FOUND)
   set(SWIFT_VERSION ${LLBUILD_OBJ_DIR}/swift-version)
-  execute_process(COMMAND ${SWIFTC_EXECUTABLE} -version
-    OUTPUT_FILE ${LLBUILD_OBJ_DIR}/swift-version.tmp
-    COMMAND ${CMAKE_COMMAND} -E copy_if_different ${LLBUILD_OBJ_DIR}/swift-version.tmp ${LLBUILD_OBJ_DIR}/swift-version
-    OUTPUT_STRIP_TRAILING_WHITESPACE)
-  add_custom_target(swiftversion ALL DEPENDS
-    ${LLBUILD_OBJ_DIR}/swift-version
-    ${SWIFTC_EXECUTABLE})
+  add_custom_target(
+    swiftversion ALL
+    COMMAND ${CMAKE_SOURCE_DIR}/utils/write-swift-version ${SWIFTC_EXECUTABLE} ${SWIFT_VERSION}
+    BYPRODUCTS ${SWIFT_VERSION}
+    COMMENT "Checking Swift compiler version"
+  )
 endif()
 
 ###


### PR DESCRIPTION
Swift-CI broke with these changes.  Seems the verison check is not being
re-run after the initial configure step.

rdar://problem/52198587