### PR TITLE
SR-11730 Improved GraphViz output

### DIFF
--- a/products/llbuild-analyze/Sources/CriticalPathTool.swift
+++ b/products/llbuild-analyze/Sources/CriticalPathTool.swift
@@ -71,8 +71,8 @@ public final class CriticalPathTool: Tool<CriticalPathTool.Options> {
             to: { $0.pretty = $1 })
 
         binder.bind(
-            option: parser.add(option: "--graphvizOutput", usage: "Graphviz display options. Possible values: \(Options.GraphvizDisplay.helpDescription)."),
-            to: { $0.graphvizDisplay = Options.GraphvizDisplay(rawValue: $1) ?? .everything }
+            option: parser.add(option: "--graphvizOutput", usage: "Graphviz display options. Possible values: \(Options.GraphvizDisplay.helpDescription). Default is all"),
+            to: { $0.graphvizDisplay = Options.GraphvizDisplay(rawValue: $1) ?? .all }
         )
         
         binder.bind(

--- a/products/llbuild-analyze/Sources/CriticalPathTool.swift
+++ b/products/llbuild-analyze/Sources/CriticalPathTool.swift
@@ -141,7 +141,7 @@ public final class CriticalPathTool: Tool<CriticalPathTool.Options> {
         if options.graphvizDisplay == .all {
             for element in path {
                 for dep in element.result.dependencies {
-                    edges.insert(DirectedEdge(a: dep, b: element.key))
+                    edges.insert(DirectedEdge(a: dep, b: element.key, isCritical: false))
                 }
             }
         }
@@ -292,105 +292,6 @@ struct EncodableRuleResult: Encodable {
     }
 }
 
-
-protocol GraphVizNode {
-    var graphVizName: String { get }
-}
-
-extension BuildKey.Command: GraphVizNode {
-    var graphVizName: String {
-        "Command:\(self.name)"
-    }
-}
-
-extension BuildKey.CustomTask: GraphVizNode {
-    var graphVizName: String {
-        "CustomTask:\(self.name)"
-    }
-}
-
-extension BuildKey.DirectoryContents: GraphVizNode {
-    var graphVizName: String {
-        "DirectoryContents:\(self.path)"
-    }
-}
-
-extension BuildKey.FilteredDirectoryContents: GraphVizNode {
-    var graphVizName: String {
-        "FilteredDirectoryContents:\(self.path)"
-    }
-}
-
-extension BuildKey.DirectoryTreeSignature: GraphVizNode {
-    var graphVizName: String {
-        "DirectoryTreeSignature:\(self.path)"
-    }
-}
-
-extension BuildKey.DirectoryTreeStructureSignature: GraphVizNode {
-    var graphVizName: String {
-        "DirectoryTreeStructureSignature:\(self.path)"
-    }
-}
-
-extension BuildKey.Node: GraphVizNode {
-    var graphVizName: String {
-        "Node:\(self.path)"
-    }
-}
-
-extension BuildKey.Stat: GraphVizNode {
-    var graphVizName: String {
-        "Stat:\(self.path)"
-    }
-}
-
-extension BuildKey.Target: GraphVizNode {
-    var graphVizName: String {
-        "Target:\(self.name)"
-    }
-}
-
-/// Struct to represent a directed edge in GraphViz from a -> b.
-/// `hash()` and `==` only take the both edges into account, not
-/// `isCritical`, so the graph can be represented as a `Set<DirectedEdge>`
-/// and gurantee that there is only one edge between two verticies.
-struct DirectedEdge: Hashable, Equatable {
-    /// Source `BuildKey`
-    let a: BuildKey
-
-    /// Destination `BuildKey`
-    let b: BuildKey
-
-    /// Flag if the edge is on critical build path.
-    var isCritical: Bool = false
-
-    static func == (lhs: Self, rhs: Self) -> Bool {
-        lhs.a == rhs.a && lhs.b == rhs.b
-    }
-
-    func hash(into hasher: inout Hasher) {
-        a.hash(into: &hasher)
-        b.hash(into: &hasher)
-    }
-
-    /// Style attributes for the edge.
-    private var style: String {
-        if isCritical {
-            return "[style=bold]"
-        }
-        return ""
-    }
-
-    /// GraphViz representation of the Edge.
-    var graphVizString: String {
-        guard let a = a as? GraphVizNode, let b = b as? GraphVizNode else {
-            fatalError("Both edges need to conform to GraphvizNode")
-        }
-        return "\t\"\(a.graphVizName)\" -> \"\(b.graphVizName)\"\(style)\n"
-    }
-
-}
 
 private protocol CommandLineArgumentChoices: CaseIterable, RawRepresentable where RawValue == String {
     static var helpDescription: String { get }

--- a/products/llbuild-analyze/Sources/CriticalPathTool.swift
+++ b/products/llbuild-analyze/Sources/CriticalPathTool.swift
@@ -25,7 +25,7 @@ public final class CriticalPathTool: Tool<CriticalPathTool.Options> {
 
         public enum GraphvizDisplay: String, CaseIterable, CommandLineArgumentChoices {
             case criticalPath
-            case everything
+            case all
         }
         
         var database: AbsolutePath!
@@ -138,7 +138,7 @@ public final class CriticalPathTool: Tool<CriticalPathTool.Options> {
             }
         }
 
-        if options.graphvizDisplay == .everything {
+        if options.graphvizDisplay == .all {
             for element in path {
                 for dep in element.result.dependencies {
                     edges.insert(DirectedEdge(a: dep, b: element.key))

--- a/products/llbuild-analyze/Sources/GraphViz.swift
+++ b/products/llbuild-analyze/Sources/GraphViz.swift
@@ -57,56 +57,8 @@ struct DirectedEdge: Hashable, Equatable {
 
 }
 
-extension BuildKey.Command: GraphVizNode {
+extension BuildKey: GraphVizNode {
     var graphVizName: String {
-        "Command:\(self.name)"
-    }
-}
-
-extension BuildKey.CustomTask: GraphVizNode {
-    var graphVizName: String {
-        "CustomTask:\(self.name)"
-    }
-}
-
-extension BuildKey.DirectoryContents: GraphVizNode {
-    var graphVizName: String {
-        "DirectoryContents:\(self.path)"
-    }
-}
-
-extension BuildKey.FilteredDirectoryContents: GraphVizNode {
-    var graphVizName: String {
-        "FilteredDirectoryContents:\(self.path)"
-    }
-}
-
-extension BuildKey.DirectoryTreeSignature: GraphVizNode {
-    var graphVizName: String {
-        "DirectoryTreeSignature:\(self.path)"
-    }
-}
-
-extension BuildKey.DirectoryTreeStructureSignature: GraphVizNode {
-    var graphVizName: String {
-        "DirectoryTreeStructureSignature:\(self.path)"
-    }
-}
-
-extension BuildKey.Node: GraphVizNode {
-    var graphVizName: String {
-        "Node:\(self.path)"
-    }
-}
-
-extension BuildKey.Stat: GraphVizNode {
-    var graphVizName: String {
-        "Stat:\(self.path)"
-    }
-}
-
-extension BuildKey.Target: GraphVizNode {
-    var graphVizName: String {
-        "Target:\(self.name)"
+        description
     }
 }

--- a/products/llbuild-analyze/Sources/GraphViz.swift
+++ b/products/llbuild-analyze/Sources/GraphViz.swift
@@ -49,9 +49,6 @@ struct DirectedEdge: Hashable, Equatable {
 
     /// GraphViz representation of the Edge.
     var graphVizString: String {
-        guard let a = a as? GraphVizNode, let b = b as? GraphVizNode else {
-            fatalError("Both edges need to conform to GraphVizNode to generate a graphVizString for DirectedEdge \(self).")
-        }
         return "\t\"\(a.graphVizName)\" -> \"\(b.graphVizName)\"\(style)\n"
     }
 

--- a/products/llbuild-analyze/Sources/GraphViz.swift
+++ b/products/llbuild-analyze/Sources/GraphViz.swift
@@ -1,0 +1,112 @@
+// This source file is part of the Swift.org open source project
+//
+// Copyright 2019 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+
+import TSCUtility
+import TSCBasic
+import llbuildAnalysis
+import llbuildSwift
+
+
+protocol GraphVizNode {
+    var graphVizName: String { get }
+}
+
+/// Struct to represent a directed edge in GraphViz from a -> b.
+/// `hash()` and `==` only take the both edges into account, not
+/// `isCritical`, so the graph can be represented as a `Set<DirectedEdge>`
+/// and gurantee that there is only one edge between two verticies.
+struct DirectedEdge: Hashable, Equatable {
+    /// Source `BuildKey`
+    let a: BuildKey
+
+    /// Destination `BuildKey`
+    let b: BuildKey
+
+    /// Flag if the edge is on critical build path.
+    let isCritical: Bool
+
+    static func == (lhs: Self, rhs: Self) -> Bool {
+        lhs.a == rhs.a && lhs.b == rhs.b
+    }
+
+    func hash(into hasher: inout Hasher) {
+        a.hash(into: &hasher)
+        b.hash(into: &hasher)
+    }
+
+    /// Style attributes for the edge.
+    private var style: String {
+        if isCritical {
+            return "[style=bold]"
+        }
+        return ""
+    }
+
+    /// GraphViz representation of the Edge.
+    var graphVizString: String {
+        guard let a = a as? GraphVizNode, let b = b as? GraphVizNode else {
+            fatalError("Both edges need to conform to GraphVizNode to generate a graphVizString for DirectedEdge \(self).")
+        }
+        return "\t\"\(a.graphVizName)\" -> \"\(b.graphVizName)\"\(style)\n"
+    }
+
+}
+
+extension BuildKey.Command: GraphVizNode {
+    var graphVizName: String {
+        "Command:\(self.name)"
+    }
+}
+
+extension BuildKey.CustomTask: GraphVizNode {
+    var graphVizName: String {
+        "CustomTask:\(self.name)"
+    }
+}
+
+extension BuildKey.DirectoryContents: GraphVizNode {
+    var graphVizName: String {
+        "DirectoryContents:\(self.path)"
+    }
+}
+
+extension BuildKey.FilteredDirectoryContents: GraphVizNode {
+    var graphVizName: String {
+        "FilteredDirectoryContents:\(self.path)"
+    }
+}
+
+extension BuildKey.DirectoryTreeSignature: GraphVizNode {
+    var graphVizName: String {
+        "DirectoryTreeSignature:\(self.path)"
+    }
+}
+
+extension BuildKey.DirectoryTreeStructureSignature: GraphVizNode {
+    var graphVizName: String {
+        "DirectoryTreeStructureSignature:\(self.path)"
+    }
+}
+
+extension BuildKey.Node: GraphVizNode {
+    var graphVizName: String {
+        "Node:\(self.path)"
+    }
+}
+
+extension BuildKey.Stat: GraphVizNode {
+    var graphVizName: String {
+        "Stat:\(self.path)"
+    }
+}
+
+extension BuildKey.Target: GraphVizNode {
+    var graphVizName: String {
+        "Target:\(self.name)"
+    }
+}


### PR DESCRIPTION
This changes the `critical-path` to to include more meaningful information in the vertices instead of just the BuildKey ID from the database.

It also adds the option to only include the critical build path or the entire graph.

https://bugs.swift.org/browse/SR-11730