### PR TITLE
Fix load-manifest dependency printout

### DIFF
--- a/lib/Commands/NinjaCommand.cpp
+++ b/lib/Commands/NinjaCommand.cpp
@@ -504,11 +504,11 @@ static int executeLoadManifestCommand(const std::vector<std::string>& args,
     unsigned count = 0;
     for (const auto& node: command->getInputs()) {
       std::cout << " ";
-      if (count == command->getNumExplicitInputs()) {
-        std::cout << "| ";
-      } else if (count == (command->getNumExplicitInputs() +
+      if (count == (command->getNumExplicitInputs() +
                            command->getNumImplicitInputs())) {
         std::cout << "|| ";
+      } else if (count == command->getNumExplicitInputs()) {
+        std::cout << "| ";
       }
       std::cout << "\"" << util::escapedString(node->getPath()) << "\"";
       ++count;

--- a/tests/Ninja/Loader/dependency-format.ninja
+++ b/tests/Ninja/Loader/dependency-format.ninja
@@ -1,0 +1,12 @@
+# Check order-only dependency formatting.
+#
+# RUN: %{llbuild} ninja load-manifest %s > %t
+# RUN: %{FileCheck} < %t %s
+
+# CHECK: "target-a": phony | "target-b"
+# CHECK: "target-b": phony || "target-a"
+# CHECK: "target-c": phony | "target-a" || "target-b"
+
+build target-a: phony | target-b
+build target-b: phony || target-a
+build target-c: phony | target-a || target-b


### PR DESCRIPTION
 * Fix `order-only` dependency printout. Should be `||`, was `|`.