### PR TITLE
build: add a dependency on the compiler

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -202,17 +202,6 @@ if(LLBUILD_ENABLE_ASSERTIONS)
   string(REPLACE "-DNDEBUG" "" CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE}")
 endif()
 
-# Add an always out-of-date target to get the Swift compiler version.
-if (SWIFTC_FOUND)
-  set(SWIFT_VERSION ${LLBUILD_OBJ_DIR}/swift-version)
-  add_custom_target(
-    swiftversion ALL
-    COMMAND ${CMAKE_SOURCE_DIR}/utils/write-swift-version ${SWIFTC_EXECUTABLE} ${SWIFT_VERSION}
-    BYPRODUCTS ${SWIFT_VERSION}
-    COMMENT "Checking Swift compiler version"
-  )
-endif()
-
 ###
 
 # Process CMakeLists files for our subdirectories.

--- a/cmake/modules/Utility.cmake
+++ b/cmake/modules/Utility.cmake
@@ -227,5 +227,6 @@ function(add_swift_module target name deps sources additional_args)
   )
   
   # Add the target.    
-  add_custom_target(${target} ALL DEPENDS ${deps} ${DYLIB_OUTPUT} ${sources} swiftversion)
+  add_custom_target(${target} ALL DEPENDS ${deps} ${DYLIB_OUTPUT} ${sources})
+  add_dependencies(${target} ${SWIFTC_EXECUTABLE})
 endfunction()


### PR DESCRIPTION
Rather than depending on the version output, depend on the actual
compiler.  This is traditionally how CMake ensures that compiler changes
are reflected in the build.