### PR TITLE
Abstract out default shell path and add Android LLVM config

### DIFF
--- a/include/llbuild/Basic/ExecutionQueue.h
+++ b/include/llbuild/Basic/ExecutionQueue.h
@@ -26,6 +26,9 @@ namespace llbuild {
     
     class ExecutionQueueDelegate;
 
+    // Default shell system path
+    const std::string DefaultShellPath = "/bin/sh";
+
     /// Description of the queue job, used for scheduling and diagnostics.
     class JobDescriptor {
     public:

--- a/include/llvm/Config/config.h
+++ b/include/llvm/Config/config.h
@@ -14,7 +14,9 @@
 #define ENABLE_CRASH_OVERRIDES 1
 
 /* Define to 1 if you have the `backtrace' function. */
+#if !defined(__ANDROID__)
 #define HAVE_BACKTRACE TRUE
+#endif
 
 #define BACKTRACE_HEADER <execinfo.h>
 
@@ -74,7 +76,11 @@
 /* #undef HAVE_FFI_H */
 
 /* Define to 1 if you have the `futimens' function. */
+#if defined(__ANDROID__)
+#define HAVE_FUTIMENS 1
+#else
 /* #undef HAVE_FUTIMENS */
+#endif
 
 /* Define to 1 if you have the `futimes' function. */
 #define HAVE_FUTIMES 1
@@ -104,7 +110,9 @@
 #define HAVE_LIBPTHREAD 1
 
 /* Define to 1 if you have the `pthread_getname_np' function. */
+#if !defined(__ANDROID__)
 #define HAVE_PTHREAD_GETNAME_NP 1
+#endif
 
 /* Define to 1 if you have the `pthread_setname_np' function. */
 #define HAVE_PTHREAD_SETNAME_NP 1

--- a/lib/Basic/ExecutionQueue.cpp
+++ b/lib/Basic/ExecutionQueue.cpp
@@ -58,7 +58,7 @@ bool ExecutionQueue::executeShellCommand(QueueJobContext* context,
 #if defined(_WIN32)
       {"C:\\windows\\system32\\cmd.exe", "/C", commandStorage.c_str()});
 #else
-      {"/bin/sh", "-c", commandStorage.c_str()});
+      {DefaultShellPath, "-c", commandStorage.c_str()});
 #endif
   return executeProcess(context, commandLine) == ProcessStatus::Succeeded;
 }

--- a/lib/BuildSystem/BuildSystem.cpp
+++ b/lib/BuildSystem/BuildSystem.cpp
@@ -2122,7 +2122,7 @@ public:
       // When provided as a scalar string, we default to executing using the
       // shell.
       args.clear();
-      args.push_back(ctx.getDelegate().getInternedString("/bin/sh"));
+      args.push_back(ctx.getDelegate().getInternedString(DefaultShellPath));
       args.push_back(ctx.getDelegate().getInternedString("-c"));
       args.push_back(ctx.getDelegate().getInternedString(value));
     } else if (name == "deps") {

--- a/lib/BuildSystem/ShellCommand.cpp
+++ b/lib/BuildSystem/ShellCommand.cpp
@@ -232,7 +232,7 @@ bool ShellCommand::configureAttribute(const ConfigureContext& ctx, StringRef nam
                        "C:\\windows\\system32\\cmd.exe"));
     args.push_back(ctx.getDelegate().getInternedString("/C"));
 #else
-    args.push_back(ctx.getDelegate().getInternedString("/bin/sh"));
+    args.push_back(ctx.getDelegate().getInternedString(DefaultShellPath));
     args.push_back(ctx.getDelegate().getInternedString("-c"));
 #endif
     args.push_back(ctx.getDelegate().getInternedString(value));

