### PR TITLE
Implement console pool semantics

### DIFF
--- a/include/llbuild/Basic/ExecutionQueue.h
+++ b/include/llbuild/Basic/ExecutionQueue.h
@@ -133,10 +133,6 @@ namespace llbuild {
       /// system to release its execution lane. Callers should put cleanup and
       /// notification work here.
       ///
-      /// \param inheritEnvironment If true, the supplied environment will be
-      /// overlayed on top base environment supplied when creating the queue. If
-      /// false, only the supplied environment will be passed to the subprocess.
-      ///
       /// \param attributes Additional attributes for the process to be spawned.
       //
       // FIXME: This interface will need to get more complicated, and provide the
@@ -145,7 +141,6 @@ namespace llbuild {
       executeProcess(QueueJobContext* context,
                      ArrayRef<StringRef> commandLine,
                      ArrayRef<std::pair<StringRef, StringRef>> environment,
-                     bool inheritEnvironment = true,
                      ProcessAttributes attributes = {true},
                      llvm::Optional<ProcessCompletionFn> completionFn = {llvm::None}) = 0;
 

--- a/include/llbuild/Basic/ExecutionQueue.h
+++ b/include/llbuild/Basic/ExecutionQueue.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See http://swift.org/LICENSE.txt for license information

--- a/include/llbuild/Basic/Subprocess.h
+++ b/include/llbuild/Basic/Subprocess.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2018 Apple Inc. and the Swift project authors
+// Copyright (c) 2018 - 2019 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See http://swift.org/LICENSE.txt for license information

--- a/include/llbuild/Basic/Subprocess.h
+++ b/include/llbuild/Basic/Subprocess.h
@@ -228,9 +228,18 @@ namespace llbuild {
       /// ultimately be sent a SIGKILL).
       bool canSafelyInterrupt;
 
+      /// Whether to connect the spawned process directly to the console.
+      bool connectToConsole = false;
+
       /// If set, the working directory to change into before spawning (support
       /// not guaranteed on all platforms).
       StringRef workingDir = {};
+
+      /// If true, the supplied environment will be overlayed on top base
+      /// environment supplied when creating the queue.
+      /// If false, only the supplied environment will be passed
+      /// to the subprocess.
+      bool inheritEnvironment = true;
 
       /// If true, exposes a control file descriptor that may be used to
       /// communicate with the build system.

--- a/lib/Basic/ExecutionQueue.cpp
+++ b/lib/Basic/ExecutionQueue.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2018 Apple Inc. and the Swift project authors
+// Copyright (c) 2018 - 2019 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See http://swift.org/LICENSE.txt for license information

--- a/lib/Basic/ExecutionQueue.cpp
+++ b/lib/Basic/ExecutionQueue.cpp
@@ -44,7 +44,7 @@ ProcessStatus ExecutionQueue::executeProcess(QueueJobContext* context,
   // here to allow it to go along with the labmda.
   std::shared_ptr<std::promise<ProcessStatus>> p{new std::promise<ProcessStatus>};
   auto result = p->get_future();
-  executeProcess(context, commandLine, {}, true, {true},
+  executeProcess(context, commandLine, {}, {true},
                  {[p](ProcessResult result) mutable {
     p->set_value(result.status);
   }});

--- a/lib/Basic/ExecutionQueue.cpp
+++ b/lib/Basic/ExecutionQueue.cpp
@@ -39,14 +39,11 @@ ExecutionQueue::~ExecutionQueue() {
 
 ProcessStatus ExecutionQueue::executeProcess(QueueJobContext* context,
                                              ArrayRef<StringRef> commandLine) {
-  // Promises are move constructible only, thus cannot be put into std::function
-  // objects that themselves get copied around. So we must create a shared_ptr
-  // here to allow it to go along with the labmda.
-  std::shared_ptr<std::promise<ProcessStatus>> p{new std::promise<ProcessStatus>};
-  auto result = p->get_future();
+  std::promise<ProcessStatus> p;
+  auto result = p.get_future();
   executeProcess(context, commandLine, {}, {true},
-                 {[p](ProcessResult result) mutable {
-    p->set_value(result.status);
+                 {[&p](ProcessResult result) mutable {
+    p.set_value(result.status);
   }});
   return result.get();
 }

--- a/lib/Basic/LaneBasedExecutionQueue.cpp
+++ b/lib/Basic/LaneBasedExecutionQueue.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014-2018 Apple Inc. and the Swift project authors
+// Copyright (c) 2014-2019 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See http://swift.org/LICENSE.txt for license information
@@ -276,7 +276,6 @@ public:
       QueueJobContext* opaqueContext,
       ArrayRef<StringRef> commandLine,
       ArrayRef<std::pair<StringRef, StringRef>> environment,
-      bool inheritEnvironment,
       ProcessAttributes attributes,
       llvm::Optional<ProcessCompletionFn> completionFn) override {
 
@@ -316,7 +315,7 @@ public:
     //
     // FIXME: This involves a lot of redundant allocation, currently. We could
     // cache this for the common case of a directly inherited environment.
-    if (inheritEnvironment) {
+    if (attributes.inheritEnvironment) {
       for (const char* const* p = this->environment; *p != nullptr; ++p) {
         auto pair = StringRef(*p).split('=');
         posixEnv.setIfMissing(pair.first, pair.second);

--- a/lib/Basic/LaneBasedExecutionQueue.cpp
+++ b/lib/Basic/LaneBasedExecutionQueue.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014-2019 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See http://swift.org/LICENSE.txt for license information

--- a/lib/Basic/Subprocess.cpp
+++ b/lib/Basic/Subprocess.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2018 Apple Inc. and the Swift project authors
+// Copyright (c) 2018 - 2019 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See http://swift.org/LICENSE.txt for license information

--- a/lib/Basic/Subprocess.cpp
+++ b/lib/Basic/Subprocess.cpp
@@ -396,7 +396,7 @@ void llbuild::basic::spawnProcess(
     ProcessCompletionFn&& completionFn
 ) {
   // Whether or not we are capturing output.
-  const bool shouldCaptureOutput = true;
+  const bool shouldCaptureOutput = !attr.connectToConsole;
 
   delegate.processStarted(ctx, handle);
 
@@ -430,14 +430,7 @@ void llbuild::basic::spawnProcess(
   DWORD creationFlags = NORMAL_PRIORITY_CLASS | CREATE_NEW_PROCESS_GROUP |
                         CREATE_UNICODE_ENVIRONMENT;
   PROCESS_INFORMATION processInfo = {0};
-  STARTUPINFOW startupInfo = {0};
 
-  startupInfo.dwFlags = STARTF_USESTDHANDLES;
-  // Set NUL as stdin
-  HANDLE nul =
-      CreateFileW(L"NUL", GENERIC_READ, FILE_SHARE_READ | FILE_SHARE_WRITE,
-                  NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
-  startupInfo.hStdInput = nul;
 #else
   // Initialize the spawn attributes.
   posix_spawnattr_t attributes;
@@ -473,7 +466,9 @@ void llbuild::basic::spawnProcess(
 
   // Set the attribute flags.
   unsigned flags = POSIX_SPAWN_SETSIGMASK | POSIX_SPAWN_SETSIGDEF;
-  flags |= POSIX_SPAWN_SETPGROUP;
+  if (!attr.connectToConsole) {
+    flags |= POSIX_SPAWN_SETPGROUP;
+  }
 
   // Close all other files by default.
   //
@@ -503,9 +498,6 @@ void llbuild::basic::spawnProcess(
     usePosixSpawnChdirFallback = false;
   }
 
-  // Open /dev/null as stdin.
-  posix_spawn_file_actions_addopen(
-      &fileActions, 0, "/dev/null", O_RDONLY, 0);
 #endif
 
 #if defined(_WIN32)
@@ -513,6 +505,18 @@ void llbuild::basic::spawnProcess(
   std::string workingDir = attr.workingDir.str();
   if (!workingDir.empty()) {
     llvm::convertUTF8ToUTF16String(workingDir, u16Cwd);
+  }
+
+  STARTUPINFOW startupInfo = {0};
+  startupInfo.dwFlags = STARTF_USESTDHANDLES;
+  if (attr.connectToConsole) {
+    startupInfo.hStdInput = GetStdHandle(STD_INPUT_HANDLE);
+  } else {
+    // Set NUL as stdin
+    HANDLE nul =
+      CreateFileW(L"NUL", GENERIC_READ, FILE_SHARE_READ | FILE_SHARE_WRITE,
+                  NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
+    startupInfo.hStdInput = nul;
   }
 
   HANDLE controlPipe[2]{NULL, NULL};
@@ -539,6 +543,18 @@ void llbuild::basic::spawnProcess(
     startupInfo.hStdError = GetStdHandle(STD_ERROR_HANDLE);
   }
 #else
+
+  if (attr.connectToConsole) {
+#ifdef __APPLE__
+    posix_spawn_file_actions_addinherit_np(&fileActions, STDIN_FILENO);
+#else
+    posix_spawn_file_actions_adddup2(&fileActions, STDIN_FILENO, STDIN_FILENO);
+#endif
+  } else {
+    // Open /dev/null as stdin.
+    posix_spawn_file_actions_addopen(&fileActions, STDIN_FILENO, "/dev/null", O_RDONLY, 0);
+  }
+
   // Create a pipe for the process to (potentially) release the lane while
   // still running.
   int controlPipe[2]{ -1, -1 };
@@ -780,8 +796,11 @@ void llbuild::basic::spawnProcess(
         releaseFn([&delegate, &pgrp, pid, handle, ctx, shouldCaptureOutput,
                    outputFd = outputPipe[0], controlFd = controlPipe[0],
                    completionFn = std::move(completionFn)]() mutable {
-          if (shouldCaptureOutput)
+          if (shouldCaptureOutput) {
             captureExecutedProcessOutput(delegate, outputFd, handle, ctx);
+          } else {
+            assert(outputFd == NULL);
+          }
 
           cleanUpExecutedProcess(delegate, pgrp, pid, handle, ctx,
                                  std::move(completionFn), controlFd);
@@ -864,12 +883,16 @@ void llbuild::basic::spawnProcess(
     if (control.shouldRelease()) {
       releaseFn([
                  &delegate, &pgrp, pid, handle, ctx,
+                 shouldCaptureOutput,
                  outputFd=outputPipe[0],
                  controlFd=controlPipe[0],
                  completionFn=std::move(completionFn)
                  ]() mutable {
-        if (shouldCaptureOutput)
+        if (shouldCaptureOutput) {
           captureExecutedProcessOutput(delegate, outputFd, handle, ctx);
+        } else {
+          assert(outputFd == -1);
+        }
 
         cleanUpExecutedProcess(delegate, pgrp, pid, handle, ctx,
                                std::move(completionFn), controlFd);

--- a/lib/BuildSystem/BuildSystem.cpp
+++ b/lib/BuildSystem/BuildSystem.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See http://swift.org/LICENSE.txt for license information

--- a/lib/BuildSystem/BuildSystem.cpp
+++ b/lib/BuildSystem/BuildSystem.cpp
@@ -2158,7 +2158,7 @@ public:
                                       QueueJobContext* context,
                                       llvm::Optional<ProcessCompletionFn> completionFn) override {
     // Execute the command.
-    bsci.getExecutionQueue().executeProcess(context, args, {}, true, {true}, {[this, &bsci, task, completionFn](ProcessResult result){
+    bsci.getExecutionQueue().executeProcess(context, args, {}, {true}, {[this, &bsci, task, completionFn](ProcessResult result){
 
       if (result.status != ProcessStatus::Succeeded) {
         // If the command failed, there is no need to gather dependencies.
@@ -3228,7 +3228,7 @@ class ArchiveShellCommand : public ExternalCommand {
     auto args = getArgs();
     bsci.getExecutionQueue().executeProcess(context,
                                             std::vector<StringRef>(args.begin(), args.end()),
-                                            {}, true, {true},
+                                            {}, {true},
                                             {[completionFn](ProcessResult result) {
       if (completionFn.hasValue())
         completionFn.getValue()(result);
@@ -3350,7 +3350,7 @@ class SharedLibraryShellCommand : public ExternalCommand {
 
     auto args = getArgs();
     bsci.getExecutionQueue().executeProcess(
-        context, std::vector<StringRef>(args.begin(), args.end()), {}, true,
+        context, std::vector<StringRef>(args.begin(), args.end()), {},
         {true}, {[completionFn](ProcessResult result) {
           if (completionFn.hasValue())
             completionFn.getValue()(result);

--- a/lib/BuildSystem/ShellCommand.cpp
+++ b/lib/BuildSystem/ShellCommand.cpp
@@ -379,10 +379,11 @@ void ShellCommand::executeExternalCommand(
     return;
   }
 
+  bool connectToConsole = false;
+
   // Execute the command.
   bsci.getExecutionQueue().executeProcess(
       context, args, env,
-      /*inheritEnvironment=*/inheritEnv,
-      {canSafelyInterrupt, workingDirectory, controlEnabled},
+      {canSafelyInterrupt, connectToConsole, workingDirectory, inheritEnv, controlEnabled},
       /*completionFn=*/{commandCompletionFn});
 }

--- a/tests/Ninja/Build/console-pool-input.ninja
+++ b/tests/Ninja/Build/console-pool-input.ninja
@@ -1,0 +1,23 @@
+# Check that jobs in a console pool jobs can read from stdin.
+
+# RUN: rm -rf %t.build
+# RUN: mkdir -p %t.build
+# RUN: cp %s %t.build/build.ninja
+# RUN: echo "something" | %{llbuild} ninja build --jobs 1 --chdir %t.build &> %t1.out
+# RUN: %{FileCheck} --input-file %t1.out %s
+
+# CHECK: [1/2] read input
+# CHECK-NEXT: got [something]
+# CHECK: [2/2] read input
+# CHECK-NEXT: got []
+
+rule CONSOLE
+  pool = console
+  command = read input; echo got [$$input]
+
+build console1: CONSOLE
+build console2: CONSOLE
+
+build all: phony console1 console2
+
+default all

--- a/tests/Ninja/Build/console-pool.ninja
+++ b/tests/Ninja/Build/console-pool.ninja
@@ -1,0 +1,28 @@
+# Check that jobs in a console pool always run in a given order.
+
+# RUN: rm -rf %t.build
+# RUN: mkdir -p %t.build
+# RUN: cp %s %t.build/build.ninja
+# RUN: %{llbuild} ninja build --jobs 1 --chdir %t.build &> %t1.out
+# RUN: %{FileCheck} --input-file %t1.out %s
+
+# CHECK: [{{.*}}/4] echo console1
+# CHECK-NEXT: console1 on console
+# CHECK: [{{.*}}/4] echo console2
+# CHECK-NEXT: console2 on console
+
+rule BACKGROUND
+  command = echo "${out}: random $${RANDOM}"
+
+rule CONSOLE
+  pool = console
+  command = echo ${out} on console
+
+build random1: BACKGROUND
+build random2: BACKGROUND
+build console1: CONSOLE
+build console2: CONSOLE
+
+build all: phony random1 random2 console1 console2
+
+default all

--- a/unittests/Basic/LaneBasedExecutionQueueTest.cpp
+++ b/unittests/Basic/LaneBasedExecutionQueueTest.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See http://swift.org/LICENSE.txt for license information

--- a/unittests/Basic/LaneBasedExecutionQueueTest.cpp
+++ b/unittests/Basic/LaneBasedExecutionQueueTest.cpp
@@ -103,7 +103,7 @@ namespace {
                                          { DefaultShellPath, "-c", yescmd.c_str() });
       std::shared_ptr<std::promise<ProcessStatus>> p{new std::promise<ProcessStatus>};
       auto result = p->get_future();
-      queue->executeProcess(context, commandLine, {}, true, {true, tempDir.str()},
+      queue->executeProcess(context, commandLine, {}, {true, false, tempDir.str()},
                      {[p](ProcessResult result) mutable {
         p->set_value(result.status);
       }});

--- a/unittests/Basic/LaneBasedExecutionQueueTest.cpp
+++ b/unittests/Basic/LaneBasedExecutionQueueTest.cpp
@@ -101,11 +101,11 @@ namespace {
       std::string yescmd = "yes >yes-output.txt";
       std::vector<StringRef> commandLine(
                                          { DefaultShellPath, "-c", yescmd.c_str() });
-      std::shared_ptr<std::promise<ProcessStatus>> p{new std::promise<ProcessStatus>};
-      auto result = p->get_future();
+      std::promise<ProcessStatus> p;
+      auto result = p.get_future();
       queue->executeProcess(context, commandLine, {}, {true, false, tempDir.str()},
-                     {[p](ProcessResult result) mutable {
-        p->set_value(result.status);
+                     {[&p](ProcessResult result) mutable {
+        p.set_value(result.status);
       }});
       result.get();
     };


### PR DESCRIPTION
 * Console pools allow to serialize jobs and connect jobs directly to console input and output.
 * The right solution is to create stackable queues with independently controlled parralelism, as well as reimplementation of the executor queue on top of one of them by pipmpl or subclassing. This PR implements the quick solution.

rdar://47093734