### PR TITLE
Basic: correct dependencies for linking on Windows

### DIFF
--- a/lib/Basic/CMakeLists.txt
+++ b/lib/Basic/CMakeLists.txt
@@ -16,7 +16,7 @@ target_link_libraries(llbuildBasic PRIVATE
   llvmSupport
   Threads::Threads)
 
-if (${CMAKE_SYSTEM_NAME} STREQUAL "Windows")
-  target_link_libraries(llbuildBasic PRIVATE
+if(CMAKE_SYSTEM_NAME STREQUAL Windows)
+  target_link_libraries(llbuildBasic PUBLIC
     ShlWapi.lib)
 endif()


### PR DESCRIPTION
This corrects the link dependencies for Windows.  llbuildBasic is always
built as a static library.  This requires that the dependencies be
linked PUBLIC so that users of the library are able to have the
dependencies fulfilled.  llbuild now properly links in ShLwApi (the
dependency was previously silently fulfilled by the implicitly linked
libraries from CMake).