### PR TITLE
build: add a workaround for CMake <3.16 on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,7 +40,15 @@ if(CMAKE_CONFIGURATION_TYPES AND NOT "${CMAKE_CFG_INTDIR}" STREQUAL ".")
 else()
   set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
   set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
-  set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
+  # CMAKE<3.16 had a bug where the import library would be placed next to the
+  # binary under all conditions.  This breaks the layout expectations, which
+  # would break linking.  As a workaround, place the binaries in the lib
+  # directory.
+  if(CMAKE_VERSION VERSION_LESS 3.16 AND CMAKE_SYSTEM_NAME STREQUAL Windows)
+    set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
+  else()
+    set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
+  endif()
 endif()
 
 set(THREADS_PREFER_PTHREAD_FLAG TRUE)


### PR DESCRIPTION
The import library is being emitted into the wrong location on CMake
3.15.1.  Add a workaround to enable use of LLBuild for building s-p-m on
Windows.