### PR TITLE
[Core] Simplify task registration

### DIFF
--- a/bindings/python/llbuild.py
+++ b/bindings/python/llbuild.py
@@ -90,7 +90,7 @@ def _rule_create_task(context, engine_context):
     delegate.inputs_available = _task_inputs_available
 
     task._task = libllbuild.llb_task_create(delegate[0])
-    return libllbuild.llb_buildengine_register_task(engine._engine, task._task)
+    return task._task
 
 @ffi.callback("bool(void*, void*, llb_rule_t*, llb_data_t*)")
 def _rule_is_result_valid(context, engine_context, rule, value):

--- a/include/llbuild/Core/BuildEngine.h
+++ b/include/llbuild/Core/BuildEngine.h
@@ -356,14 +356,6 @@ public:
   /// @name Task Management APIs
   /// @{
 
-  /// Register the given task, in response to a Rule evaluation.
-  ///
-  /// The engine tasks ownership of the \arg Task, and it is expected to
-  /// subsequently be returned as the task to execute for a Rule evaluation.
-  ///
-  /// \returns The provided task, for the convenience of the client.
-  Task* registerTask(Task* task);
-
   /// The maximum allowed input ID.
   static const uintptr_t kMaximumInputID = ~(uintptr_t)0xFF;
 

