### PR TITLE
[Windows] Fix a compilation error

### DIFF
--- a/unittests/BuildSystem/BuildSystemTaskTests.cpp
+++ b/unittests/BuildSystem/BuildSystemTaskTests.cpp
@@ -1157,7 +1157,7 @@ TEST(BuildSystemTaskTests, directoryContentsWithSkippedCommand) {
   ASSERT_TRUE(result.hasValue());
   ASSERT_FALSE(result.getValue().isSkippedCommand());
 
-  auto filters = StringList({"filter"});
+  auto filters = StringList("filter");
   result = system.build(BuildKey::makeDirectoryTreeSignature("inputDir", filters));
   ASSERT_TRUE(result.hasValue());
   ASSERT_FALSE(result.getValue().isSkippedCommand());


### PR DESCRIPTION
This was failing to compile on Windows for some reason:

```
[1/2] Building CXX object unittests\BuildSystem\CMakeFiles\BuildSystemTests.dir\BuildSystemTaskTests.cpp.obj
FAILED: unittests/BuildSystem/CMakeFiles/BuildSystemTests.dir/BuildSystemTaskTests.cpp.obj
C:\PROGRA~2\MICROS~1\2019\COMMUN~1\VC\Tools\MSVC\1421~1.277\bin\Hostx64\x64\cl.exe  /nologo /TP  -IZ:\llbuild\include -IZ:\llbuild\utils\unittest\googletest\include -IS:\sqlite-amalgamation-3270200 /DWIN32 /D_WINDOWS /W3 /GR /EHsc -DLLVM_ON_WIN32 /MD /Zi /O2 /Ob1 /DNDEBUG   -wd4068 -wd4141 -wd4146 -wd4244 -wd4267 -wd4291 -wd4800 -wd4996 -std:c++14 /showIncludes /Founittests\BuildSystem\CMakeFiles\BuildSystemTests.dir\BuildSystemTaskTests.cpp.obj /Fdunittests\BuildSystem\CMakeFiles\BuildSystemTests.dir\ /FS -c Z:\llbuild\unittests\BuildSystem\BuildSystemTaskTests.cpp
Z:\llbuild\unittests\BuildSystem\BuildSystemTaskTests.cpp(1161): error C2440: '<function-style-cast>': cannot convert from 'std::initializer_list<const char *>' to 'llbuild::basic::StringList'
Z:\llbuild\unittests\BuildSystem\BuildSystemTaskTests.cpp(1161): note: No constructor could take the source type, or constructor overload resolution was ambiguous
ninja: build stopped: subcommand failed.
```