### PR TITLE
Simulate ninja -t clean by removing the database.

### DIFF
--- a/lib/Commands/NinjaBuildCommand.cpp
+++ b/lib/Commands/NinjaBuildCommand.cpp
@@ -1774,6 +1774,7 @@ int commands::executeNinjaBuildCommand(std::vector<std::string> args) {
 
   if (!customTool.empty()) {
     std::vector<std::string> availableTools = {
+      "clean",
       "targets",
       "list",
     };
@@ -1867,6 +1868,18 @@ int commands::executeNinjaBuildCommand(std::vector<std::string> args) {
       }
 
       return 0;
+    }
+
+    // Emulate `-t clean` by removing the database.
+    if (!customTool.empty() && customTool == "clean") {
+      if(dbFilename.empty()) {
+        context.emitError("unable to clean without a database. Command ignored.");
+        return 1;
+      } else {
+        (void)basic::sys::unlink(dbFilename.c_str());
+        context.emitNote("cleaned the build database, artifacts preserved.");
+        return 0;
+      }
     }
 
     // Otherwise, run the build.

--- a/tests/Ninja/Build/t-clean.ninja
+++ b/tests/Ninja/Build/t-clean.ninja
@@ -1,0 +1,27 @@
+# Check that we emulate -t clean
+
+# RUN: rm -rf %t.build
+# RUN: mkdir -p %t.build
+# RUN: cp %s %t.build/build.ninja
+# RUN: touch %t.build/input
+# RUN: %{llbuild} ninja build --jobs 1 --chdir %t.build > %t1.out
+# RUN: test -f %t.build/build.db
+# RUN: %{FileCheck} --check-prefix=CHECK-BEFORE-CLEAN < %t1.out %s
+#
+# RUN: %{llbuild} ninja build --jobs 1 --chdir %t.build -t clean > %t2.out
+# RUN: test ! -f %t.build/build.db
+# RUN: %{FileCheck} --check-prefix=CHECK-AFTER-CLEAN < %t2.out %s
+#
+# RUN: %{llbuild} ninja build --jobs 1 --chdir %t.build > %t3.out
+# RUN: %{FileCheck} --check-prefix=CHECK-REBUILD < %t3.out %s
+
+# CHECK-BEFORE-CLEAN: [1/{{.*}}] cp
+# CHECK-AFTER-CLEAN-NOT: [1/{{.*}}]
+# CHECK-REBUILD: [1/{{.*}}] cp
+
+rule CP
+  command = cp $in $out
+
+build output: CP input
+
+default output


### PR DESCRIPTION
There's a belief that it is quite hard (if not impossible) to make a _correct_ `-t clean` simulation. The next best thing to at least avoid breaking scripts that request `ninja -t clean` is to remove the build database. That's what we do in this patch.

rdar://20224847