### PR TITLE
Basic: adjust the reported subprocess id

### DIFF
--- a/lib/Basic/Subprocess.cpp
+++ b/lib/Basic/Subprocess.cpp
@@ -680,7 +680,7 @@ void llbuild::basic::spawnProcess(
             ctx, handle,
             workingDirectoryUnsupported
                 ? Twine("working-directory unsupported on this platform")
-                : Twine("unable to spawn process '") + args[0] + "' (" + sys::strerror(result) +
+                : Twine("unable to spawn process '") + argsStorage[0] + "' (" + sys::strerror(result) +
                       ")");
         delegate.processFinished(ctx, handle, processResult);
         pid = (llbuild_pid_t)-1;


### PR DESCRIPTION
Adjust the reported error to use the first string in the command line.
This is needed to ensure that we use the correct value on Windows.  THis
allows the Windows build to get further.