### PR TITLE
Allow building iOS + CocoaPods

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -7,6 +7,9 @@ import PackageDescription
 
 let package = Package(
     name: "llbuild",
+    platforms: [
+        .macOS(.v10_10), .iOS(.v9), .watchOS(.v2), .tvOS(.v9),
+    ],
     products: [
         .library(
             name: "libllbuild",

--- a/Package.swift
+++ b/Package.swift
@@ -14,6 +14,10 @@ let package = Package(
         .library(
             name: "llbuildSwift",
             targets: ["llbuildSwift"]),
+        .library(
+            name: "llbuild-framework",
+            type: .dynamic,
+            targets: ["llbuildSwift"]),
     ],
     targets: [
         /// The llbuild testing tool.

--- a/Package.swift
+++ b/Package.swift
@@ -18,7 +18,7 @@ let package = Package(
             name: "llbuildSwift",
             targets: ["llbuildSwift"]),
         .library(
-            name: "llbuild-framework",
+            name: "llbuildSwiftDynamic",
             type: .dynamic,
             targets: ["llbuildSwift"]),
     ],

--- a/Package.swift
+++ b/Package.swift
@@ -129,7 +129,7 @@ let package = Package(
             name: "llvmSupport",
             dependencies: ["llvmDemangle"],
             path: "lib/llvm/Support",
-            linkerSettings: [.linkedLibrary("ncurses")]
+            linkerSettings: [.linkedLibrary("ncurses", .when(platforms: [.linux, .macOS]))]
         ),
     ],
     cxxLanguageStandard: .cxx14

--- a/Package.swift
+++ b/Package.swift
@@ -8,7 +8,7 @@ import PackageDescription
 let package = Package(
     name: "llbuild",
     platforms: [
-        .macOS(.v10_10), .iOS(.v9), .watchOS(.v2), .tvOS(.v9),
+        .macOS(.v10_10), .iOS(.v9),
     ],
     products: [
         .library(

--- a/include/llbuild/Basic/Tracing.h
+++ b/include/llbuild/Basic/Tracing.h
@@ -19,6 +19,7 @@
 // os_signpost is included in mac OS 10.14, if that header is not available, we don't trace at all.
 #if __has_include(<os/signpost.h>)
 #include <os/signpost.h>
+#include <dispatch/dispatch.h>
 
 /// Returns the singleton instance of os_log_t to use with os_log and os_signpost API.
 API_AVAILABLE(macos(10.12), ios(10.0), watchos(3.0), tvos(10.0))

--- a/include/llbuild/BuildSystem/BuildSystemFrontend.h
+++ b/include/llbuild/BuildSystem/BuildSystemFrontend.h
@@ -116,7 +116,7 @@ public:
   /// Handle used to communicate information about a launched process.
   struct ProcessHandle {
     /// Opaque ID.
-    uintptr_t id;
+    uint64_t id;
   };
   
 private:

--- a/include/llvm/Config/config.h
+++ b/include/llvm/Config/config.h
@@ -256,7 +256,10 @@
 #if defined(__APPLE__)
 #include "TargetConditionals.h"
 #endif
-#if !defined(__APPLE__) || !TARGET_OS_IPHONE
+
+#if defined(__APPLE__) && TARGET_OS_IPHONE
+#undef HAVE_TERMINFO
+#else
 #define HAVE_TERMINFO 1
 #endif
 

--- a/include/llvm/Config/config.h
+++ b/include/llvm/Config/config.h
@@ -253,7 +253,12 @@
 #define HAVE_SYS_TYPES_H 1
 
 /* Define if the setupterm() function is supported this platform. */
+#if defined(__APPLE__)
+#include "TargetConditionals.h"
+#endif
+#if !defined(__APPLE__) || !TARGET_OS_IPHONE
 #define HAVE_TERMINFO 1
+#endif
 
 /* Define if the xar_open() function is supported this platform. */
 #define HAVE_LIBXAR 1

--- a/lib/Basic/Subprocess.cpp
+++ b/lib/Basic/Subprocess.cpp
@@ -44,7 +44,8 @@
 
 #ifdef __APPLE__
 #include <pthread/spawn.h>
-
+#include "TargetConditionals.h"
+#if !TARGET_OS_IPHONE
 extern "C" {
   // Provided by System.framework's libsystem_kernel interface
   extern int __pthread_chdir(const char *path);
@@ -64,7 +65,7 @@ int pthread_fchdir_np(int fd)
 {
   return __pthread_fchdir(fd);
 }
-
+#endif
 #endif
 
 #ifndef __GLIBC_PREREQ
@@ -624,7 +625,7 @@ void llbuild::basic::spawnProcess(
 
 #if !defined(_WIN32)
       if (usePosixSpawnChdirFallback) {
-#ifdef __APPLE__
+#if defined(__APPLE__) && !TARGET_OS_IPHONE
         thread_local std::string threadWorkingDir;
 
         if (workingDir.empty()) {
@@ -646,7 +647,7 @@ void llbuild::basic::spawnProcess(
           workingDirectoryUnsupported = true;
           result = -1;
         }
-#endif // ifdef __APPLE__
+#endif // if defined(__APPLE__) && !TARGET_OS_IPHONE
       }
 #endif // else !defined(_WIN32)
 

--- a/llbuild.podspec
+++ b/llbuild.podspec
@@ -23,7 +23,7 @@ Pod::Spec.new do |s|
   s.ios.deployment_target     = "10.0"
   s.osx.deployment_target     = "10.10"
 
-  s.source = { git: "https://github.com/apple/swift-llbuild",
+  s.source = { git: "https://github.com/apple/swift-llbuild.git",
                tag: s.version }
 
   s.default_subspecs = ['Swift']

--- a/llbuild.podspec
+++ b/llbuild.podspec
@@ -74,7 +74,7 @@ Pod::Spec.new do |s|
     sp.source_files = 'lib/BuildSystem/**/*.cpp'
     # internal header files, used this way to prevent header clash between subspecs
     sp.preserve_paths = 'include/llbuild/BuildSystem', 'lib/BuildSystem/**/*.h'
-    sp.compiler_flags = '-I${PODS_TARGET_SRCROOT}/include'
+    sp.compiler_flags = '-I${PODS_TARGET_SRCROOT}/include -Wno-error=c++11-narrowing'
 
     sp.dependency 'llbuild/Core'
   end

--- a/llbuild.podspec
+++ b/llbuild.podspec
@@ -20,7 +20,7 @@ Pod::Spec.new do |s|
   s.documentation_url  = "https://llbuild.readthedocs.io/"
   s.author             = "Apple"
 
-  s.ios.deployment_target     = "10.0"
+  s.ios.deployment_target     = "9.0"
   s.osx.deployment_target     = "10.10"
 
   s.source = { git: "https://github.com/apple/swift-llbuild.git",

--- a/llbuild.podspec
+++ b/llbuild.podspec
@@ -45,7 +45,7 @@ Pod::Spec.new do |s|
     # the first is an 'umbrella header', the rest have to be public because 
     # otherwise modular header warnings abound
     sp.public_header_files = 'products/libllbuild/include/llbuild/llbuild.h', 'products/libllbuild/include/llbuild/*.h'
-    sp.preserve_paths = 'products/libllbuild/BuildKey-C-API-Private.h'
+    sp.preserve_paths = 'products/libllbuild/BuildKey-C-API-Private.h', 'include/llbuild/BuildSystem/{BuildDescription,BuildKey,BuildValue}.h'
     
     sp.dependency 'llbuild/Core'
     sp.osx.dependency 'llbuild/BuildSystem' 

--- a/llbuild.podspec
+++ b/llbuild.podspec
@@ -18,13 +18,10 @@ Pod::Spec.new do |s|
   s.license      = { type: 'Apache 2.0', file: "LICENSE.txt" }
 
   s.documentation_url  = "https://llbuild.readthedocs.io/"
-
   s.author             = "Apple"
 
   s.ios.deployment_target     = "9.0"
   s.osx.deployment_target     = "10.10"
-  s.watchos.deployment_target = "2.0"
-  s.tvos.deployment_target    = "9.0"
 
   s.source = { git: "https://github.com/apple/swift-llbuild",
                tag: s.version }

--- a/llbuild.podspec
+++ b/llbuild.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
   s.name         = "llbuild"
-  s.version      = "0.1.1"
+  s.version      = ENV['LLBUILD_PODSPEC_VERSION'] || "9999.0.0"
   s.summary      = "A low-level build system."
 
   s.description  = <<-DESC.strip_heredoc

--- a/llbuild.podspec
+++ b/llbuild.podspec
@@ -28,7 +28,7 @@ Pod::Spec.new do |s|
 
   s.default_subspecs = ['Swift']
   s.pod_target_xcconfig = { 
-    'OTHER_LDFLAGS' => '-lsqlite3 -lncurses',
+    'OTHER_LDFLAGS' => '-lsqlite3',
     'GCC_C_LANGUAGE_STANDARD' => 'c11',
     'CLANG_CXX_LANGUAGE_STANDARD' => 'c++14',
     'CLANG_CXX_LIBRARY' => 'libc++',

--- a/llbuild.podspec
+++ b/llbuild.podspec
@@ -40,13 +40,11 @@ Pod::Spec.new do |s|
   end
 
   s.subspec 'Library' do |sp|
-    sp.osx.source_files = 'products/libllbuild/**/*.cpp', 'products/libllbuild/include/llbuild/*.h'
-    sp.ios.source_files = 'products/libllbuild/**/*.cpp', 'products/libllbuild/include/llbuild/{llbuild,core,buildkey,buildvalue,db}.h'
+    sp.source_files = 'products/libllbuild/**/*.cpp', 'products/libllbuild/include/llbuild/*.h'
 
     # the first is an 'umbrella header', the rest have to be public because 
     # otherwise modular header warnings abound
-    sp.ios.public_header_files = 'products/libllbuild/include/llbuild/llbuild.h', 'products/libllbuild/include/llbuild/{core,buildkey,buildvalue,db}.h'
-    sp.osx.public_header_files = 'products/libllbuild/include/llbuild/llbuild.h', 'products/libllbuild/include/llbuild/*.h'
+    sp.public_header_files = 'products/libllbuild/include/llbuild/llbuild.h', 'products/libllbuild/include/llbuild/*.h'
     sp.preserve_paths = 'products/libllbuild/BuildKey-C-API-Private.h'
     
     sp.dependency 'llbuild/Core'

--- a/llbuild.podspec
+++ b/llbuild.podspec
@@ -36,17 +36,16 @@ Pod::Spec.new do |s|
 
   s.subspec 'Swift' do |sp|
     sp.source_files = 'products/llbuildSwift/**/*.swift'
-    sp.ios.exclude_files = 'products/llbuildSwift/**/{BuildDBBindings,BuildSystemBindings}.swift'
     sp.dependency 'llbuild/Library'
   end
 
   s.subspec 'Library' do |sp|
     sp.osx.source_files = 'products/libllbuild/**/*.cpp', 'products/libllbuild/include/llbuild/*.h'
-    sp.ios.source_files = 'products/libllbuild/**/*.cpp', 'products/libllbuild/include/llbuild/{llbuild,core,buildkey,buildvalue}.h'
-    sp.ios.exclude_files = 'products/libllbuild/{BuildDB-C-API,BuildSystem-C-API}.cpp'
+    sp.ios.source_files = 'products/libllbuild/**/*.cpp', 'products/libllbuild/include/llbuild/{llbuild,core,buildkey,buildvalue,db}.h'
+
     # the first is an 'umbrella header', the rest have to be public because 
     # otherwise modular header warnings abound
-    sp.ios.public_header_files = 'products/libllbuild/include/llbuild/llbuild.h', 'products/libllbuild/include/llbuild/{core,buildkey,buildvalue}.h'
+    sp.ios.public_header_files = 'products/libllbuild/include/llbuild/llbuild.h', 'products/libllbuild/include/llbuild/{core,buildkey,buildvalue,db}.h'
     sp.osx.public_header_files = 'products/libllbuild/include/llbuild/llbuild.h', 'products/libllbuild/include/llbuild/*.h'
     sp.preserve_paths = 'products/libllbuild/BuildKey-C-API-Private.h'
     

--- a/llbuild.podspec
+++ b/llbuild.podspec
@@ -20,7 +20,7 @@ Pod::Spec.new do |s|
   s.documentation_url  = "https://llbuild.readthedocs.io/"
   s.author             = "Apple"
 
-  s.ios.deployment_target     = "9.0"
+  s.ios.deployment_target     = "10.0"
   s.osx.deployment_target     = "10.10"
 
   s.source = { git: "https://github.com/apple/swift-llbuild",

--- a/llbuild.podspec
+++ b/llbuild.podspec
@@ -27,7 +27,12 @@ Pod::Spec.new do |s|
                tag: s.version }
 
   s.default_subspecs = ['Swift']
-  s.pod_target_xcconfig = { 'OTHER_LDFLAGS' => '-lsqlite3 -lncurses' }
+  s.pod_target_xcconfig = { 
+    'OTHER_LDFLAGS' => '-lsqlite3 -lncurses',
+    'GCC_C_LANGUAGE_STANDARD' => 'c11',
+    'CLANG_CXX_LANGUAGE_STANDARD' => 'c++14',
+    'CLANG_CXX_LIBRARY' => 'libc++',
+  }
 
   s.subspec 'Swift' do |sp|
     sp.source_files = 'products/llbuildSwift/**/*.swift'

--- a/llbuild.podspec
+++ b/llbuild.podspec
@@ -1,0 +1,86 @@
+Pod::Spec.new do |s|
+
+  s.name         = "llbuild"
+  s.version      = "0.1.1"
+  s.summary      = "A low-level build system."
+
+  s.description  = <<-DESC.strip_heredoc
+                    **llbuild** is a set of libraries for building build systems. Unlike most build
+                    system projects which focus on the syntax for describing the build, llbuild is
+                    designed around a reusable, flexible, and scalable general purpose *build
+                    engine* capable of solving many "build system"-like problems. The project also
+                    includes additional libraries on top of that engine which provide support for
+                    constructing *bespoke* build systems (like `swift build`) or for building from
+                    Ninja manifests.
+                   DESC
+
+  s.homepage     = "https://github.com/apple/swift-llbuild"
+  s.license      = { type: 'Apache 2.0', file: "LICENSE.txt" }
+
+  s.documentation_url  = "https://llbuild.readthedocs.io/"
+
+  s.author             = "Apple"
+
+  s.ios.deployment_target     = "9.0"
+  s.osx.deployment_target     = "10.10"
+  s.watchos.deployment_target = "2.0"
+  s.tvos.deployment_target    = "9.0"
+
+  s.source = { git: "https://github.com/apple/swift-llbuild",
+               tag: s.version }
+
+  s.default_subspecs = ['Swift']
+  s.pod_target_xcconfig = { 'OTHER_LDFLAGS' => '-lsqlite3 -lncurses' }
+
+  s.subspec 'Swift' do |sp|
+    sp.source_files = 'products/llbuildSwift/**/*.swift'
+    sp.dependency 'llbuild/Library'
+  end
+
+  s.subspec 'Library' do |sp|
+    sp.source_files = 'products/libllbuild/**/*.cpp', 'products/libllbuild/include/llbuild/*.h'
+    # the first is an 'umbrella header', the rest have to be public because 
+    # otherwise modular header warnings abound
+    sp.public_header_files = 'products/libllbuild/include/llbuild/llbuild.h', 'products/libllbuild/include/llbuild/*.h'
+    sp.preserve_paths = 'products/libllbuild/BuildKey-C-API-Private.h'
+    sp.compiler_flags = '-I${PODS_TARGET_SRCROOT}/include'
+
+    sp.dependency 'llbuild/Core'
+    sp.dependency 'llbuild/BuildSystem' 
+  end
+
+  s.subspec 'Core' do |sp|
+    sp.source_files = 'lib/Core/**/*.cpp'
+    # internal header files, used this way to prevent header clash between subspecs
+    sp.preserve_paths = 'include/llbuild/Core', 'lib/Core/**/*.h'
+    sp.compiler_flags = '-I${PODS_TARGET_SRCROOT}/include'
+
+    sp.dependency 'llbuild/Basic'
+  end
+
+  s.subspec 'Basic' do |sp|
+    sp.source_files = 'lib/Basic/**/*.cpp'
+    # internal header files, used this way to prevent header clash between subspecs
+    sp.preserve_paths = 'include/llbuild/Basic', 'lib/Basic/**/*.h'
+    sp.exclude_files = 'include/llbuild/Basic/LeanWindows.h'
+    sp.compiler_flags = '-I${PODS_TARGET_SRCROOT}/include'
+
+    sp.dependency 'llbuild/llvmSupport'
+  end
+
+  s.subspec 'BuildSystem' do |sp|
+    sp.source_files = 'lib/BuildSystem/**/*.cpp'
+    # internal header files, used this way to prevent header clash between subspecs
+    sp.preserve_paths = 'include/llbuild/BuildSystem', 'lib/BuildSystem/**/*.h'
+    sp.compiler_flags = '-I${PODS_TARGET_SRCROOT}/include'
+
+    sp.dependency 'llbuild/Core'
+  end
+
+  s.subspec 'llvmSupport' do |sp|
+    sp.source_files = 'lib/llvm/{Support,Demangle}/**/*.cpp'
+    # internal header files, used this way to prevent header clash between subspecs
+    sp.preserve_paths = 'include/llvm', 'include/llvm-c', 'lib/llvm/Support/Unix', 'lib/llvm/Demangle/**/*.h'
+    sp.compiler_flags = '-I${PODS_TARGET_SRCROOT}/include'
+  end
+end

--- a/products/libllbuild/BuildSystem-C-API.cpp
+++ b/products/libllbuild/BuildSystem-C-API.cpp
@@ -13,6 +13,8 @@
 // Include the public API.
 #include <llbuild/llbuild.h>
 
+#if !defined(__APPLE__) || !TARGET_OS_IPHONE
+
 #include "llbuild/Basic/FileSystem.h"
 #include "llbuild/BuildSystem/BuildFile.h"
 #include "llbuild/BuildSystem/BuildKey.h"
@@ -898,3 +900,5 @@ void llb_set_quality_of_service(llb_quality_of_service_t level) {
 
 void* llb_alloc(size_t size) { return malloc(size); }
 void llb_free(void* ptr) { free(ptr); }
+
+#endif

--- a/products/libllbuild/BuildSystem-C-API.cpp
+++ b/products/libllbuild/BuildSystem-C-API.cpp
@@ -13,6 +13,10 @@
 // Include the public API.
 #include <llbuild/llbuild.h>
 
+#ifdef __APPLE__
+#include "TargetConditionals.h"
+#endif
+
 #if !defined(__APPLE__) || !TARGET_OS_IPHONE
 
 #include "llbuild/Basic/FileSystem.h"

--- a/products/libllbuild/include/llbuild/buildsystem.h
+++ b/products/libllbuild/include/llbuild/buildsystem.h
@@ -23,6 +23,12 @@
 
 #include "buildkey.h"
 
+#ifdef __APPLE__
+#include "TargetConditionals.h"
+#endif
+
+#if !defined(__APPLE__) || !TARGET_OS_IPHONE
+
 #include <stdbool.h>
 #include <stdint.h>
 
@@ -701,5 +707,7 @@ llb_alloc(size_t size);
 LLBUILD_EXPORT void
 llb_free(void* ptr);
 /// @}
+
+#endif
 
 #endif

--- a/products/libllbuild/include/llbuild/llbuild.h
+++ b/products/libllbuild/include/llbuild/llbuild.h
@@ -109,26 +109,20 @@ LLBUILD_EXPORT const char* llb_get_full_version_string(void);
 LLBUILD_EXPORT int llb_get_api_version(void);
 
 // The Core component.
-#if __has_include("llbuild/core.h")
 #include "llbuild/core.h"
-#endif
 
-// The BuildSystem component.
-#if __has_include("llbuild/buildsystem.h")
-#include "llbuild/buildsystem.h"
+#ifdef __APPLE__
+#include "TargetConditionals.h"
 #endif
+#if !defined(__APPLE__) || !TARGET_OS_IPHONE
+// The BuildSystem component.
+#include "llbuild/buildsystem.h"
 
 // The Database component.
-#if __has_include("llbuild/db.h")
 #include "llbuild/db.h"
 #endif
 
-#if __has_include("llbuild/buildkey.h")
 #include "llbuild/buildkey.h"
-#endif
-
-#if __has_include("llbuild/buildvalue.h")
 #include "llbuild/buildvalue.h"
-#endif
 
 #endif

--- a/products/libllbuild/include/llbuild/llbuild.h
+++ b/products/libllbuild/include/llbuild/llbuild.h
@@ -117,10 +117,10 @@ LLBUILD_EXPORT int llb_get_api_version(void);
 #if !defined(__APPLE__) || !TARGET_OS_IPHONE
 // The BuildSystem component.
 #include "llbuild/buildsystem.h"
+#endif
 
 // The Database component.
 #include "llbuild/db.h"
-#endif
 
 #include "llbuild/buildkey.h"
 #include "llbuild/buildvalue.h"

--- a/products/libllbuild/include/llbuild/llbuild.h
+++ b/products/libllbuild/include/llbuild/llbuild.h
@@ -109,16 +109,26 @@ LLBUILD_EXPORT const char* llb_get_full_version_string(void);
 LLBUILD_EXPORT int llb_get_api_version(void);
 
 // The Core component.
-#include "core.h"
+#if __has_include("llbuild/core.h")
+#include "llbuild/core.h"
+#endif
 
 // The BuildSystem component.
-#include "buildsystem.h"
+#if __has_include("llbuild/buildsystem.h")
+#include "llbuild/buildsystem.h"
+#endif
 
 // The Database component.
-#include "db.h"
+#if __has_include("llbuild/db.h")
+#include "llbuild/db.h"
+#endif
 
-#include "buildkey.h"
+#if __has_include("llbuild/buildkey.h")
+#include "llbuild/buildkey.h"
+#endif
 
-#include "buildvalue.h"
+#if __has_include("llbuild/buildvalue.h")
+#include "llbuild/buildvalue.h"
+#endif
 
 #endif

--- a/products/llbuildSwift/BuildDBBindings.swift
+++ b/products/llbuildSwift/BuildDBBindings.swift
@@ -8,13 +8,15 @@
 
 // This file contains Swift bindings for the llbuild C API.
 
-#if os(macOS)
+#if canImport(Darwin)
 import Darwin.C
 #elseif os(Windows)
 import MSVCRT
 import WinSDK
-#else
+#elseif canImport(Glibc)
 import Glibc
+#else
+#error("Missing libc or equivalent")
 #endif
 
 import Foundation

--- a/products/llbuildSwift/BuildKey.swift
+++ b/products/llbuildSwift/BuildKey.swift
@@ -8,13 +8,15 @@
 
 // This file contains Swift bindings for the llbuild C API.
 
-#if os(macOS)
+#if canImport(Darwin)
 import Darwin.C
 #elseif os(Windows)
 import MSVCRT
 import WinSDK
-#else
+#elseif canImport(Glibc)
 import Glibc
+#else
+#error("Missing libc or equivalent")
 #endif
 
 // We don't need this import if we're building

--- a/products/llbuildSwift/BuildSystemBindings.swift
+++ b/products/llbuildSwift/BuildSystemBindings.swift
@@ -27,6 +27,8 @@ import Foundation
 import llbuild
 #endif
 
+#if !os(iOS)
+
 private func bytesFromData(_ data: llb_data_t) -> [UInt8] {
     return Array(UnsafeBufferPointer(start: data.data, count: Int(data.length)))
 }
@@ -860,3 +862,4 @@ public final class BuildSystem {
     }
 }
 
+#endif

--- a/products/llbuildSwift/BuildSystemBindings.swift
+++ b/products/llbuildSwift/BuildSystemBindings.swift
@@ -8,13 +8,15 @@
 
 // This file contains Swift bindings for the llbuild C API.
 
-#if os(Linux)
-import Glibc
+#if canImport(Darwin)
+import Darwin.C
 #elseif os(Windows)
 import MSVCRT
 import WinSDK
+#elseif canImport(Glibc)
+import Glibc
 #else
-import Darwin.C
+#error("Missing libc or equivalent")
 #endif
 
 import Foundation
@@ -707,15 +709,15 @@ public final class BuildSystem {
         info.pointee.inode = UInt64(s.st_ino)
         info.pointee.mode = UInt64(s.st_mode)
         info.pointee.size = UInt64(s.st_size)
-        #if os(macOS)
-        info.pointee.mod_time.seconds = UInt64(s.st_mtimespec.tv_sec)
-        info.pointee.mod_time.nanoseconds = UInt64(s.st_mtimespec.tv_nsec)
+        #if os(Linux)
+        info.pointee.mod_time.seconds = UInt64(s.st_mtim.tv_sec)
+        info.pointee.mod_time.nanoseconds = UInt64(s.st_mtim.tv_nsec)
         #elseif os(Windows)
         info.pointee.mod_time.seconds = UInt64(s.st_mtime)
         info.pointee.mod_time.nanoseconds = 0
         #else
-        info.pointee.mod_time.seconds = UInt64(s.st_mtim.tv_sec)
-        info.pointee.mod_time.nanoseconds = UInt64(s.st_mtim.tv_nsec)
+        info.pointee.mod_time.seconds = UInt64(s.st_mtimespec.tv_sec)
+        info.pointee.mod_time.nanoseconds = UInt64(s.st_mtimespec.tv_nsec)
         #endif
     }
 

--- a/products/llbuildSwift/BuildSystemBindings.swift
+++ b/products/llbuildSwift/BuildSystemBindings.swift
@@ -711,15 +711,17 @@ public final class BuildSystem {
         info.pointee.inode = UInt64(s.st_ino)
         info.pointee.mode = UInt64(s.st_mode)
         info.pointee.size = UInt64(s.st_size)
-        #if os(Linux)
-        info.pointee.mod_time.seconds = UInt64(s.st_mtim.tv_sec)
-        info.pointee.mod_time.nanoseconds = UInt64(s.st_mtim.tv_nsec)
+        #if canImport(Darwin)
+        info.pointee.mod_time.seconds = UInt64(s.st_mtimespec.tv_sec)
+        info.pointee.mod_time.nanoseconds = UInt64(s.st_mtimespec.tv_nsec)
         #elseif os(Windows)
         info.pointee.mod_time.seconds = UInt64(s.st_mtime)
         info.pointee.mod_time.nanoseconds = 0
+        #elseif canImport(Glibc)
+        info.pointee.mod_time.seconds = UInt64(s.st_mtim.tv_sec)
+        info.pointee.mod_time.nanoseconds = UInt64(s.st_mtim.tv_nsec)
         #else
-        info.pointee.mod_time.seconds = UInt64(s.st_mtimespec.tv_sec)
-        info.pointee.mod_time.nanoseconds = UInt64(s.st_mtimespec.tv_nsec)
+        #error("Missing libc or equivalent")
         #endif
     }
 

--- a/products/llbuildSwift/BuildValue.swift
+++ b/products/llbuildSwift/BuildValue.swift
@@ -8,13 +8,15 @@
 
 // This file contains Swift bindings for the llbuild C API.
 
-#if os(macOS)
+#if canImport(Darwin)
 import Darwin.C
 #elseif os(Windows)
 import MSVCRT
 import WinSDK
-#else
+#elseif canImport(Glibc)
 import Glibc
+#else
+#error("Missing libc or equivalent")
 #endif
 
 // We don't need this import if we're building

--- a/products/llbuildSwift/Internals.swift
+++ b/products/llbuildSwift/Internals.swift
@@ -8,13 +8,15 @@
 
 // This file contains Swift bindings for the llbuild C API.
 
-#if os(Linux)
-import Glibc
+#if canImport(Darwin)
+import Darwin.C
 #elseif os(Windows)
 import MSVCRT
 import WinSDK
+#elseif canImport(Glibc)
+import Glibc
 #else
-import Darwin.C
+#error("Missing libc or equivalent")
 #endif
 
 // We don't need this import if we're building

--- a/utils/push-podspec
+++ b/utils/push-podspec
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -eu
+
+function usage() {
+  echo "Usage: $0 VERSION"
+}
+
+if [[ $# -eq 0 ]]; then
+  usage
+  exit 1
+fi
+
+export LLBUILD_PODSPEC_VERSION="$1"
+echo "Pushing llbuild.podspec to trunk with version $LLBUILD_PODSPEC_VERSION"
+pod trunk push llbuild.podspec


### PR DESCRIPTION
This PR makes small adjustments so that swift-llbuild can be embedded in iOS applications and other projects targeting Apple systems.

Changes:
* Add a dylib-only target, because currently, that's the only way to make Xcode link the library dynamically.
* Add missing import.
* Invert several platform conditionals so that they're targeting all Apple systems and not only `#if os(macOS)`.
* Add minimum versions to `Package.swift`.