### PR TITLE
build: clean up some vestigial support code (NFC)

### DIFF
--- a/cmake/modules/Utility.cmake
+++ b/cmake/modules/Utility.cmake
@@ -1,8 +1,4 @@
-include(ProcessorCount)
 include(CMakeParseArguments)
-
-# Compute the number of processors.
-ProcessorCount(NUM_PROCESSORS)
 
 function(append_if condition value)
   if (${condition})


### PR DESCRIPTION
This was used for the parallel compilation of Swift code which has since
been migrated to CMake.  Remove the vestigial code to clean up the
module.