### PR TITLE
build: sink processor checks into Utility

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,20 +7,15 @@ if(NOT DEFINED LLBUILD_SUPPORT_BINDINGS)
   set(LLBUILD_SUPPORT_BINDINGS "")
 endif()
 
-
 # Include standard CMake modules.
 include(CMakeParseArguments)
 include(CheckCXXCompilerFlag)
-include(ProcessorCount)
 
 # Get the SDK path for OSX.
 execute_process(
     COMMAND xcrun --sdk macosx --show-sdk-path
     OUTPUT_VARIABLE CMAKE_OSX_SYSROOT
     OUTPUT_STRIP_TRAILING_WHITESPACE)
-
-# Compute the number of processors.
-ProcessorCount(NUM_PROCESSORS)
 
 project(llbuild)
 

--- a/cmake/modules/Utility.cmake
+++ b/cmake/modules/Utility.cmake
@@ -1,3 +1,8 @@
+include(ProcessorCount)
+
+# Compute the number of processors.
+ProcessorCount(NUM_PROCESSORS)
+
 function(append_if condition value)
   if (${condition})
     foreach(variable ${ARGN})


### PR DESCRIPTION
The processor count is used by the Swift build function.  Locate it near
it.  This will eventually go away as CMake 3.15 supports Swift
natively.