### PR TITLE
Fix timestamp-related non-determinism on old FSs

### DIFF
--- a/tests/Ninja/Build/absolute-dependencies.ninja
+++ b/tests/Ninja/Build/absolute-dependencies.ninja
@@ -5,7 +5,9 @@
 # RUN: cp %s %t.build/build.ninja
 # RUN: touch %t.build/test.c %t.build/include-level-1 %t.build/include-level-2
 # RUN: echo "aggregate-include: include-level-1 include-level-2" > %t.build/aggregate-include.d
+# RUN: touch -r / %t.build/include-level-2
 # RUN: %{llbuild} ninja build --jobs 1 --chdir %t.build &> %t1.out
+# RUN: %{FileCheck} --input-file %t1.out %s
 # RUN: touch %t.build/include-level-2
 # RUN: %{llbuild} ninja build --jobs 1 --chdir %t.build &> %t2.out
 # RUN: %{FileCheck} --input-file %t2.out %s

--- a/tests/Ninja/Build/modify-retaining-timestamp.ninja
+++ b/tests/Ninja/Build/modify-retaining-timestamp.ninja
@@ -1,4 +1,4 @@
-# Check regeneration without timestamp modification.
+# Check that regeneration does not happen without timestamp modification.
 
 # RUN: rm -rf %t.build
 # RUN: mkdir -p %t.build
@@ -11,13 +11,9 @@
 #
 # RUN: echo "modified" >> %t.build/test.in
 # RUN: touch -r %t.build/build.ninja %t.build/test.in
-# RUN: touch -A02 %t.build/test.in  # This should not be necessary
 # RUN: %{llbuild} ninja build --jobs 1 --chdir %t.build &> %t2.out
 # RUN: %{FileCheck} --check-prefix CHECK-AFTER-TOUCH --input-file %t2.out %s
-# CHECK-AFTER-TOUCH: [1/{{.*}}] cat test.in > test.out
-#
-# FIXME: Disabled on Linux until timestamps are fixed.
-# REQUIRES: platform=Darwin
+# CHECK-AFTER-TOUCH-NOT: [1/{{.*}}]
 
 rule CAT
      command = cat $in > $out

--- a/tests/Ninja/Build/order-only-skip.ninja
+++ b/tests/Ninja/Build/order-only-skip.ninja
@@ -4,20 +4,17 @@
 # RUN: mkdir -p %t.build
 # RUN: cp %s %t.build/build.ninja
 # RUN: touch %t.build/test.in %t.build/include-source
+# RUN: touch -r / %t.build/include-source
 # RUN: %{llbuild} ninja build --jobs 1 --chdir %t.build &> %t1.out
 # RUN: %{FileCheck} --check-prefix=CHECK-INITIAL --input-file %t1.out %s
 # CHECK-INITIAL: [1/{{.*}}] cat include-source > generated-include
 # CHECK-INITIAL-NEXT: [2/{{.*}}] cat test.in > test.out
 #
 # RUN: echo "modified" >> %t.build/include-source
-# RUN: touch -A02 %t.build/include-source
 # RUN: %{llbuild} ninja build --jobs 1 --chdir %t.build &> %t2.out
 # RUN: %{FileCheck} --check-prefix CHECK-AFTER-TOUCH --input-file %t2.out %s
 # CHECK-AFTER-TOUCH: [1/{{.*}}]
 # CHECK-AFTER-TOUCH-NOT: [2/{{.*}}]
-
-# Modify back when timestamp handling is fixed.
-# REQUIRES: platform=Darwin
 
 
 rule CAT

--- a/tests/Ninja/Build/rebuild-manifest.ninja
+++ b/tests/Ninja/Build/rebuild-manifest.ninja
@@ -5,15 +5,12 @@
 # RUN: mkdir -p %t.build
 # RUN: touch %t.build/input
 # RUN: cp %s %t.build/build.ninja
+# RUN: touch -r / %t.build/build.ninja
 # RUN: %{llbuild} ninja build --jobs 1 --chdir %t.build &> %t1.out
 # RUN: %{FileCheck} < %t1.out %s
 
 # CHECK: [1/{{.*}}] GENERATE MANIFEST
 # CHECK: [1/{{.*}}] cat input > output
-
-# FIXME: This test fails non-deterministically on Linux, we need to investigate (rdar://problem/23239574).
-#
-# REQUIRES: platform=Darwin
 
 rule GENERATE_MANIFEST
      command = echo "build output: CAT input" >> build.ninja


### PR DESCRIPTION
 1. Linux might have 1-ms FS object timestamp resolution which is not enough
if we're checking the timestamps too quickly.
 2. macOS with HFS has 1-second FS timestamp resolution, yielding the same problems.

rdar://23239574
rdar://56090104