### PR TITLE
Shim llvm::sys::getDefaultTargetTriple() to Swift

### DIFF
--- a/products/libllbuild/C-API.cpp
+++ b/products/libllbuild/C-API.cpp
@@ -14,6 +14,7 @@
 #include <llbuild/llbuild.h>
 
 #include "llbuild/Basic/Version.h"
+#include "llvm/Support/Host.h"
 
 using namespace llbuild;
 
@@ -28,4 +29,11 @@ const char* llb_get_full_version_string(void) {
 
 int llb_get_api_version(void) {
     return LLBUILD_C_API_VERSION;
+}
+
+const char * llb_get_default_target_triple() {
+  // Use a static local to store the triple, to avoid lifetime issues.
+  static std::string tripleString = llvm::sys::getDefaultTargetTriple();
+
+  return tripleString.c_str();
 }

--- a/products/libllbuild/include/llbuild/llbuild.h
+++ b/products/libllbuild/include/llbuild/llbuild.h
@@ -108,6 +108,9 @@ LLBUILD_EXPORT const char* llb_get_full_version_string(void);
 /// Get the C API version number.
 LLBUILD_EXPORT int llb_get_api_version(void);
 
+/// Get the default target triple for the host machine computed by LLVM.
+LLBUILD_EXPORT const char * llb_get_default_target_triple();
+
 // The Core component.
 #include "llbuild/core.h"
 

--- a/products/llbuildSwift/BuildSystemBindings.swift
+++ b/products/llbuildSwift/BuildSystemBindings.swift
@@ -862,6 +862,8 @@ public final class BuildSystem {
     public static func setSchedulerLaneWidth(width: UInt32) {
         schedulerLanes = width
     }
+
+    public static let defaultTargetTriple = String(cString: llb_get_default_target_triple())
 }
 
 #endif

--- a/unittests/CAPI/C-API.cpp
+++ b/unittests/CAPI/C-API.cpp
@@ -12,6 +12,8 @@
 
 #include "llbuild/llbuild.h"
 
+#include "llvm/Support/Host.h"
+
 #include "gtest/gtest.h"
 
 namespace {
@@ -20,6 +22,12 @@ namespace {
 TEST(CAPI, GetAPIVersion) {
   auto version = llb_get_api_version();
   EXPECT_EQ(version, LLBUILD_C_API_VERSION);
+}
+
+/// We should correctly convey the LLVM triple.
+TEST(CAPI, GetDefaultTargetTriple) {
+  auto triple = llb_get_default_target_triple();
+  EXPECT_EQ(triple, llvm::sys::getDefaultTargetTriple());
 }
 
 }

--- a/unittests/Swift/BuildSystemBindingsTests.swift
+++ b/unittests/Swift/BuildSystemBindingsTests.swift
@@ -131,4 +131,11 @@ class BuildSystemBindingsTests: XCTestCase {
     XCTAssertEqual(delegate.rules, [Key("foo"): Delegate.DummyRule(key: Key("foo"))])
     XCTAssertTrue(delegate.errors.isEmpty)
   }
+
+  func testDefaultTargetTriple() {
+    let triple = BuildSystem.defaultTargetTriple
+    let dashCount = triple.filter { $0 == "-" }.count
+    XCTAssertGreaterThanOrEqual(dashCount, 2)
+    XCTAssertLessThanOrEqual(dashCount, 3)
+  }
 }


### PR DESCRIPTION
The default target triple for the host machine can be useful information when constructing command line arguments for a tool, but this information isn’t in LLVM’s C API, so it’s inaccessible from Swift. This commit exposes it in libllbuild as `llb_get_default_target_triple()` and in llbuildSwift as `BuildSystem.defaultTargetTriple`.