### PR TITLE
Basic: correct fd check as identified by clang

### DIFF
--- a/include/llbuild/Basic/PlatformUtility.h
+++ b/include/llbuild/Basic/PlatformUtility.h
@@ -72,6 +72,7 @@ template <typename = FD> struct FileDescriptorTraits;
 
 #if defined(_WIN32)
 template <> struct FileDescriptorTraits<HANDLE> {
+  static bool IsValid(HANDLE hFile) { return hFile != INVALID_HANDLE_VALUE; }
   static void Close(HANDLE hFile) { CloseHandle(hFile); }
   static int Read(HANDLE hFile, void *destinationBuffer,
                   unsigned int maxCharCount) {
@@ -84,6 +85,7 @@ template <> struct FileDescriptorTraits<HANDLE> {
 };
 #endif
 template <> struct FileDescriptorTraits<int> {
+  static bool IsValid(int fd) { return fd >= 0; }
   static void Close(int fd) { close(fd); }
   static int Read(int hFile, void *destinationBuffer,
                   unsigned int maxCharCount) {

--- a/lib/Basic/Subprocess.cpp
+++ b/lib/Basic/Subprocess.cpp
@@ -310,7 +310,7 @@ static void cleanUpExecutedProcess(ProcessDelegate& delegate,
   // Note: We purposely hold this open until after the process has finished as
   // it simplifies client implentation. If we close it early, clients need to be
   // aware of and potentially handle a SIGPIPE.
-  if (releaseFd >= 0) {
+  if (sys::FileDescriptorTraits<>::IsValid(releaseFd)) {
     sys::FileDescriptorTraits<>::Close(releaseFd);
   }
 


### PR DESCRIPTION
clang objects to the ordered comparison between `HANDLE` and `int`.
Provide a trait based validation check for the FD.  Windows
traditionally uses `INVALID_HANDLE_VALUE` to indicate an invalid handle.