### PR TITLE
Make huge performance improvements in build database Swift layer

### DIFF
--- a/include/llbuild/Core/BuildDB.h
+++ b/include/llbuild/Core/BuildDB.h
@@ -129,6 +129,16 @@ public:
   /// \param error_out [out] Error string if return value is false.
   virtual bool getKeys(std::vector<KeyType>& keys_out, std::string* error_out) = 0;
 
+  /// Get a list of all keys and their results known by the database.
+  ///
+  /// \param keys_out [out] The known keys will be appended to this vector.
+  /// \param results_out [out] The results to the known keys will be appended to this vector.
+  /// \param error_out [out] Error string if return value is false
+  ///
+  /// \note The number of keys and results added to the out parameters is always
+  /// the same.
+  virtual bool getKeysWithResult(std::vector<KeyType> &keys_out, std::vector<Result> &results_out, std::string* error_out) = 0;
+  
   /// Dump a debug view of the database contents
   virtual void dump(raw_ostream& os) { (void)os; }
 };

--- a/products/libllbuild/BuildKey-C-API-Private.h
+++ b/products/libllbuild/BuildKey-C-API-Private.h
@@ -10,6 +10,7 @@
 #define BuildKey_C_API_Private_h
 
 #include "llbuild/BuildSystem/BuildKey.h"
+#include "llbuild/Core/BuildEngine.h"
 
 namespace {
 using namespace llbuild::buildsystem;
@@ -18,15 +19,36 @@ using namespace llbuild::buildsystem;
 class CAPIBuildKey {
   
 private:
+  llbuild::core::KeyID identifier;
+  bool hasIdentifier;
   BuildKey internalBuildKey;
+  size_t hashValue;
 public:
   
-  CAPIBuildKey(const BuildKey &buildKey): internalBuildKey(buildKey) {}
+  CAPIBuildKey(const BuildKey &buildKey): hasIdentifier(false), internalBuildKey(buildKey) {
+    hashValue = std::hash<std::string>{}(internalBuildKey.getKeyData());
+  }
+  
+  CAPIBuildKey(const BuildKey &buildKey, llbuild::core::KeyID identifier): identifier(identifier), hasIdentifier(true), internalBuildKey(buildKey) {
+    hashValue = std::hash<std::string>{}(internalBuildKey.getKeyData());
+  }
   
   BuildKey &getInternalBuildKey() {
     return internalBuildKey;
   }
+  size_t getHashValue() {
+    return hashValue;
+  }
   llb_build_key_kind_t getKind();
+  
+  bool operator ==(const CAPIBuildKey &b);
+};
+}
+
+namespace std {
+template <>
+struct hash<CAPIBuildKey> {
+  size_t operator()(CAPIBuildKey& key) const;
 };
 }
 

--- a/products/libllbuild/include/llbuild/buildkey.h
+++ b/products/libllbuild/include/llbuild/buildkey.h
@@ -21,6 +21,8 @@
 #error Clients must include the "llbuild.h" umbrella header.
 #endif
 
