### PR TITLE
build: re-install libllbuild.so on Linux

### DIFF
--- a/products/libllbuild/CMakeLists.txt
+++ b/products/libllbuild/CMakeLists.txt
@@ -50,6 +50,14 @@ install(TARGETS libllbuild
   RUNTIME DESTINATION bin
   COMPONENT libllbuild)
 
+if(SWIFTC_FOUND)
+  if(NOT CMAKE_SYSTEM_NAME STREQUAL Windows)
+    install(TARGETS libllbuild
+      DESTINATION lib/swift/pm/llbuild
+      COMPONENT libllbuildSwift)
+  endif()
+endif()
+
 add_custom_target(install-libllbuild
                   DEPENDS libllbuild
                   COMMENT "Installing libllbuild..."


### PR DESCRIPTION
Install libllbuild as part of the llbuild build at a second location on
non-Windows targets: `lib/swift/pm/llbuild`.  This is needed for the
proper execution on Linux platforms.