### PR TITLE
build: llbuildSwift requires libllbuild

### DIFF
--- a/products/llbuildSwift/CMakeLists.txt
+++ b/products/llbuildSwift/CMakeLists.txt
@@ -63,6 +63,7 @@ else()
 endif()
 set_target_properties(llbuildSwift PROPERTIES
   Swift_MODULE_NAME llbuildSwift
+  INTERFACE_LINK_LIBRARIES libllbuild
   INTERFACE_INCLUDE_DIRECTORIES ${CMAKE_CURRENT_BINARY_DIR})
 
 install(TARGETS llbuildSwift


### PR DESCRIPTION
This is so that export targets can work properly for
swift-package-manager.  llbuildSwift should bring along the include
paths to libllbuild which it exposes.