### PR TITLE
Fix Case of ShLwApi

### DIFF
--- a/lib/Basic/CMakeLists.txt
+++ b/lib/Basic/CMakeLists.txt
@@ -18,5 +18,5 @@ target_link_libraries(llbuildBasic PRIVATE
 
 if(CMAKE_SYSTEM_NAME STREQUAL Windows)
   target_link_libraries(llbuildBasic PUBLIC
-    ShlWapi.lib)
+    ShLwApi.lib)
 endif()


### PR DESCRIPTION
The Shell Lightweight API is spelled `ShLwApi` (however, the header is
spelled `Shlwapi`). This allows llbuild to compile targeting Windows on
case sensitive platforms.