### PR TITLE
Fix Path Normalization on Windows

### DIFF
--- a/lib/Ninja/Manifest.cpp
+++ b/lib/Ninja/Manifest.cpp
@@ -53,7 +53,7 @@ bool Manifest::normalize_path(StringRef workingDirectory, SmallVectorImpl<char>&
   if (llvm::sys::fs::make_absolute(workingDirectory, tmp) != std::error_code()) {
     return false;
   }
-  if (tmp.size() == 0 || tmp[0] != slash) {
+  if (tmp.size() == 0 || !llvm::sys::path::is_absolute(tmp)) {
       return false;
   }
 


### PR DESCRIPTION
Absolute paths on Windows do not begin with a leading slash. Defer to
llvm's is_absolute instead which handles cross platform paths.