### PR TITLE
Don't destroy a weak pointer

### DIFF
--- a/products/llbuildSwift/BuildKey.swift
+++ b/products/llbuildSwift/BuildKey.swift
@@ -115,6 +115,7 @@ public class BuildKey: CustomStringConvertible, Equatable, Hashable {
     }
     
     deinit {
+        if weakPointer { return }
         llb_build_key_destroy(internalBuildKey)
     }
     


### PR DESCRIPTION
The state of having a weak pointer in BuildKey was previously added but the check before destroying wasn't included.

rdar://54298130

I don't know how that slipped through, that's the essential part of the change in https://github.com/apple/swift-llbuild/pull/522.