### PR TITLE
Create compatibility to Xcode 10

### DIFF
--- a/products/llbuildSwift/BuildDBBindings.swift
+++ b/products/llbuildSwift/BuildDBBindings.swift
@@ -101,7 +101,7 @@ public class RuleResult {
     /// The duration since a reference time of when the command finished computing
     public let end: Double
     /// The duration in seconds the result needed to finish
-    public var duration: Double { end - start }
+    public var duration: Double { return end - start }
     /// A list of the dependencies of the computed task, use the database's allKeys to check for their key
     public let dependencies: [BuildKey]
     

--- a/products/llbuildSwift/BuildKey.swift
+++ b/products/llbuildSwift/BuildKey.swift
@@ -29,13 +29,13 @@ public class BuildKey: CustomStringConvertible, Equatable, Hashable {
     
     /// Returns the kind of the key
     public var kind: Kind {
-        llb_build_key_get_kind(internalBuildKey)
+        return llb_build_key_get_kind(internalBuildKey)
     }
     
     /// Returns the key data without the identifier for the kind
     /// This can't be removed for legacy reasons.
     public var key: String {
-        String(cString: Array(self.keyData.dropFirst() + [0]))
+        return String(cString: Array(self.keyData.dropFirst() + [0]))
     }
     
     /// This raw data is used for internal representation and is encoded differently per subclass
@@ -90,7 +90,7 @@ public class BuildKey: CustomStringConvertible, Equatable, Hashable {
     }
     
     public var description: String {
-        "<\(type(of: self))>"
+        return "<\(type(of: self))>"
     }
     
     public static func ==(lhs: BuildKey, rhs: BuildKey) -> Bool {
@@ -103,7 +103,7 @@ public class BuildKey: CustomStringConvertible, Equatable, Hashable {
     }
     
     public static func construct(data: llb_data_t) -> BuildKey {
-        construct(key: withUnsafePointer(to: data, llb_build_key_make))
+        return construct(key: withUnsafePointer(to: data, llb_build_key_make))
     }
     
     public func hash(into hasher: inout Hasher) {
@@ -122,16 +122,16 @@ public class BuildKey: CustomStringConvertible, Equatable, Hashable {
         
         /// The name of the command
         public var name: String {
-            formString { llb_build_key_get_command_name(internalBuildKey, &$0) }
+            return formString { llb_build_key_get_command_name(internalBuildKey, &$0) }
         }
         
         override func equal(to other: BuildKey) -> Bool {
-            guard let rhs = other as? Self else { return false }
+            guard let rhs = other as? Command else { return false }
             return name == rhs.name
         }
         
         public override var description: String {
-            "<BuildKey.\(type(of: self)) name=\(name)>"
+            return "<BuildKey.\(type(of: self)) name=\(name)>"
         }
     }
 
@@ -143,25 +143,25 @@ public class BuildKey: CustomStringConvertible, Equatable, Hashable {
         
         /// The name of the task
         public var name: String {
-            formString {
+            return formString {
                 llb_build_key_get_custom_task_name(internalBuildKey, &$0)
             }
         }
         
         /// Custom data attached to the task
         public var taskData: String {
-            formString {
+            return formString {
                 llb_build_key_get_custom_task_data(internalBuildKey, &$0)
             }
         }
         
         override func equal(to other: BuildKey) -> Bool {
-            guard let rhs = other as? Self else { return false }
+            guard let rhs = other as? CustomTask else { return false }
             return name == rhs.name && taskData == rhs.taskData
         }
         
         public override var description: String {
-            "<BuildKey.\(type(of: self)) name=\(name) taskData=\(taskData)>"
+            return "<BuildKey.\(type(of: self)) name=\(name) taskData=\(taskData)>"
         }
     }
 
@@ -173,18 +173,18 @@ public class BuildKey: CustomStringConvertible, Equatable, Hashable {
         
         /// The path of the directory
         public var path: String {
-            formString {
+            return formString {
                 llb_build_key_get_directory_path(internalBuildKey, &$0)
             }
         }
         
         override func equal(to other: BuildKey) -> Bool {
-            guard let rhs = other as? Self else { return false }
+            guard let rhs = other as? DirectoryContents else { return false }
             return path == rhs.path
         }
         
         public override var description: String {
-            "<BuildKey.\(type(of: self)) path=\(path)>"
+            return "<BuildKey.\(type(of: self)) path=\(path)>"
         }
     }
 
@@ -200,7 +200,7 @@ public class BuildKey: CustomStringConvertible, Equatable, Hashable {
         
         /// The path of the directory
         public var path: String {
-            formString {
+            return formString {
                 llb_build_key_get_filtered_directory_path(internalBuildKey, &$0)
             }
         }
@@ -218,12 +218,12 @@ public class BuildKey: CustomStringConvertible, Equatable, Hashable {
         }
         
         override func equal(to other: BuildKey) -> Bool {
-            guard let rhs = other as? Self else { return false }
+            guard let rhs = other as? FilteredDirectoryContents else { return false }
             return path == rhs.path && filters == rhs.filters
         }
         
         public override var description: String {
-            "<BuildKey.\(type(of: self)) path=\(path) filters=[\(filters.joined(separator: ", "))]>"
+            return "<BuildKey.\(type(of: self)) path=\(path) filters=[\(filters.joined(separator: ", "))]>"
         }
     }
 
@@ -239,7 +239,7 @@ public class BuildKey: CustomStringConvertible, Equatable, Hashable {
         
         /// The path of the directory
         public var path: String {
-            formString {
+            return formString {
                 llb_build_key_get_directory_tree_signature_path(internalBuildKey, &$0)
             }
         }
@@ -257,12 +257,12 @@ public class BuildKey: CustomStringConvertible, Equatable, Hashable {
         }
         
         override func equal(to other: BuildKey) -> Bool {
-            guard let rhs = other as? Self else { return false }
+            guard let rhs = other as? DirectoryTreeSignature else { return false }
             return path == rhs.path && filters == rhs.filters
         }
         
         public override var description: String {
-            "<BuildKey.\(type(of: self)) path=\(path) filters=[\(filters.joined(separator: ", "))]>"
+            return "<BuildKey.\(type(of: self)) path=\(path) filters=[\(filters.joined(separator: ", "))]>"
         }
     }
 
@@ -274,18 +274,18 @@ public class BuildKey: CustomStringConvertible, Equatable, Hashable {
         
         /// The path of the directory
         public var path: String {
-            formString {
+            return formString {
                 llb_build_key_get_directory_tree_structure_signature_path(internalBuildKey, &$0)
             }
         }
         
         override func equal(to other: BuildKey) -> Bool {
-            guard let rhs = other as? Self else { return false }
+            guard let rhs = other as? DirectoryTreeStructureSignature else { return false }
             return path == rhs.path
         }
         
         public override var description: String {
-            "<BuildKey.\(type(of: self)) path=\(path)>"
+            return "<BuildKey.\(type(of: self)) path=\(path)>"
         }
     }
 
@@ -297,18 +297,18 @@ public class BuildKey: CustomStringConvertible, Equatable, Hashable {
         
         /// The path of the node
         public var path: String {
-            formString {
+            return formString {
                 llb_build_key_get_node_path(internalBuildKey, &$0)
             }
         }
         
         override func equal(to other: BuildKey) -> Bool {
-            guard let rhs = other as? Self else { return false }
+            guard let rhs = other as? Node else { return false }
             return path == rhs.path
         }
         
         public override var description: String {
-            "<BuildKey.\(type(of: self)) path=\(path)>"
+            return "<BuildKey.\(type(of: self)) path=\(path)>"
         }
     }
 
@@ -320,18 +320,18 @@ public class BuildKey: CustomStringConvertible, Equatable, Hashable {
         
         /// The path of the node
         public var path: String {
-            formString {
+            return formString {
                 llb_build_key_get_stat_path(internalBuildKey, &$0)
             }
         }
         
         override func equal(to other: BuildKey) -> Bool {
-            guard let rhs = other as? Self else { return false }
+            guard let rhs = other as? Stat else { return false }
             return path == rhs.path
         }
         
         public override var description: String {
-            "<BuildKey.\(type(of: self)) path=\(path)>"
+            return "<BuildKey.\(type(of: self)) path=\(path)>"
         }
     }
 
@@ -343,18 +343,18 @@ public class BuildKey: CustomStringConvertible, Equatable, Hashable {
         
         /// The name of the target
         public var name: String {
-            formString {
+            return formString {
                 llb_build_key_get_target_name(internalBuildKey, &$0)
             }
         }
         
         override func equal(to other: BuildKey) -> Bool {
-            guard let rhs = other as? Self else { return false }
+            guard let rhs = other as? Target else { return false }
             return name == rhs.name
         }
         
         public override var description: String {
-            "<BuildKey.\(type(of: self)) name=\(name)>"
+            return "<BuildKey.\(type(of: self)) name=\(name)>"
         }
     }
 

--- a/products/llbuildSwift/BuildValue.swift
+++ b/products/llbuildSwift/BuildValue.swift
@@ -52,25 +52,25 @@ extension BuildValueKind: CustomStringConvertible {
 
 extension BuildValueFileInfo: Equatable {
     public static func == (lhs: BuildValueFileInfo, rhs: BuildValueFileInfo) -> Bool {
-        lhs.device == rhs.device && lhs.inode == rhs.inode && lhs.mode == rhs.mode && lhs.size == rhs.size && lhs.modTime == rhs.modTime
+        return lhs.device == rhs.device && lhs.inode == rhs.inode && lhs.mode == rhs.mode && lhs.size == rhs.size && lhs.modTime == rhs.modTime
     }
 }
 
 extension BuildValueFileInfo: CustomStringConvertible {
     public var description: String {
-        "<FileInfo device=\(device) inode=\(inode) mode=\(mode) size=\(size) modTime=\(modTime)>"
+        return "<FileInfo device=\(device) inode=\(inode) mode=\(mode) size=\(size) modTime=\(modTime)>"
     }
 }
 
 extension BuildValueFileTimestamp: Equatable {
     public static func == (lhs: llb_build_value_file_timestamp_t_, rhs: BuildValueFileTimestamp) -> Bool {
-        lhs.seconds == rhs.seconds && lhs.nanoseconds == rhs.nanoseconds
+        return lhs.seconds == rhs.seconds && lhs.nanoseconds == rhs.nanoseconds
     }
 }
 
 extension BuildValueFileTimestamp: CustomStringConvertible {
     public var description: String {
-        "<FileTimestamp seconds=\(seconds) nanoseconds=\(nanoseconds)>"
+        return "<FileTimestamp seconds=\(seconds) nanoseconds=\(nanoseconds)>"
     }
 }
 
@@ -144,7 +144,7 @@ public class BuildValue: CustomStringConvertible, Equatable, Hashable {
     }
     
     public var description: String {
-        "<BuildValue.\(type(of: self))>"
+        return "<BuildValue.\(type(of: self))>"
     }
     
     public static func ==(lhs: BuildValue, rhs: BuildValue) -> Bool {
@@ -157,7 +157,7 @@ public class BuildValue: CustomStringConvertible, Equatable, Hashable {
     
     /// This needs to be overriden in subclass if properties need to be checked
     fileprivate func equal(to other: BuildValue) -> Bool {
-        type(of: self) == type(of: other)
+        return type(of: self) == type(of: other)
     }
     
     /// An invalid value, for sentinel purposes.
@@ -186,11 +186,11 @@ public class BuildValue: CustomStringConvertible, Equatable, Hashable {
         }
         
         override func equal(to other: BuildValue) -> Bool {
-            (other as? Self)?.fileInfo == fileInfo
+            return (other as? ExistingInput)?.fileInfo == fileInfo
         }
         
         public override var description: String {
-            "<BuildValue.\(type(of: self)) fileInfo=\(fileInfo)>"
+            return "<BuildValue.\(type(of: self)) fileInfo=\(fileInfo)>"
         }
     }
 
@@ -227,12 +227,12 @@ public class BuildValue: CustomStringConvertible, Equatable, Hashable {
         }
         
         override func equal(to other: BuildValue) -> Bool {
-            guard let other = other as? Self else { return false }
+            guard let other = other as? DirectoryContents else { return false }
             return fileInfo == other.fileInfo && contents == other.contents
         }
         
         public override var description: String {
-            "<BuildValue.\(type(of: self)) fileInfo=\(fileInfo) contents=[\(contents.joined(separator: ", "))]>"
+            return "<BuildValue.\(type(of: self)) fileInfo=\(fileInfo) contents=[\(contents.joined(separator: ", "))]>"
         }
     }
 
@@ -248,12 +248,12 @@ public class BuildValue: CustomStringConvertible, Equatable, Hashable {
         }
         
         override func equal(to other: BuildValue) -> Bool {
-            guard let other = other as? Self else { return false }
+            guard let other = other as? DirectoryTreeSignature else { return false }
             return signature == other.signature
         }
         
         public override var description: String {
-            "<BuildValue.\(type(of: self)) signature=\(signature)>"
+            return "<BuildValue.\(type(of: self)) signature=\(signature)>"
         }
     }
 
@@ -269,12 +269,12 @@ public class BuildValue: CustomStringConvertible, Equatable, Hashable {
         }
         
         override func equal(to other: BuildValue) -> Bool {
-            guard let other = other as? Self else { return false }
+            guard let other = other as? DirectoryTreeStructureSignature else { return false }
             return signature == other.signature
         }
         
         public override var description: String {
-            "<BuildValue.\(type(of: self)) signature=\(signature)>"
+            return "<BuildValue.\(type(of: self)) signature=\(signature)>"
         }
     }
 
@@ -311,12 +311,12 @@ public class BuildValue: CustomStringConvertible, Equatable, Hashable {
         }
         
         override func equal(to other: BuildValue) -> Bool {
-            guard let other = other as? Self else { return false }
+            guard let other = other as? SuccessfulCommand else { return false }
             return outputInfos == other.outputInfos
         }
         
         public override var description: String {
-            "<BuildValue.\(type(of: self)) outputInfos=[\(outputInfos.map { $0.description }.joined(separator: ", "))]>"
+            return "<BuildValue.\(type(of: self)) outputInfos=[\(outputInfos.map { $0.description }.joined(separator: ", "))]>"
         }
     }
 
@@ -377,12 +377,12 @@ public class BuildValue: CustomStringConvertible, Equatable, Hashable {
         }
         
         override func equal(to other: BuildValue) -> Bool {
-            guard let other = other as? Self else { return false }
+            guard let other = other as? StaleFileRemoval else { return false }
             return fileList == other.fileList
         }
         
         public override var description: String {
-            "<BuildValue.\(type(of: self)) fileList=[\(fileList.joined(separator: ", "))]>"
+            return "<BuildValue.\(type(of: self)) fileList=[\(fileList.joined(separator: ", "))]>"
         }
     }
 
@@ -407,12 +407,12 @@ public class BuildValue: CustomStringConvertible, Equatable, Hashable {
         }
         
         override func equal(to other: BuildValue) -> Bool {
-            guard let other = other as? Self else { return false }
+            guard let other = other as? FilteredDirectoryContents else { return false }
             return contents == other.contents
         }
         
         public override var description: String {
-            "<BuildValue.\(type(of: self)) contents=[\(contents.joined(separator: ", "))]>"
+            return "<BuildValue.\(type(of: self)) contents=[\(contents.joined(separator: ", "))]>"
         }
     }
 
@@ -439,12 +439,12 @@ public class BuildValue: CustomStringConvertible, Equatable, Hashable {
         }
         
         override func equal(to other: BuildValue) -> Bool {
-            guard let other = other as? Self else { return false }
+            guard let other = other as? SuccessfulCommandWithOutputSignature else { return false }
             return outputInfos == other.outputInfos && signature == other.signature
         }
         
         public override var description: String {
-            "<BuildValue.\(type(of: self)) outputInfos=[\(outputInfos.map { $0.description }.joined(separator: ", "))] signature=\(signature)>"
+            return "<BuildValue.\(type(of: self)) outputInfos=[\(outputInfos.map { $0.description }.joined(separator: ", "))] signature=\(signature)>"
         }
     }
 

--- a/products/llbuildSwift/Internals.swift
+++ b/products/llbuildSwift/Internals.swift
@@ -41,8 +41,8 @@ internal func stringFromData(_ data: llb_data_t) -> String {
 }
 
 extension Array where Element == String {
-    internal func withCArrayOfStrings<T>(_ body: (UnsafePointer<UnsafePointer<CChar>>) -> T) -> T {
-        func appendPointer(_ index: Self.Index, to target: inout Array<UnsafePointer<CChar>>) -> T {
+    internal func withCArrayOfStrings<T>(_ body: @escaping (UnsafePointer<UnsafePointer<CChar>>) -> T) -> T {
+        func appendPointer(_ index: Array.Index, to target: inout Array<UnsafePointer<CChar>>) -> T {
             if index == self.endIndex {
                 return body(&target)
             } else {


### PR DESCRIPTION
Xcode 10 ships with Swift 5.0 and doesn't know about implicit return or using Self in class context. The changes before required people to use Xcode 11 which isn't the officially released version.

I think we can revert this commit eventually to switch back using the cool 5.1 features once there's an official version available.