### PR TITLE
Added timing information to the build database

### DIFF
--- a/include/llbuild/Basic/Clock.h
+++ b/include/llbuild/Basic/Clock.h
@@ -1,0 +1,42 @@
+//===- Clock.h --------------------------------------------------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2019 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLBUILD_BASIC_CLOCK_h
+#define LLBUILD_BASIC_CLOCK_h
+
+#include <algorithm>
+#include <chrono>
+
+namespace llbuild {
+namespace basic {
+
+class Clock {
+public:
+  /// A timestamp is the number of seconds since the clock's epoch time.
+  typedef double Timestamp;
+  
+  Clock() LLBUILD_DELETED_FUNCTION;
+  
+  /// Returns a global timestamp that represents the current time in seconds since a reference data.
+  /// *NOTE*: This function uses a monotonic clock, so don't compare between systems.
+  inline static Timestamp now() {
+    // steady_clock is monotonic
+    auto now = std::chrono::steady_clock::now();
+    std::chrono::duration<double> difference = std::chrono::duration_cast<std::chrono::seconds>(now.time_since_epoch());
+    return difference.count();
+  }
+};
+
+}
+}
+
+#endif

--- a/include/llbuild/Core/BuildDB.h
+++ b/include/llbuild/Core/BuildDB.h
@@ -65,7 +65,7 @@ public:
   ///
   /// \param success_out [out] Whether or not the query succeeded.
   /// \param error_out [out] Error string if success_out is false.
-  virtual uint64_t getCurrentIteration(bool* success_out, std::string* error_out) = 0;
+  virtual Epoch getCurrentEpoch(bool* success_out, std::string* error_out) = 0;
 
   /// Set the current build iteration.
   ///

--- a/include/llbuild/Core/BuildEngine.h
+++ b/include/llbuild/Core/BuildEngine.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See http://swift.org/LICENSE.txt for license information
@@ -37,9 +37,9 @@ typedef std::vector<uint8_t> ValueType;
 class BuildDB;
 class BuildEngine;
 
-/// A monotonically increasing timestamp identifying which iteration of a build
+/// A monotonically increasing number identifying which iteration of a build
 /// an event occurred during.
-typedef uint64_t Timestamp;
+typedef uint64_t Epoch;
 
 /// This object contains the result of executing a task to produce the value for
 /// a key.