+#include <stddef.h>
+
 LLBUILD_ASSUME_NONNULL_BEGIN
 
 typedef enum LLBUILD_ENUM_ATTRIBUTES {
@@ -58,7 +60,13 @@ typedef enum LLBUILD_ENUM_ATTRIBUTES {
 typedef struct llb_build_key_t_ llb_build_key_t;
 
 LLBUILD_EXPORT llb_build_key_t *llb_build_key_make(const llb_data_t *data);
-LLBUILD_EXPORT void llb_build_key_get_key_data(llb_build_key_t *key, void *_Nullable context, void (*iteration)(void *_Nullable context, uint8_t data));
+
+LLBUILD_EXPORT bool llb_build_key_equal(llb_build_key_t *key1, llb_build_key_t *key2);
+
+LLBUILD_EXPORT size_t llb_build_key_hash(llb_build_key_t *key);
+
+LLBUILD_EXPORT void llb_build_key_get_key_data(llb_build_key_t *key, void *_Nonnull context, void (*_Nonnull iteration)(void *context, uint8_t *data, size_t count));
+
 LLBUILD_EXPORT llb_build_key_kind_t llb_build_key_get_kind(llb_build_key_t *key);
 
 LLBUILD_EXPORT void llb_build_key_destroy(llb_build_key_t *key);

--- a/products/libllbuild/include/llbuild/db.h
+++ b/products/libllbuild/include/llbuild/db.h
@@ -62,7 +62,7 @@ typedef struct llb_database_t_ llb_database_t;
 /// Open the database that's saved at the given path by creating a llb_database_t instance. If the creation fails due to an error, nullptr will be returned.
 LLBUILD_EXPORT const llb_database_t *_Nullable llb_database_open(char *path, uint32_t clientSchemaVersion, llb_data_t *error_out);
 
-/// Destroy a build system instance
+/// Destroy a build database instance
 LLBUILD_EXPORT void
 llb_database_destroy(llb_database_t *database);
 
@@ -72,25 +72,34 @@ llb_database_lookup_rule_result(llb_database_t *database, llb_build_key_t *key, 
 
 /// Destroys a result object by freeing its memory
 LLBUILD_EXPORT void
-llb_database_destroy_result(const llb_database_result_t *result);
+llb_database_destroy_result(llb_database_result_t *result);
 
-/// Opaque pointer to a fetch result for getting all keys from the database
-typedef struct llb_database_result_keys_t_ llb_database_result_keys_t;
+/// Opaque pointer to a fetch result for getting all keys (with or without results) from the database
+typedef struct llb_database_result_keys_t_ llb_database_fetch_result_t;
 
-/// Method for getting the number of keys from a result keys object
+/// Method for getting the number of keys from a fetch result object
 LLBUILD_EXPORT const llb_database_key_id
-llb_database_result_keys_get_count(llb_database_result_keys_t *result);
+llb_database_fetch_result_get_count(llb_database_fetch_result_t *result);
 
-/// Method for getting the key for a given id from a result keys object
+/// Method for getting the key for a given id from a fetch result object
 LLBUILD_EXPORT llb_build_key_t *
-llb_database_result_keys_get_key_at_index(llb_database_result_keys_t *result, int32_t index);
+llb_database_fetch_result_get_key_at_index(llb_database_fetch_result_t *result, int32_t index);
 
-/// Destroys the given result keys object, call this when the object is not used anymore
+/// Returns `true` if the result contains rule results. If it does, it's safe to call `llb_database_fetch_result_get_result_at_index` for any index between 0 and `llb_database_fetch_result_get_count`.
+LLBUILD_EXPORT const bool llb_database_fetch_result_contains_rule_results(llb_database_fetch_result_t *result);
+
+/// Method for getting the result at a given index from a fetch result object. The returned pointer might be nil if the fetch didn't include results
+LLBUILD_EXPORT llb_database_result_t *_Nullable
+llb_database_fetch_result_get_result_at_index(llb_database_fetch_result_t *result, int32_t index);
+
+/// Destroys the given fetch result object, call this when the object is not used anymore
 LLBUILD_EXPORT void
-llb_database_destroy_result_keys(llb_database_result_keys_t *result);
+llb_database_destroy_fetch_result(llb_database_fetch_result_t *result);
 
-/// Fetch all keys from the database. The keysResult_out object needs to be destroyed when not used anymore via \see llb_database_destroy_result_keys
+/// Fetch all keys from the database. The keysResult_out object needs to be destroyed when not used anymore via \see llb_database_destroy_fetch_result
 LLBUILD_EXPORT const bool
-llb_database_get_keys(llb_database_t *database, llb_database_result_keys_t *_Nullable *_Nonnull keysResult_out, llb_data_t *_Nullable error_out);
+llb_database_get_keys(llb_database_t *database, llb_database_fetch_result_t *_Nullable *_Nonnull keysResult_out, llb_data_t *_Nullable error_out);
+
+LLBUILD_EXPORT const bool llb_database_get_keys_and_results(llb_database_t *database, llb_database_fetch_result_t *_Nullable *_Nonnull keysAndResults_out, llb_data_t *_Nullable error_out);
 
 LLBUILD_ASSUME_NONNULL_END

--- a/products/llbuildSwift/BuildValue.swift
+++ b/products/llbuildSwift/BuildValue.swift
@@ -128,6 +128,10 @@ public class BuildValue: CustomStringConvertible, Equatable, Hashable {
         }
     }
     
+    deinit {
+        llb_build_value_destroy(internalBuildValue)
+    }
+    
     /// The kind of the build value.
     /// The kind also defines the subclass, so kind == .invalid means the instance should be of type Invalid
     public var kind: Kind {

--- a/unittests/Core/BuildEngineTest.cpp
+++ b/unittests/Core/BuildEngineTest.cpp
@@ -462,6 +462,7 @@ TEST(BuildEngineTest, incrementalDependency) {
     virtual bool buildStarted(std::string* error_out) override { return true; }
     virtual void buildComplete() override {}
     virtual bool getKeys(std::vector<KeyType>& keys_out, std::string* error_out) override { return false; }
+    virtual bool getKeysWithResult(std::vector<KeyType> &keys_out, std::vector<Result> &results_out, std::string* error_out) override { return false; };
   };
   CustomDB *db = new CustomDB();
   std::string error;

--- a/unittests/Swift/BuildDBBindingsTests.swift
+++ b/unittests/Swift/BuildDBBindingsTests.swift
@@ -106,23 +106,17 @@ class BuildDBBindingsTests: XCTestCase {
   
   override func setUp() {
     super.setUp()
-    let tmpDir = "/tmp/llbuild-test/\(UUID())"
+    let tmpDir = "/tmp/llbuild-test/\(self.name)"
+    
+    // We intentionally ignore errors here since the directory might not exist yet
+    do { try FileManager.default.removeItem(atPath: tmpDir) } catch {}
     
     do {
       try FileManager.default.createDirectory(atPath: tmpDir, withIntermediateDirectories: true)
     } catch {
-      fatalError("Could not create temporary directory for test case BuildDBBindingsTests at path: \(tmpDir)")
+      fatalError("Could not create or remove temporary directory for test case BuildDBBindingsTests at path: \(tmpDir)")
     }
     self.tmpDirectory = tmpDir
-  }
-  
-  override func tearDown() {
-    super.tearDown()
-    do {
-      try FileManager.default.removeItem(atPath: self.tmpDirectory)
-    } catch {
-      // intentionally left empty as we don't care about already removed directories
-    }
   }
   
   func testCouldNotOpenDatabaseErrors() {


### PR DESCRIPTION
Add new method to build database to fetch all keys *and* results.
  - makes fetching of all results much faster
Change ownership model of build keys.
  - all that are handed out by the database are owned by the database
  - manually constructed are owned by the creator (BuildKey.swift)
Move equal and hash implementation to C++ layer
  - makes use of new unique identifier which gets provided by the build database (if owned by it)

rdar://54701714