--- a/lib/BuildSystem/BuildSystem.cpp
+++ b/lib/BuildSystem/BuildSystem.cpp
@@ -1530,7 +1530,7 @@ Rule BuildSystemEngineDelegate::lookupRule(const KeyType& keyData) {
         keyData,
         /*signature=*/{},
         /*Action=*/ [](BuildEngine& engine) -> Task* {
-          return engine.registerTask(new MissingCommandTask());
+          return new MissingCommandTask();
         },
         /*IsValid=*/ [](BuildEngine&, const Rule&, const ValueType&) -> bool {
           // The cached result for a missing command is never valid.
@@ -1545,7 +1545,7 @@ Rule BuildSystemEngineDelegate::lookupRule(const KeyType& keyData) {
       keyData,
       command->getSignature(),
       /*Action=*/ [command](BuildEngine& engine) -> Task* {
-        return engine.registerTask(new CommandTask(*command));
+        return new CommandTask(*command);
       },
       /*IsValid=*/ [command](BuildEngine& engine, const Rule& rule,
                              const ValueType& value) -> bool {
@@ -1578,7 +1578,7 @@ Rule BuildSystemEngineDelegate::lookupRule(const KeyType& keyData) {
         keyData,
         command->getSignature(),
         /*Action=*/ [command](BuildEngine& engine) -> Task* {
-          return engine.registerTask(new CommandTask(*command));
+          return new CommandTask(*command);
         },
         /*IsValid=*/ [command](BuildEngine& engine, const Rule& rule,
                                const ValueType& value) -> bool {
@@ -1594,7 +1594,7 @@ Rule BuildSystemEngineDelegate::lookupRule(const KeyType& keyData) {
       keyData,
       /*signature=*/{},
       /*Action=*/ [](BuildEngine& engine) -> Task* {
-        return engine.registerTask(new MissingCommandTask());
+        return new MissingCommandTask();
       },
       /*IsValid=*/ [](BuildEngine&, const Rule&, const ValueType&) -> bool {
         // The cached result for a missing command is never valid.
@@ -1609,7 +1609,7 @@ Rule BuildSystemEngineDelegate::lookupRule(const KeyType& keyData) {
       keyData,
       /*signature=*/{},
       /*Action=*/ [path](BuildEngine& engine) -> Task* {
-        return engine.registerTask(new DirectoryContentsTask(path));
+        return new DirectoryContentsTask(path);
       },
       /*IsValid=*/ [path](BuildEngine& engine, const Rule& rule,
           const ValueType& value) mutable -> bool {
@@ -1627,8 +1627,7 @@ Rule BuildSystemEngineDelegate::lookupRule(const KeyType& keyData) {
       /*signature=*/{},
       /*Action=*/ [path, patterns](BuildEngine& engine) -> Task* {
         BinaryDecoder decoder(patterns);
-        return engine.registerTask(new FilteredDirectoryContentsTask(path,
-            StringList(decoder)));
+        return new FilteredDirectoryContentsTask(path, StringList(decoder));
       },
       /*IsValid=*/ nullptr
     };
@@ -1643,8 +1642,7 @@ Rule BuildSystemEngineDelegate::lookupRule(const KeyType& keyData) {
       /*Action=*/ [path, filters](
           BuildEngine& engine) mutable -> Task* {
         BinaryDecoder decoder(filters);
-        return engine.registerTask(new DirectoryTreeSignatureTask(
-            path, StringList(decoder)));
+        return new DirectoryTreeSignatureTask(path, StringList(decoder));
       },
         // Directory signatures don't require any validation outside of their
         // concrete dependencies.
@@ -1659,7 +1657,7 @@ Rule BuildSystemEngineDelegate::lookupRule(const KeyType& keyData) {
       /*signature=*/{},
       /*Action=*/ [path](
           BuildEngine& engine) mutable -> Task* {
-        return engine.registerTask(new DirectoryTreeStructureSignatureTask(path));
+        return new DirectoryTreeStructureSignatureTask(path);
       },
         // Directory signatures don't require any validation outside of their
         // concrete dependencies.
@@ -1700,7 +1698,7 @@ Rule BuildSystemEngineDelegate::lookupRule(const KeyType& keyData) {
           keyData,
           node->getSignature(),
           /*Action=*/ [](BuildEngine& engine) -> Task* {
-            return engine.registerTask(new VirtualInputNodeTask());
+            return new VirtualInputNodeTask();
           },
           /*IsValid=*/ [node](BuildEngine& engine, const Rule& rule,
                                 const ValueType& value) -> bool {
@@ -1715,7 +1713,7 @@ Rule BuildSystemEngineDelegate::lookupRule(const KeyType& keyData) {
           keyData,
           node->getSignature(),
           /*Action=*/ [node](BuildEngine& engine) -> Task* {
-            return engine.registerTask(new DirectoryInputNodeTask(*node));
+            return new DirectoryInputNodeTask(*node);
           },
             // Directory nodes don't require any validation outside of their
             // concrete dependencies.
@@ -1728,8 +1726,7 @@ Rule BuildSystemEngineDelegate::lookupRule(const KeyType& keyData) {
           keyData,
           node->getSignature(),
           /*Action=*/ [node](BuildEngine& engine) -> Task* {
-            return engine.registerTask(
-                new DirectoryStructureInputNodeTask(*node));
+            return new DirectoryStructureInputNodeTask(*node);
           },
             // Directory nodes don't require any validation outside of their
             // concrete dependencies.
@@ -1741,7 +1738,7 @@ Rule BuildSystemEngineDelegate::lookupRule(const KeyType& keyData) {
         keyData,
         node->getSignature(),
         /*Action=*/ [node](BuildEngine& engine) -> Task* {
-          return engine.registerTask(new FileInputNodeTask(*node));
+          return new FileInputNodeTask(*node);
         },
         /*IsValid=*/ [node](BuildEngine& engine, const Rule& rule,
                             const ValueType& value) -> bool {
@@ -1756,7 +1753,7 @@ Rule BuildSystemEngineDelegate::lookupRule(const KeyType& keyData) {
       keyData,
       node->getSignature(),
       /*Action=*/ [node](BuildEngine& engine) -> Task* {
-        return engine.registerTask(new ProducedNodeTask(*node));
+        return new ProducedNodeTask(*node);
       },
       /*IsValid=*/ [node](BuildEngine& engine, const Rule& rule,
                           const ValueType& value) -> bool {
@@ -1783,7 +1780,7 @@ Rule BuildSystemEngineDelegate::lookupRule(const KeyType& keyData) {
       keyData,
       /*signature=*/{},
       /*Action=*/ [statnode](BuildEngine& engine) -> Task* {
-        return engine.registerTask(new StatTask(*statnode));
+        return new StatTask(*statnode);
       },
       /*IsValid=*/ [statnode](BuildEngine& engine, const Rule& rule,
                             const ValueType& value) -> bool {
@@ -1807,7 +1804,7 @@ Rule BuildSystemEngineDelegate::lookupRule(const KeyType& keyData) {
       keyData,
       /*signature=*/{},
       /*Action=*/ [target](BuildEngine& engine) -> Task* {
-        return engine.registerTask(new TargetTask(*target));
+        return new TargetTask(*target);
       },
       /*IsValid=*/ [target](BuildEngine& engine, const Rule& rule,
                             const ValueType& value) -> bool {

--- a/lib/Commands/BuildEngineCommand.cpp
+++ b/lib/Commands/BuildEngineCommand.cpp
@@ -139,7 +139,6 @@ struct AckermannTask : core::Task {
   AckermannValue recursiveResultB = {};
 
   AckermannTask(core::BuildEngine& engine, int m, int n) : m(m), n(n) {
-    engine.registerTask(this);
   }
 
   /// Called when the task is started.

--- a/lib/Commands/NinjaBuildCommand.cpp
+++ b/lib/Commands/NinjaBuildCommand.cpp
@@ -1437,7 +1437,7 @@ buildCommand(BuildContext& context, ninja::Command* command) {
     }
   };
 
-  return context.engine.registerTask(new NinjaCommandTask(context, command));
+  return new NinjaCommandTask(context, command);
 }
 
 static core::Task* buildInput(BuildContext& context, ninja::Node* input) {
@@ -1471,7 +1471,7 @@ static core::Task* buildInput(BuildContext& context, ninja::Node* input) {
     }
   };
 
-  return context.engine.registerTask(new NinjaInputTask(context, input));
+  return new NinjaInputTask(context, input);
 }
 
 static core::Task*
@@ -1511,7 +1511,7 @@ buildTargets(BuildContext& context,
     }
   };
 
-  return context.engine.registerTask(new TargetsTask(context, targetsToBuild));
+  return new TargetsTask(context, targetsToBuild);
 }
 
 static core::Task*
@@ -1573,8 +1573,7 @@ selectCompositeBuildResult(BuildContext& context, ninja::Command* command,
     }
   };
 
-  return context.engine.registerTask(
-    new SelectResultTask(context, command, inputIndex, compositeRuleName));
+  return new SelectResultTask(context, command, inputIndex, compositeRuleName);
 }
 
 static bool buildInputIsResultValid(ninja::Node* node,

--- a/perftests/Xcode/PerfTests/CorePerfTests.mm
+++ b/perftests/Xcode/PerfTests/CorePerfTests.mm
@@ -91,8 +91,7 @@ typedef std::function<Task*(BuildEngine&)> ActionFn;
 
 static ActionFn simpleAction(const std::vector<KeyType>& Inputs,
                              SimpleTask::ComputeFnType Compute) {
-  return [=] (BuildEngine& engine) {
-    return engine.registerTask(new SimpleTask(Inputs, Compute)); };
+  return [=] (BuildEngine& engine) { return new SimpleTask(Inputs, Compute); };
 }
 
 }

--- a/products/libllbuild/Core-C-API.cpp
+++ b/products/libllbuild/Core-C-API.cpp
@@ -204,13 +204,6 @@ void llb_buildengine_build(llb_buildengine_t* engine_p, const llb_data_t* key,
   *result_out = llb_data_t{ result.size(), result.data() };
 }
 
-llb_task_t* llb_buildengine_register_task(llb_buildengine_t* engine_p,
-                                          llb_task_t* task) {
-  auto& engine = ((CAPIBuildEngine*) engine_p)->engine;
-  engine->registerTask((Task*)task);
-  return task;
-}
-
 void llb_buildengine_task_needs_input(llb_buildengine_t* engine_p,
                                       llb_task_t* task,
                                       const llb_data_t* key,

--- a/products/libllbuild/include/llbuild/core.h
+++ b/products/libllbuild/include/llbuild/core.h
@@ -154,15 +154,6 @@ LLBUILD_EXPORT void
 llb_buildengine_build(llb_buildengine_t* engine, const llb_data_t* key,
                       llb_data_t* result_out);
 
-/// Register the given task, in response to a Rule evaluation.
-///
-/// The engine tasks ownership of the \arg task, and it is expected to
-/// subsequently be returned as the task to execute for a rule evaluation.
-///
-/// \returns The provided task, for the convenience of the client.
-LLBUILD_EXPORT llb_task_t*
-llb_buildengine_register_task(llb_buildengine_t* engine, llb_task_t* task);
-
 /// Specify the given \arg Task depends upon the result of computing \arg Key.
 ///
 /// The result, when available, will be provided to the task via \see

--- a/products/llbuildSwift/CoreBindings.swift
+++ b/products/llbuildSwift/CoreBindings.swift
@@ -521,12 +521,9 @@ public class BuildEngine {
         }
 
         // Create the internal task.
-        taskWrapper.taskInternal = llb_task_create(taskDelegate)
-
-        // FIXME: Why do we have both of these, it is kind of annoying. It makes
-        // some amount of sense in the C++ API, but the C API should probably just
-        // collapse them.
-        return llb_buildengine_register_task(self._engine, taskWrapper.taskInternal)
+        let lltask = llb_task_create(taskDelegate)
+        taskWrapper.taskInternal = lltask
+        return lltask!
     }
 }
 

--- a/unittests/Core/BuildEngineCancellationTest.cpp
+++ b/unittests/Core/BuildEngineCancellationTest.cpp
@@ -113,15 +113,15 @@ typedef std::function<Task*(BuildEngine&)> ActionFn;
 static ActionFn simpleAction(const std::vector<KeyType>& inputs,
                              SimpleTask::ComputeFnType compute) {
   return [=] (BuildEngine& engine) {
-    return engine.registerTask(new SimpleTask([inputs]{ return inputs; },
-                                              compute)); };
+    return new SimpleTask([inputs]{ return inputs; }, compute);
+  };
 }
 
 static ActionFn simpleActionExternalTask(const std::vector<KeyType>& inputs,
                              SimpleTask::ComputeFnType compute, Task** task) {
   return [=] (BuildEngine& engine) {
     *task = new SimpleTask([inputs]{ return inputs; }, compute);
-    return engine.registerTask(*task); };
+    return *task; };
 }
 
 TEST(BuildEngineCancellationTest, basic) {

--- a/unittests/Core/BuildEngineTest.cpp
+++ b/unittests/Core/BuildEngineTest.cpp
@@ -132,8 +132,8 @@ typedef std::function<Task*(BuildEngine&)> ActionFn;
 static ActionFn simpleAction(const std::vector<KeyType>& inputs,
                              SimpleTask::ComputeFnType compute) {
   return [=] (BuildEngine& engine) {
-    return engine.registerTask(new SimpleTask([inputs]{ return inputs; },
-                                              compute)); };
+    return new SimpleTask([inputs]{ return inputs; }, compute);
+  };
 }
 
 TEST(BuildEngineTest, basic) {
@@ -605,7 +605,7 @@ TEST(BuildEngineTest, discoveredDependencies) {
       "output", {},
       [&valueB, &builtKeys] (BuildEngine& engine) {
         builtKeys.push_back("output");
-        return engine.registerTask(new TaskWithDiscoveredDependency(valueB));
+        return new TaskWithDiscoveredDependency(valueB);
       } });
 
   // Build the first result.
@@ -740,7 +740,7 @@ TEST(BuildEngineTest, CycleDuringScanningFromTop) {
   engine.addRule({
       "A", {},
       [&](BuildEngine& engine) {
-        return engine.registerTask(
+        return
             new SimpleTask(
                 [&]() -> std::vector<std::string> {
                   switch (iteration) {
@@ -753,7 +753,7 @@ TEST(BuildEngineTest, CycleDuringScanningFromTop) {
                   }
                 },
                 [&](const std::vector<int>& inputs) {
-                  return 2; }));
+                  return 2; });
         },
       [&](BuildEngine&, const Rule&, const ValueType&) {
         // Always rebuild
@@ -763,7 +763,7 @@ TEST(BuildEngineTest, CycleDuringScanningFromTop) {
   engine.addRule({
       "B", {},
       [&](BuildEngine& engine) {
-        return engine.registerTask(
+        return
             new SimpleTask(
                 [&]() -> std::vector<std::string> {
                   switch (iteration) {
@@ -776,7 +776,7 @@ TEST(BuildEngineTest, CycleDuringScanningFromTop) {
                   }
                 },
                 [&](const std::vector<int>& inputs) {
-                  return 2; }));
+                  return 2; });
         },
       [&](BuildEngine&, const Rule&, const ValueType&) {
         // Always rebuild
@@ -786,7 +786,7 @@ TEST(BuildEngineTest, CycleDuringScanningFromTop) {
   engine.addRule({
       "C", {},
       [&](BuildEngine& engine) {
-        return engine.registerTask(
+        return
             new SimpleTask(
                 [&]() -> std::vector<std::string> {
                   switch (iteration) {
@@ -799,7 +799,7 @@ TEST(BuildEngineTest, CycleDuringScanningFromTop) {
                   }
                 },
                 [&](const std::vector<int>& inputs) {
-                  return 2; }));
+                  return 2; });
         },
       [&](BuildEngine&, const Rule&, const ValueType&) {
         // Always rebuild

--- a/unittests/Core/DepsBuildEngineTest.cpp
+++ b/unittests/Core/DepsBuildEngineTest.cpp
@@ -109,7 +109,7 @@ typedef std::function<Task*(BuildEngine&)> ActionFn;
 static ActionFn simpleAction(const std::vector<KeyType>& inputs,
                              SimpleTask::ComputeFnType compute) {
   return [=] (BuildEngine& engine) {
-    return engine.registerTask(new SimpleTask(inputs, compute)); };
+    return new SimpleTask(inputs, compute); };
 }
 
 // Test for a tricky case involving concurrent dependency scanning.
@@ -208,7 +208,7 @@ TEST(DepsBuildEngineTest, BogusConcurrentDepScan) {
       "output", {},
       [&builtKeys] (BuildEngine& engine) {
         builtKeys.push_back("output");
-        return engine.registerTask(new DynamicTask());
+        return new DynamicTask();
       } });
 
   // Build the first result.


### PR DESCRIPTION
Removes registerTask() method, takes ownership directly during the
rule action call.