### PR TITLE
Add warning for sign-compare when building in Xcode

### DIFF
--- a/Xcode/Configs/Common.xcconfig
+++ b/Xcode/Configs/Common.xcconfig
@@ -38,7 +38,7 @@ CLANG_CXX_LIBRARY = libc++
 #include "Version.xcconfig"
 
 COMMON_PREPROCESSOR_DEFINITIONS = $(LLBUILD_VERSION_DEFINITIONS)
-OTHER_CPLUSPLUSFLAGS = $(OTHER_CFLAGS) -Wimplicit-fallthrough -Wall
+OTHER_CPLUSPLUSFLAGS = $(OTHER_CFLAGS) -Wimplicit-fallthrough -Wsign-compare -Wall
 
 // MARK: Signing Support
 

--- a/perftests/Xcode/PerfTests/BinaryCodingPerfTests.mm
+++ b/perftests/Xcode/PerfTests/BinaryCodingPerfTests.mm
@@ -33,7 +33,7 @@ using namespace llbuild::basic;
                 coder.write(uint64_t(0xAABBCCDDAABBCCDDULL));
             }
             auto result = coder.contents();
-            XCTAssertEqual(result.size(), 1 << 20);
+            XCTAssertEqual(result.size(), (size_t) 1 << 20);
         }
     }];
 }
@@ -47,7 +47,7 @@ using namespace llbuild::basic;
         coder.write(uint64_t(0xAABBCCDDAABBCCDDULL ^ i));
     }
     auto data = coder.contents();
-    XCTAssertEqual(data.size(), 1 << 20);
+    XCTAssertEqual(data.size(), (size_t) 1 << 20);
     
     [self measureBlock:^{
         // We do 1000 iterations to sum to 100 MBs.

--- a/products/libllbuild/BuildDB-C-API.cpp
+++ b/products/libllbuild/BuildDB-C-API.cpp
@@ -363,7 +363,7 @@ const bool llb_database_get_keys_and_results(llb_database_t *database, llb_datab
   std::vector<llb_database_result_t> databaseResults;
   databaseResults.reserve(results.size());
   
-  for (int index = 0; index < keys.size(); index++) {
+  for (size_t index = 0; index < keys.size(); index++) {
     keyIDs.emplace_back(db->getKeyID(keys[index]));
     databaseResults.emplace_back(mapResult(*db, results[index]));
   }


### PR DESCRIPTION
The warning for sign compare is already turned on in CMake but not in the Xcode configuration.
That way a comparison with a signed and unsigned number slipped through which is fixed as well.