### PR TITLE
Finalize all sql statements when database gets closed

### DIFF
--- a/unittests/Core/SQLiteBuildDBTest.cpp
+++ b/unittests/Core/SQLiteBuildDBTest.cpp
@@ -109,3 +109,22 @@ TEST(SQLiteBuildDBTest, LockedWhileBuilding) {
   ec = llvm::sys::fs::remove(dbPath.str());
   EXPECT_EQ(bool(ec), false);
 }
+
+TEST(SQLiteBuildDBTest, CloseDBConnectionAfterCloseCall) {
+  // Create a temporary file.
+  llvm::SmallString<256> dbPath;
+  auto ec = llvm::sys::fs::createTemporaryFile("build", "db", dbPath);
+  EXPECT_EQ(bool(ec), false);
+  const char* path = dbPath.c_str();
+  fprintf(stderr, "using db: %s\n", path);
+  
+  std::string error;
+  std::unique_ptr<BuildDB> buildDB = createSQLiteBuildDB(dbPath, 1, /* recreateUnmatchedVersion = */ true, &error);
+  EXPECT_TRUE(buildDB != nullptr);
+  EXPECT_EQ(error, "");
+  
+  buildDB->buildStarted(&error);
+  EXPECT_EQ(error, "");
+  
+  buildDB->buildComplete();
+}


### PR DESCRIPTION
Without finalizing the sqlite database doesn't get closed accordingly.

rdar://55274300