--- a/lib/Commands/NinjaBuildCommand.cpp
+++ b/lib/Commands/NinjaBuildCommand.cpp
@@ -1134,7 +1134,7 @@ buildCommand(BuildContext& context, ninja::Command* command) {
         "C:\\windows\\system32\\cmd.exe",
         "/C",
 #else
-        "/bin/sh",
+        DefaultShellPath,
         "-c",
 #endif
         command->getCommandString().c_str()

--- a/tests/BuildSystem/Build/exit-status.llbuild
+++ b/tests/BuildSystem/Build/exit-status.llbuild
@@ -3,13 +3,13 @@
 # RUN: rm -rf %t.build
 # RUN: mkdir -p %t.build
 # RUN: cp %s %t.build/build.llbuild
-# RUN: /bin/sh -c "%{llbuild} buildsystem build --serial --chdir %t.build; echo \"exit code: $?\"" > %t.out
+# RUN: %{sh-invoke} -c "%{llbuild} buildsystem build --serial --chdir %t.build; echo \"exit code: $?\"" > %t.out
 # RUN: %{FileCheck} < %t.out %s
 
 # Check that we error on invalid build files.
 #
 # RUN: echo "bogus" > %t.build/bogus.llbuild
-# RUN: /bin/sh -c "%{llbuild} buildsystem build --serial --chdir %t.build -f bogus.llbuild; echo \"exit code: $?\"" > %t.out
+# RUN: %{sh-invoke} -c "%{llbuild} buildsystem build --serial --chdir %t.build -f bogus.llbuild; echo \"exit code: $?\"" > %t.out
 # RUN: %{FileCheck} < %t.out %s
 
 # CHECK: exit code: 1

--- a/tests/Ninja/Build/cycle-detection.ninja
+++ b/tests/Ninja/Build/cycle-detection.ninja
@@ -3,7 +3,7 @@
 # RUN: rm -rf %t.build
 # RUN: mkdir -p %t.build
 # RUN: cp %s %t.build/build.ninja
-# RUN: /bin/sh -c "%{llbuild} ninja build --jobs 1 --no-db --chdir %t.build; echo \"exit code: $?\"" &> %t.out
+# RUN: %{sh-invoke} -c "%{llbuild} ninja build --jobs 1 --no-db --chdir %t.build; echo \"exit code: $?\"" &> %t.out
 # RUN: %{FileCheck} < %t.out %s
 
 # CHECK: cycle detected among targets: "output" -> "output-1" -> "intermediate" -> "output-2" -> "output-1"

--- a/tests/Ninja/Build/exit-status.ninja
+++ b/tests/Ninja/Build/exit-status.ninja
@@ -3,7 +3,7 @@
 # RUN: rm -rf %t.build
 # RUN: mkdir -p %t.build
 # RUN: cp %s %t.build/build.ninja
-# RUN: /bin/sh -c "%{llbuild} ninja build --jobs 1 --chdir %t.build; echo \"exit code: $?\"" > %t.out
+# RUN: %{sh-invoke} -c "%{llbuild} ninja build --jobs 1 --chdir %t.build; echo \"exit code: $?\"" > %t.out
 # RUN: %{FileCheck} < %t.out %s
 # CHECK: exit code: 1
 

--- a/tests/Ninja/Build/inherited-file-descriptors.ninja
+++ b/tests/Ninja/Build/inherited-file-descriptors.ninja
@@ -7,7 +7,7 @@
 # RUN: mkdir -p %t.build
 # RUN: ln -s %S/Inputs/check-open-fds %t.build
 # RUN: ln -s %s %t.build/build.ninja
-# RUN: /bin/sh -c "%{llbuild} ninja build --jobs 1 --no-db --chdir %t.build 4< /dev/null" &> %t.out
+# RUN: %{sh-invoke} -c "%{llbuild} ninja build --jobs 1 --no-db --chdir %t.build 4< /dev/null" &> %t.out
 # RUN: %{FileCheck} < %t.out %s
 
 # CHECK: [1/1] ./check-open-fds

--- a/tests/Ninja/Build/missing-inputs.ninja
+++ b/tests/Ninja/Build/missing-inputs.ninja
@@ -6,7 +6,7 @@
 # RUN: rm -rf %t.build
 # RUN: mkdir -p %t.build
 # RUN: cp %s %t.build/build.ninja
-# RUN: /bin/sh -c "%{llbuild} ninja build --jobs 1 --chdir %t.build --no-db; echo \"exit code: $?\"" &> %t1.out
+# RUN: %{sh-invoke} -c "%{llbuild} ninja build --jobs 1 --chdir %t.build --no-db; echo \"exit code: $?\"" &> %t1.out
 # RUN: %{FileCheck} < %t1.out %s
 #
 # CHECK: error:{{.*}} missing input 'input-1' and no rule to build it

--- a/tests/Ninja/Build/targets-tool.ninja
+++ b/tests/Ninja/Build/targets-tool.ninja
@@ -10,7 +10,7 @@
 
 # Check that we error on an unsupported argument.
 #
-# RUN: /bin/sh -c "%{llbuild} ninja build -f %s -t targets depth 2; echo \"exit code: $?\"" &> %t2.out
+# RUN: %{sh-invoke} -c "%{llbuild} ninja build -f %s -t targets depth 2; echo \"exit code: $?\"" &> %t2.out
 # RUN: %{FileCheck} --check-prefix CHECK-TARGETS-ERR --input-file %t2.out %s
 
 # CHECK-TARGETS-ERR: unsupported argument to tool 'targets': 'depth'

--- a/tests/lit.cfg
+++ b/tests/lit.cfg
@@ -101,6 +101,7 @@ config.substitutions.append( ('%{swiftc-platform-flags}', "" if not config.osx_s
 config.substitutions.append( ('%{build-dir}', llbuild_obj_root) ) 
 config.substitutions.append( ('%{env}', which('env')) )
 config.substitutions.append( ('%{sort}', which('sort')) )
+config.substitutions.append( ('%{sh-invoke}', '/bin/sh') )
 
 ###
 

--- a/unittests/Basic/LaneBasedExecutionQueueTest.cpp
+++ b/unittests/Basic/LaneBasedExecutionQueueTest.cpp
@@ -100,7 +100,7 @@ namespace {
     auto fn = [&tempDir, &queue](QueueJobContext* context) {
       std::string yescmd = "yes >yes-output.txt";
       std::vector<StringRef> commandLine(
-                                         { "/bin/sh", "-c", yescmd.c_str() });
+                                         { DefaultShellPath, "-c", yescmd.c_str() });
       std::shared_ptr<std::promise<ProcessStatus>> p{new std::promise<ProcessStatus>};
       auto result = p->get_future();
       queue->executeProcess(context, commandLine, {}, true, {true, tempDir.str()},


### PR DESCRIPTION
Using this pull and a couple other small tweaks ([like this one](https://github.com/termux/termux-packages/blob/master/packages/llbuild/lib-Basic-PlatformUtility.cpp.patch)), I got all but one of the tests (BuildSystemCAPI.CustomToolWithDiscoveredDependencies) to pass when building llbuild and running it natively on Android in [the Termux app](https://github.com/termux/termux-app).

Abstracting out the shell path is particularly useful on Android as the system shell is in /system/bin/sh and the local shell at /data/data/com.termux/files/usr/bin/sh, so setting the path in only two places like this makes it much easier to patch.