### PR TITLE
Add adjust-times as a test target dependency

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -35,7 +35,7 @@ if(PYTHONINTERP_FOUND AND LIT_FOUND AND FILECHECK_FOUND)
     --param build_mode=${build_mode})
 
   set(test_target_dependencies
-    llbuild libllbuild swift-build-tool UnitTests)
+    llbuild libllbuild swift-build-tool UnitTests adjust-times)
 
   add_custom_target(test-llbuild
     COMMAND ${lit_command} ${CMAKE_CURRENT_BINARY_DIR}


### PR DESCRIPTION
 * Tests are invoked by `ninja test`, skipping the default build. The `adjust-times` utility has to be a dependency of the test target.