### PR TITLE
build: prepare for Foundation conversion to CMake 3.15

### DIFF
--- a/products/llbuildSwift/CMakeLists.txt
+++ b/products/llbuildSwift/CMakeLists.txt
@@ -19,6 +19,7 @@ else()
   if(FOUNDATION_BUILD_DIR)
     list(APPEND additional_args
       -L${FOUNDATION_BUILD_DIR}
+      -L${FOUNDATION_BUILD_DIR}/Foundation
       -Fsystem ${FOUNDATION_BUILD_DIR}
       -Fsystem ${FOUNDATION_BUILD_DIR}/CoreFoundation-prefix/System/Library/Frameworks
       -I${FOUNDATION_BUILD_DIR}/swift)


### PR DESCRIPTION
Stage the path structure to match the output of Foundation's results
after the migration to 3.15.1.  This is migration work, with the
canonical layout changing over to this layout.  This will be cleaned up
in a subsequent PR.