### PR TITLE
[BuildEngine] Fix potential deadlock during cancel

### DIFF
--- a/lib/Core/BuildEngine.cpp
+++ b/lib/Core/BuildEngine.cpp
@@ -904,6 +904,13 @@ private:
               ruleInfo->keyID, ruleInfo->rule, ruleInfo->result, &error);
           if (!result) {
             delegate.error(error);
+
+            // Decrement our count of outstanding tasks. This must be done prior
+            // the subsequent synchronous cancellation, since it will otherwise
+            // deadlock waiting for the task we have already popped off the
+            // queue. rdar://problem/50203529
+            --numOutstandingUnfinishedTasks;
+
             cancelRemainingTasks();
             return false;
           }


### PR DESCRIPTION
If a failure occurs updating the build DB during finished task
processing, we trigger synchronous cancellation of the build. This
currently triggers a deadlock, waiting for the task that failed to be
marked as finished. This change prevents that deadlock by decrementing
the outstanding task count prior to such cancellation.

rdar://problem/50203529