### PR TITLE
Bump up exposed versions

### DIFF
--- a/lib/Basic/Version.cpp
+++ b/lib/Basic/Version.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2015 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See http://swift.org/LICENSE.txt for license information
@@ -17,7 +17,7 @@
 namespace llbuild {
 
 std::string getLLBuildFullVersion(StringRef productName) {
-  std::string result = productName.str() + " version 3.0";
+  std::string result = productName.str() + " version 5.2";
 
   // Include the additional build version information, if present.
 #ifdef LLBUILD_VENDOR_STRING

--- a/lib/Commands/NinjaBuildCommand.cpp
+++ b/lib/Commands/NinjaBuildCommand.cpp
@@ -1765,7 +1765,7 @@ int commands::executeNinjaBuildCommand(std::vector<std::string> args) {
     if (option == "--version") {
       // Report a fake version for tools (like CMake) that detect compatibility
       // based on the 'Ninja' version.
-      printf("1.6 Ninja Compatible (%s)\n", getLLBuildFullVersion().c_str());
+      printf("1.7.0 Ninja Compatible (%s)\n", getLLBuildFullVersion().c_str());
       return 0;
     } else if (option == "--help") {
       usage(/*exitCode=*/0);


### PR DESCRIPTION
 * Bump up versions exposed by `llbuild --version` and `llbuild ninja build --version` to coincide with the Swift releases.
 * rdar://57024160