### PR TITLE
Ask for microseconds and calculate seconds

### DIFF
--- a/include/llbuild/Basic/Clock.h
+++ b/include/llbuild/Basic/Clock.h
@@ -31,7 +31,7 @@ public:
   inline static Timestamp now() {
     // steady_clock is monotonic
     auto now = std::chrono::steady_clock::now();
-    std::chrono::duration<double> difference = std::chrono::duration_cast<std::chrono::seconds>(now.time_since_epoch());
+    auto difference = std::chrono::duration_cast<std::chrono::duration<double>>(now.time_since_epoch());
     return difference.count();
   }
 };


### PR DESCRIPTION
The API returns the rounded number in the requested unit. Requesting seconds as double still returns the rounded number casted to a double.
To get more accurate information, we'll request a smaller unit - microseconds - and calculate that back to seconds before returning.

rdar://54207984