### PR TITLE
Add convenience initializer for RuleResult

### DIFF
--- a/products/libllbuild/BuildDB-C-API.cpp
+++ b/products/libllbuild/BuildDB-C-API.cpp
@@ -154,6 +154,9 @@ const llb_database_result_t mapResult(CAPIBuildDB &db, Result result) {
 
 void llb_database_destroy_result(const llb_database_result_t *result) {
   delete result->value.data;
+  for (uint32_t index = 0; index < result->dependencies_count; index++) {
+    llb_build_key_destroy(result->dependencies[index]);
+  }
   delete result->dependencies;
 }
 

--- a/unittests/Swift/BuildDBBindingsTests.swift
+++ b/unittests/Swift/BuildDBBindingsTests.swift
@@ -194,4 +194,17 @@ class BuildDBBindingsTests: XCTestCase {
     XCTAssertEqual(result3.value, BuildValue.SuccessfulCommand(outputInfos: [BuildValue.SuccessfulCommand.FileInfo()]))
   }
   
+  func testRuleResult() throws {
+    let deps = [BuildKey.CustomTask(name: "name", taskData: "taskData"), BuildKey.Command(name: "command")]
+    let result = RuleResult(value: BuildValue.FailedCommand(), signature: 0xff, computedAt: 1, builtAt: 2, start: 3, end: 4, dependencies: deps)
+    XCTAssertEqual(result.value, BuildValue.FailedCommand())
+    XCTAssertEqual(result.signature, 0xff)
+    XCTAssertEqual(result.computedAt, 1)
+    XCTAssertEqual(result.builtAt, 2)
+    XCTAssertEqual(result.start, 3)
+    XCTAssertEqual(result.end, 4)
+    XCTAssertEqual(result.dependencies.count, 2)
+    XCTAssertEqual(result.dependencies, deps)
+  }
+  
 }


### PR DESCRIPTION
Make RuleResult conform to Equatable.
Destroy owned build keys when destroying rule result.

rdar://50298961

This is some independent pre-work done for https://github.com/apple/swift-llbuild/pull/525