@@ -51,7 +51,7 @@ struct Result {
   basic::CommandSignature signature;
 
   /// The build timestamp during which the result \see Value was computed.
-  uint64_t computedAt = 0;
+  Epoch computedAt = 0;
 
   /// The build timestamp at which this result was last checked to be
   /// up-to-date.
@@ -63,7 +63,7 @@ struct Result {
   // of the \see builtAt fields up to date. That is unfortunate from a
   // persistence perspective, where it would be ideal if we didn't touch any
   // disk state for null builds.
-  uint64_t builtAt = 0;
+  Epoch builtAt = 0;
 
   /// The explicit dependencies required by the generation.
   //
@@ -287,11 +287,11 @@ public:
   /// Return the delegate the engine was configured with.
   BuildEngineDelegate* getDelegate();
 
-  /// Get the current build timestamp used by the engine.
+  /// Get the current build epoch used by the engine.
   ///
-  /// The timestamp is a monotonically increasing value which is incremented
+  /// The iteration is a monotonically increasing value which is incremented
   /// with each requested build.
-  Timestamp getCurrentTimestamp();
+  Epoch getCurrentEpoch();
 
   /// @name Rule Definition
   /// @{

--- a/include/llbuild/Core/BuildEngine.h
+++ b/include/llbuild/Core/BuildEngine.h
@@ -16,6 +16,8 @@
 #include "llbuild/Basic/Compiler.h"
 #include "llbuild/Basic/Hashing.h"
 
+#include "llbuild/Basic/Clock.h"
+
 #include "llvm/ADT/StringRef.h"
 #include "llvm/ADT/Twine.h"
 
@@ -70,6 +72,12 @@ struct Result {
   // FIXME: At some point, figure out the optimal representation for this field,
   // which is likely to be a lot of the resident memory size.
   std::vector<KeyID> dependencies;
+  
+  /// The start of the command as a timestamp since a reference time
+  basic::Clock::Timestamp start;
+  
+  /// The timestamp of when the command finished computing
+  basic::Clock::Timestamp end;
 };
 
 /// A task object represents an abstract in-progress computation in the build

--- a/lib/BuildSystem/ExternalCommand.cpp
+++ b/lib/BuildSystem/ExternalCommand.cpp
@@ -322,7 +322,7 @@ ExternalCommand::computeCommandResult(BuildSystemCommandInterface& bsci) {
       // info, but need to refactor the command result to just store the node
       // subvalues instead.
       FileInfo info{};
-      info.size = bsci.getBuildEngine().getCurrentTimestamp();
+      info.size = bsci.getBuildEngine().getCurrentEpoch();
       outputInfos.push_back(info);
     } else if (node->isVirtual()) {
       outputInfos.push_back(FileInfo{});

--- a/lib/Core/SQLiteBuildDB.cpp
+++ b/lib/Core/SQLiteBuildDB.cpp
@@ -335,7 +335,7 @@ public:
     this->delegate = delegate;
   }
 
-  virtual uint64_t getCurrentIteration(bool* success_out, std::string *error_out) override {
+  virtual Epoch getCurrentEpoch(bool* success_out, std::string *error_out) override {
     std::lock_guard<std::mutex> guard(dbMutex);
 
     if (!open(error_out)) {

--- a/llbuild.xcodeproj/project.pbxproj
+++ b/llbuild.xcodeproj/project.pbxproj
@@ -943,6 +943,7 @@
 		B546B3A022C65DF0007046C0 /* BuildSystemBindingsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BuildSystemBindingsTests.swift; sourceTree = "<group>"; };
 		B546B3A422CA161A007046C0 /* BuildDBBindingsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BuildDBBindingsTests.swift; sourceTree = "<group>"; };
 		B563CEA620A6252500276198 /* CrossPlatformCompatibility.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CrossPlatformCompatibility.h; sourceTree = "<group>"; };
+		B58006ED22F9E847004869A2 /* Clock.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Clock.h; sourceTree = "<group>"; };
 		BC8DEF0520300AAF00E9EF0C /* CMakeLists.txt */ = {isa = PBXFileReference; fileEncoding = 4; indentWidth = 2; lastKnownFileType = text; path = CMakeLists.txt; sourceTree = "<group>"; tabWidth = 2; };
 		BC8DEF0620300AAF00E9EF0C /* BuildSystemBindings.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BuildSystemBindings.swift; sourceTree = "<group>"; };
 		BC8DEF0720300AAF00E9EF0C /* CoreBindings.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CoreBindings.swift; sourceTree = "<group>"; };
@@ -1954,6 +1955,7 @@
 			isa = PBXGroup;
 			children = (
 				E120B9EF1E4E65FC00B28469 /* BinaryCoding.h */,
+				B58006ED22F9E847004869A2 /* Clock.h */,
 				E182BE111ABA2B8D001840AD /* Compiler.h */,
 				B563CEA620A6252500276198 /* CrossPlatformCompatibility.h */,
 				40C71A8022F0EBCF008FDC9C /* Defer.h */,

--- a/unittests/Core/BuildEngineTest.cpp
+++ b/unittests/Core/BuildEngineTest.cpp
@@ -442,7 +442,7 @@ TEST(BuildEngineTest, incrementalDependency) {
 
     virtual void attachDelegate(BuildDBDelegate* delegate) override { ; }
 
-    virtual uint64_t getCurrentIteration(bool* success_out, std::string* error_out) override {
+    virtual uint64_t getCurrentEpoch(bool* success_out, std::string* error_out) override {
       return 0;
     }
     virtual bool setCurrentIteration(uint64_t value, std::string* error_out) override { return true; }

--- a/unittests/Core/SQLiteBuildDBTest.cpp
+++ b/unittests/Core/SQLiteBuildDBTest.cpp
@@ -45,7 +45,7 @@ TEST(SQLiteBuildDBTest, ErrorHandling) {
     // The database is opened lazily, thus run an operation that will cause it
     // to be opened and verify that it fails as expected.
     bool result = true;
-    buildDB->getCurrentIteration(&result, &error);
+    buildDB->getCurrentEpoch(&result, &error);
     EXPECT_FALSE(result);
 
     std::stringstream out;
@@ -96,7 +96,7 @@ TEST(SQLiteBuildDBTest, LockedWhileBuilding) {
   // The database is opened lazily, thus run an operation that will cause it
   // to be opened and verify that it fails as expected.
   bool success = true;
-  otherBuildDB->getCurrentIteration(&success, &error);
+  otherBuildDB->getCurrentEpoch(&success, &error);
   EXPECT_FALSE(success);
   EXPECT_EQ(error, out.str());
 

--- a/unittests/Swift/BuildDBBindingsTests.swift
+++ b/unittests/Swift/BuildDBBindingsTests.swift
@@ -141,7 +141,7 @@ class BuildDBBindingsTests: XCTestCase {
     
     expectCouldNotOpenError(path: exampleBuildDBPath,
                             clientSchemaVersion: 8,
-                            expectedError: "Version mismatch. (database-schema: 10 requested schema: 10. database-client: \(exampleBuildDBClientSchemaVersion) requested client: 8)")
+                            expectedError: "Version mismatch. (database-schema: 11 requested schema: 11. database-client: \(exampleBuildDBClientSchemaVersion) requested client: 8)")
     XCTAssertNoThrow(try BuildDB(path: exampleBuildDBPath, clientSchemaVersion: exampleBuildDBClientSchemaVersion))
   }
   


### PR DESCRIPTION
This renames existing timestamp properties and functions to epoch
to better differentiate between the new timestamp types.
A new Clock class gives access to static methods for getting global
timestamps in s.
The timing information is stored in the SQLite database in the rule
results table. That defines a new schema version.

rdar://52892354