### PR TITLE
Absolutize node names

### DIFF
--- a/include/llbuild/Ninja/Manifest.h
+++ b/include/llbuild/Ninja/Manifest.h
@@ -395,7 +395,8 @@ public:
   }
 
   /// Get or create the unique node for the given path.
-  Node* getOrCreateNode(StringRef path);
+  Node* findNode(StringRef workingDirectory, StringRef path);
+  Node* findOrCreateNode(StringRef workingDirectory, StringRef path);
 
   std::vector<Command*>& getCommands() {
     return commands;

--- a/include/llbuild/Ninja/Manifest.h
+++ b/include/llbuild/Ninja/Manifest.h
@@ -96,12 +96,14 @@ public:
 //
 // FIXME: Figure out what the deal is with normalization.
 class Node {
-  std::string path;
+  std::string canonicalPath;
+  std::string screenPath;
 
 public:
-  explicit Node(StringRef path) : path(path) {}
+  explicit Node(StringRef canonicalPath, StringRef screenPath) : canonicalPath(canonicalPath), screenPath(screenPath) {}
 
-  const std::string& getPath() const { return path; }
+  const std::string& getCanonicalPath() const { return canonicalPath; }
+  const std::string& getScreenPath() const { return screenPath; }
 };
 
 /// A pool represents a generic bucket for organizing commands.

--- a/include/llbuild/Ninja/ManifestLoader.h
+++ b/include/llbuild/Ninja/ManifestLoader.h
@@ -62,7 +62,7 @@ class ManifestLoader {
   void *impl;
 
 public:
-  ManifestLoader(std::string mainFilename, ManifestLoaderActions& actions);
+  ManifestLoader(StringRef workingDirectory, StringRef mainFilename, ManifestLoaderActions& actions);
   ~ManifestLoader();
 
   /// Load the manifest.

--- a/lib/Commands/NinjaBuildCommand.cpp
+++ b/lib/Commands/NinjaBuildCommand.cpp
@@ -30,6 +30,8 @@
 #include "llbuild/Ninja/ManifestLoader.h"
 
 #include "llvm/ADT/SmallString.h"
+#include "llvm/Support/FileSystem.h"
+#include "llvm/Support/Path.h"
 #include "llvm/Support/raw_ostream.h"
 
 #include "CommandLineStatusOutput.h"
@@ -336,6 +338,7 @@ public:
 };
 
 struct NinjaBuildEngineDelegate : public core::BuildEngineDelegate {
+  std::string workingDirectory;
   class BuildContext* context = nullptr;
 
   virtual core::Rule lookupRule(const core::KeyType& key) override;
@@ -343,11 +346,16 @@ struct NinjaBuildEngineDelegate : public core::BuildEngineDelegate {
   virtual void cycleDetected(const std::vector<core::Rule*>& items) override;
 
   virtual void error(const Twine& message) override;
+
+  NinjaBuildEngineDelegate(StringRef workingDirectory)
+    : workingDirectory(workingDirectory) { }
 };
 
 /// Wrapper for information used during a single build.
 class BuildContext : public ExecutionQueueDelegate {
 public:
+  const std::string workingDirectory;
+
   /// The build engine delegate.
   NinjaBuildEngineDelegate delegate;
 
@@ -490,14 +498,16 @@ public:
   }
 
 public:
-  BuildContext()
-    : engine(delegate),
+  BuildContext(StringRef workingDirectory)
+    : workingDirectory(workingDirectory),
+      delegate({workingDirectory}),
+      engine(delegate),
       isCancelled(false)
   {
     // Open the status output.
     std::string error;
     if (!statusOutput.open(&error)) {
-      fprintf(stderr, "error: %s: unable to open output: %s\n",
+      fprintf(stderr, "%s: error: unable to open output: %s\n",
               getProgramName(), error.c_str());
       exit(1);
     }
@@ -1204,25 +1214,38 @@ buildCommand(BuildContext& context, ninja::Command* command) {
         struct DepsActions : public core::MakefileDepsParser::ParseActions {
           BuildContext& context;
           NinjaCommandTask* task;
-          const std::string& path;
+          const StringRef workingDirectory;
+          const StringRef path;
           unsigned numErrors{0};
 
           DepsActions(BuildContext& context, NinjaCommandTask* task,
-                      const std::string& path)
-            : context(context), task(task), path(path) {}
+                      const StringRef workingDirectory,
+                      const StringRef path)
+            : context(context), task(task), workingDirectory(workingDirectory), path(path) { }
 
           virtual void error(const char* message, uint64_t position) override {
             context.emitError(
                 "error reading dependency file: %s (%s) at offset %u",
-                path.c_str(), message, unsigned(position));
+                path.str().c_str(), message, unsigned(position));
             ++numErrors;
           }
 
           virtual void actOnRuleDependency(const char* dependency,
                                            uint64_t length,
-                                           const StringRef
-                                             unescapedWord) override {
-            context.engine.taskDiscoveredDependency(task, unescapedWord);
+                                           const StringRef unescapedWord) override {
+            StringRef path;
+            SmallString<256> absPathTmp;
+
+            if (llvm::sys::path::is_absolute(unescapedWord)) {
+              path = unescapedWord;
+            } else {
+              absPathTmp = unescapedWord;
+              llvm::sys::fs::make_absolute(workingDirectory, absPathTmp);
+              assert(absPathTmp[0] == '/');
+              path = absPathTmp;
+            }
+
+            context.engine.taskDiscoveredDependency(task, path);
           }
 
           virtual void actOnRuleStart(const char* name, uint64_t length,
@@ -1230,7 +1253,7 @@ buildCommand(BuildContext& context, ninja::Command* command) {
           virtual void actOnRuleEnd() override {}
         };
 
-        DepsActions actions(context, this, command->getDepsFile());
+        DepsActions actions(context, this, context.workingDirectory, command->getDepsFile());
         core::MakefileDepsParser(data.get(), length, actions).parse();
         return actions.numErrors == 0;
       }
@@ -1486,7 +1509,7 @@ core::Rule NinjaBuildEngineDelegate::lookupRule(const core::KeyType& key) {
   // FIXME: This is frequently a redundant lookup, given that the caller might
   // well have had the Node* available. This is something that would be nice
   // to avoid when we support generic key types.
-  ninja::Node* node = context->manifest->getOrCreateNode(key);
+  ninja::Node* node = context->manifest->findOrCreateNode(workingDirectory, key);
 
   return core::Rule{
     node->getPath(),
@@ -1774,6 +1797,14 @@ int commands::executeNinjaBuildCommand(std::vector<std::string> args) {
     }
   }
 
+  SmallString<128> current_dir;
+  if (std::error_code ec = llvm::sys::fs::current_path(current_dir)) {
+    fprintf(stderr, "%s: error: cannot determine current directory\n",
+            getProgramName());
+    return 1;
+  }
+  const std::string workingDirectory = current_dir.str();
+
   // Run up to two iterations, the first one loads the manifest and rebuilds it
   // if necessary, the second only runs if the manifest needs to be reloaded.
   //
@@ -1781,7 +1812,7 @@ int commands::executeNinjaBuildCommand(std::vector<std::string> args) {
   // reloaded (we reopen the database, for example), but we don't expect that to
   // be a common case spot in practice.
   for (int iteration = 0; iteration != 2; ++iteration) {
-    BuildContext context;
+    BuildContext context{workingDirectory};
 
     context.numFailedCommandsToTolerate = numFailedCommandsToTolerate;
     context.quiet = quiet;
@@ -1805,7 +1836,7 @@ int commands::executeNinjaBuildCommand(std::vector<std::string> args) {
 
     // Load the manifest.
     BuildManifestActions actions(context);
-    ninja::ManifestLoader loader(manifestFilename, actions);
+    ninja::ManifestLoader loader(workingDirectory, manifestFilename, actions);
     context.manifest = loader.load();
 
     // If there were errors loading, we are done.
@@ -1838,9 +1869,6 @@ int commands::executeNinjaBuildCommand(std::vector<std::string> args) {
     }
 
     // Otherwise, run the build.
-
-    // Parse the positional arguments.
-    std::vector<std::string> targetsToBuild(args);
 
     // Attach the database, if requested.
     if (!dbFilename.empty()) {
@@ -1946,7 +1974,9 @@ int commands::executeNinjaBuildCommand(std::vector<std::string> args) {
 
     // If this is the first iteration, build the manifest, unless disabled.
     if (autoRegenerateManifest && iteration == 0) {
-      context.engine.build(manifestFilename);
+      SmallString<256> absManifestFilename = StringRef(manifestFilename);
+      llvm::sys::fs::make_absolute(workingDirectory, absManifestFilename);
+      context.engine.build(StringRef(absManifestFilename));
 
       // If the manifest was rebuilt, then reload it and build again.
       if (context.numBuiltCommands) {
@@ -1970,6 +2000,19 @@ int commands::executeNinjaBuildCommand(std::vector<std::string> args) {
       }
 
       fprintf(context.profileFP, "[\n");
+    }
+
+    // Parse the positional arguments.
+    std::vector<std::string> targetsToBuild;
+
+    for (const std::string& arg: args) {
+      if (auto *node = context.manifest->findNode(context.workingDirectory, arg)) {
+          targetsToBuild.push_back(node->getPath());
+      } else {
+        fprintf(stderr, "%s: error: unknown target: '%s'\n",
+            getProgramName(), arg.c_str());
+        exit(1);
+      }
     }
 
     // If no explicit targets were named, build the default targets.

--- a/lib/Commands/NinjaCommand.cpp
+++ b/lib/Commands/NinjaCommand.cpp
@@ -18,6 +18,7 @@
 #include "llbuild/Ninja/Manifest.h"
 #include "llbuild/Ninja/ManifestLoader.h"
 #include "llbuild/Ninja/Parser.h"
+#include "llvm/Support/FileSystem.h"
 
 #include "CommandUtil.h"
 #include "NinjaBuildCommand.h"
@@ -412,8 +413,16 @@ static int executeLoadManifestCommand(const std::vector<std::string>& args,
     filename = filename.substr(pos+1);
   }
 
+  SmallString<128> current_dir;
+  if (std::error_code ec = llvm::sys::fs::current_path(current_dir)) {
+    fprintf(stderr, "%s: error: cannot determine current directory\n",
+            getProgramName());
+    return 1;
+  }
+  const std::string workingDirectory = current_dir.str();
+
   LoadManifestActions actions;
-  ninja::ManifestLoader loader(filename, actions);
+  ninja::ManifestLoader loader(workingDirectory, filename, actions);
   std::unique_ptr<ninja::Manifest> manifest = loader.load();
 
   // If only loading, we are done.

--- a/lib/Commands/NinjaCommand.cpp
+++ b/lib/Commands/NinjaCommand.cpp
@@ -499,15 +499,15 @@ static int executeLoadManifestCommand(const std::vector<std::string>& args,
             [] (ninja::Command* a, ninja::Command* b) {
               // Commands can not have duplicate outputs, so comparing based
               // only on the first still provides a total ordering.
-              return a->getOutputs()[0]->getPath() <
-                b->getOutputs()[0]->getPath();
+              return a->getOutputs()[0]->getScreenPath() <
+                b->getOutputs()[0]->getScreenPath();
             });
   std::cout << "# Commands\n";
   for (const auto& command: commands) {
     // Write the command entry.
     std::cout << "build";
     for (const auto& node: command->getOutputs()) {
-      std::cout << " \"" << util::escapedString(node->getPath()) << "\"";
+      std::cout << " \"" << util::escapedString(node->getScreenPath()) << "\"";
     }
     std::cout << ": " << command->getRule()->getName();
     unsigned count = 0;
@@ -519,7 +519,7 @@ static int executeLoadManifestCommand(const std::vector<std::string>& args,
                            command->getNumImplicitInputs())) {
         std::cout << "|| ";
       }
-      std::cout << "\"" << util::escapedString(node->getPath()) << "\"";
+      std::cout << "\"" << util::escapedString(node->getScreenPath()) << "\"";
       ++count;
     }
     std::cout << "\n";
@@ -561,13 +561,13 @@ static int executeLoadManifestCommand(const std::vector<std::string>& args,
     std::vector<ninja::Node*> defaultTargets = manifest->getDefaultTargets();
     std::sort(defaultTargets.begin(), defaultTargets.end(),
               [] (ninja::Node* a, ninja::Node* b) {
-        return a->getPath() < b->getPath();
+        return a->getScreenPath() < b->getScreenPath();
       });
     std::cout << "default ";
     for (const auto& node: defaultTargets) {
       if (node != defaultTargets[0])
         std::cout << " ";
-      std::cout << "\"" << node->getPath() << "\"";
+      std::cout << "\"" << node->getScreenPath() << "\"";
     }
     std::cout << "\n\n";
   }

--- a/lib/Ninja/Manifest.cpp
+++ b/lib/Ninja/Manifest.cpp
@@ -80,6 +80,6 @@ Node* Manifest::findOrCreateNode(StringRef workingDirectory, StringRef path0) {
 
   auto& result = nodes[path];
   if (!result)
-    result = new (getAllocator()) Node(path);
+    result = new (getAllocator()) Node(path, path0);
   return result;
 }

--- a/lib/Ninja/ManifestLoader.cpp
+++ b/lib/Ninja/ManifestLoader.cpp
@@ -400,7 +400,7 @@ public:
       for (unsigned i = 0, ie = decl->getNumExplicitInputs(); i != ie; ++i) {
         if (i != 0)
           result << " ";
-        auto& path = decl->getInputs()[i]->getPath();
+        auto& path = decl->getInputs()[i]->getScreenPath();
         result << (context->shellEscapeInAndOut ? basic::shellEscaped(path)
                                                 : path);
       }
@@ -409,7 +409,7 @@ public:
       for (unsigned i = 0, ie = decl->getOutputs().size(); i != ie; ++i) {
         if (i != 0)
           result << " ";
-        auto& path = decl->getOutputs()[i]->getPath();
+        auto& path = decl->getOutputs()[i]->getScreenPath();
         result << (context->shellEscapeInAndOut ? basic::shellEscaped(path)
                                                 : path);
       }

--- a/lib/Ninja/ManifestLoader.cpp
+++ b/lib/Ninja/ManifestLoader.cpp
@@ -58,6 +58,7 @@ class ManifestLoaderImpl: public ParseActions {
         scope(scope) {}
   };
 
+  std::string workingDirectory;
   std::string mainFilename;
   ManifestLoaderActions& actions;
   std::unique_ptr<Manifest> theManifest;
@@ -70,10 +71,9 @@ class ManifestLoaderImpl: public ParseActions {
   SmallString<10 * 1024> buildDescription;
 
 public:
-  ManifestLoaderImpl(std::string mainFilename, ManifestLoaderActions& actions)
-    : mainFilename(mainFilename), actions(actions), theManifest(nullptr)
-  {
-  }
+  ManifestLoaderImpl(StringRef workingDirectory, StringRef mainFilename, ManifestLoaderActions& actions)
+    : workingDirectory(workingDirectory), mainFilename(mainFilename), actions(actions), theManifest(nullptr)
+  { }
 
   std::unique_ptr<Manifest> load() {
     // Create the manifest.
@@ -277,14 +277,14 @@ public:
     // Resolve all of the inputs and outputs.
     for (const auto& nameTok: nameToks) {
       StringRef name(nameTok.start, nameTok.length);
+      Node* node = theManifest->findNode(workingDirectory, name);
 
-      auto it = theManifest->getNodes().find(name);
-      if (it == theManifest->getNodes().end()) {
+      if (node == nullptr) {
         error("unknown target name", nameTok);
         continue;
       }
 
-      theManifest->getDefaultTargets().push_back(it->second);
+      theManifest->getDefaultTargets().push_back(node);
     }
   }
 
@@ -341,7 +341,7 @@ public:
       if (path.empty()) {
         error("empty output path", token);
       }
-      outputs.push_back(theManifest->getOrCreateNode(path.str()));
+      outputs.push_back(theManifest->findOrCreateNode(workingDirectory, path));
     }
     for (const auto& token: inputTokens) {
       // Evaluate the token string.
@@ -350,7 +350,7 @@ public:
       if (path.empty()) {
         error("empty input path", token);
       }
-      inputs.push_back(theManifest->getOrCreateNode(path.str()));
+      inputs.push_back(theManifest->findOrCreateNode(workingDirectory, path));
     }
 
     Command* decl = new (theManifest->getAllocator())
@@ -624,9 +624,10 @@ public:
 
 #pragma mark - ManifestLoader
 
-ManifestLoader::ManifestLoader(std::string filename,
+ManifestLoader::ManifestLoader(StringRef workingDirectory,
+                               StringRef filename,
                                ManifestLoaderActions &actions)
-  : impl(static_cast<void*>(new ManifestLoaderImpl(filename, actions)))
+  : impl(static_cast<void*>(new ManifestLoaderImpl(workingDirectory, filename, actions)))
 {
 }
 

--- a/tests/Ninja/Build/absolute-dependencies.ninja
+++ b/tests/Ninja/Build/absolute-dependencies.ninja
@@ -1,0 +1,31 @@
+# Check that touching absolute transitive dependencies affect relative targets.
+
+# RUN: rm -rf %t.build
+# RUN: mkdir -p %t.build
+# RUN: cp %s %t.build/build.ninja
+# RUN: touch %t.build/test.c %t.build/include-level-1 %t.build/include-level-2
+# RUN: echo "aggregate-include: include-level-1 include-level-2" > %t.build/aggregate-include.d
+# RUN: %{llbuild} ninja build --jobs 1 --chdir %t.build &> %t1.out
+# RUN: touch %t.build/include-level-2
+# RUN: %{llbuild} ninja build --jobs 1 --chdir %t.build &> %t2.out
+# RUN: %{FileCheck} --input-file %t2.out %s
+
+# CHECK: [1/2] cat include-level-1 > aggregate-include
+# CHECK-NEXT: [2/2] touch test.o &&
+
+rule GENERATE
+     command = cat $in > $out
+     depfile = $DEPS
+
+rule MOCKCC
+     command = touch $out && echo "$out: $${PWD}/test.c $${PWD}/aggregate-include" > $DEPS
+     depfile = $DEPS
+
+build aggregate-include: GENERATE include-level-1
+      DEPS = aggregate-include.d
+
+build test.o: MOCKCC test.c || aggregate-include
+      DEPS = test.d
+
+build all: phony test.o
+

--- a/tests/Ninja/Build/cycle-detection.ninja
+++ b/tests/Ninja/Build/cycle-detection.ninja
@@ -6,7 +6,7 @@
 # RUN: %{sh-invoke} -c "%{llbuild} ninja build --jobs 1 --no-db --chdir %t.build; echo \"exit code: $?\"" &> %t.out
 # RUN: %{FileCheck} < %t.out %s
 
-# CHECK: cycle detected among targets: "output" -> "output-1" -> "intermediate" -> "output-2" -> "output-1"
+# CHECK: cycle detected among targets: "{{/.*/}}output" -> "{{/.*/}}output-1" -> "{{/.*/}}intermediate" -> "{{/.*/}}output-2" -> "{{/.*/}}output-1"
 # CHECK-NOT: command failure
 # CHECK: exit code: 1
 

--- a/tests/Ninja/Build/graphviz-output.ninja
+++ b/tests/Ninja/Build/graphviz-output.ninja
@@ -10,19 +10,21 @@
 # RUN: %{FileCheck} < %t.dot %s
 #
 # CHECK: digraph {{.*}} {
-# CHECK: "a.c"
 #
-# CHECK: "a.o"
-# CHECK-NEXT: "a.o" -> "a.c"
+# CHECK: "{{/.*/}}a.o"
+# CHECK-NEXT: "{{/.*/}}a.o" -> "a.c"
 #
-# CHECK: "a.out"
+# CHECK: "{{/.*/}}a.out"
 # We skip a -next here, to avoid a dependency on the traversal order.
-# CHECK: "a.out" -> "a.o"
+# CHECK: "{{/.*/}}a.out" -> "{{/.*/}}a.o"
+#
+# CHECK: "{{/.*/}}b.o"
+# CHECK-NEXT: "{{/.*/}}b.o" -> "b.c"
+#
+# CHECK: "a.c"
 #
 # CHECK: "b.c"
 #
-# CHECK: "b.o"
-# CHECK-NEXT: "b.o" -> "b.c"
 
 rule CC
      command = cc -c -o ${out} ${in}

--- a/tests/Ninja/Build/tracing-scanning.ninja
+++ b/tests/Ninja/Build/tracing-scanning.ninja
@@ -18,7 +18,7 @@
 # needs to be deferred waiting for "input-2" to complete. After it completes, we
 # rescan "output" and realize it needs to run.
 #
-# CHECK: { "new-rule", "[[RULE1:.*]]", "output" },
+# CHECK: { "new-rule", "[[RULE1:.*]]", "{{/.*/}}output" },
 # CHECK: { "checking-rule-needs-to-run", "[[RULE1]]" },
 # CHECK: { "paused-input-request-for-rule-scan", "[[RULE1]]" },
 # CHECK: { "new-rule", "[[RULE2:.*]]", "input-1" },

--- a/tests/Ninja/Build/tracing.ninja
+++ b/tests/Ninja/Build/tracing.ninja
@@ -11,7 +11,7 @@
 
 # The first task we see is for the "dummy" rule...
 #
-# CHECK: { "new-rule", "[[RULE1:.*]]", "dummy" },
+# CHECK: { "new-rule", "[[RULE1:.*]]", "{{/.*/}}dummy" },
 # CHECK: { "checking-rule-needs-to-run", "[[RULE1]]" },
 # CHECK: { "rule-needs-to-run", "[[RULE1]]", "never-built" },
 # CHECK: { "new-task", "[[TASK1:.*]]" },
@@ -20,7 +20,7 @@
 # ... which then asks for the input from the "dummy-A" rule, which triggers the
 # creation of its task (and registers the pending task [[TASK1]] with that rule).
 #
-# CHECK: { "new-rule", "[[RULE2:.*]]", "dummy-A" },
+# CHECK: { "new-rule", "[[RULE2:.*]]", "{{/.*/}}dummy-A" },
 # CHECK: { "handling-task-input-request", "[[TASK1]]", "[[RULE2]]" },
 # CHECK: { "new-task", "[[TASK2:.*]]" },
 # CHECK: { "created-task-for-rule", "[[TASK2]]", "[[RULE2]]" },


### PR DESCRIPTION
The `clang` generates either absolute or relative dependencies (in `.d` files) depending on its flags. This makes `llbuild ninja build` miss dependencies sometimes since from `llbuild ninja`'s standpoint the relative path name is different from absolute (this matches OS `ninja` behavior).

This patch resolves this edge case by absolutizing the node names (dependencies and rules).

An unfortunate consequence of this patch is that the debug output from the `llbuild ninja build` tool may sometimes differ: the absolute pathnames could be displayed instead of relative ones.

rdar://55235219