### PR TITLE
[LLVM] Disable use of LLVM's CommandLine library in shared code.

### DIFF
--- a/lib/llvm/Support/Debug.cpp
+++ b/lib/llvm/Support/Debug.cpp
@@ -78,7 +78,10 @@ void setCurrentDebugTypes(const char **Types, unsigned Count) {
 } // namespace llvm
 
 // All Debug.h functionality is a no-op in NDEBUG mode.
-#ifndef NDEBUG
+//
+// LLBUILD-ONLY: Debug.h macros are disabled for llbuild (they inject static
+// constructors into library code).
+#if !defined(NDEBUG) && defined(LLVM_CODE_DISABLED_FOR_LLBUILD)
 
 // -debug - Command line option to enable the DEBUG statements in the passes.
 // This flag may only be enabled in debug builds.

--- a/lib/llvm/Support/Signals.cpp
+++ b/lib/llvm/Support/Signals.cpp
@@ -38,10 +38,13 @@ using namespace llvm;
 
 // Use explicit storage to avoid accessing cl::opt in a signal handler.
 static bool DisableSymbolicationFlag = false;
+
+#if defined(LLVM_CODE_DISABLED_FOR_LLBUILD)
 static cl::opt<bool, true>
     DisableSymbolication("disable-symbolication",
                          cl::desc("Disable symbolizing crash backtraces."),
                          cl::location(DisableSymbolicationFlag), cl::Hidden);
+#endif
 
 // Callbacks to run in signal handler must be lock-free because a signal handler
 // could be running as we add new callbacks. We don't add unbounded numbers of


### PR DESCRIPTION
 - This library injects static constructors which are unsuitable for use in
   library code, and in particular are causing the CAPI unit tests to fail at
   runtime (because of multiple definitions).

 - <rdar://problem/52894543> llbuild CAPI tests aren't running (the google test binary fails with LLVM command line errors)