### PR TITLE
Streamline file descriptor handling during spawning

### DIFF
--- a/include/llbuild/Basic/PlatformUtility.h
+++ b/include/llbuild/Basic/PlatformUtility.h
@@ -72,6 +72,7 @@ template <typename = FD> struct FileDescriptorTraits;
 
 #if defined(_WIN32)
 template <> struct FileDescriptorTraits<HANDLE> {
+  typedef HANDLE DescriptorType;
   static bool IsValid(HANDLE hFile) { return hFile != INVALID_HANDLE_VALUE; }
   static void Close(HANDLE hFile) { CloseHandle(hFile); }
   static int Read(HANDLE hFile, void *destinationBuffer,
@@ -85,6 +86,8 @@ template <> struct FileDescriptorTraits<HANDLE> {
 };
 #endif
 template <> struct FileDescriptorTraits<int> {
+  typedef int DescriptorType;
+  static const int InvalidDescriptor = -1;
   static bool IsValid(int fd) { return fd >= 0; }
   static void Close(int fd) { close(fd); }
   static int Read(int hFile, void *destinationBuffer,


### PR DESCRIPTION
  * Leak of the output pipe file descriptors if control pipe can't be opened.
  * Leak of posix file actions memory if the control pipes can't be created.
  * Descriptors leak of unrelated tasks into spawned task (linux, win).
  * Windows code improperly inheriting the control file descriptors.
  * Windows code not checking results of the system calls.
  * A race condition in the control channel parsing on windows resulting in  a potential double-close() (which can close someone else's handle).
    
rdar://56800263
