### PR TITLE
Refactor Rule to be a virtual base class

### DIFF
--- a/include/llbuild/Core/BuildEngine.h
+++ b/include/llbuild/Core/BuildEngine.h
@@ -214,7 +214,7 @@ public:
   /// state managed externally to the build engine. For example, a rule which
   /// computes something on the file system may use this to verify that the
   /// computed output has not changed since it was built.
-  virtual bool isResultValid(BuildEngine&, const ValueType&);
+  virtual bool isResultValid(BuildEngine&, const ValueType&) = 0;
 
   /// Called to indicate a change in the rule status.
   virtual void updateStatus(BuildEngine&, StatusKind);

--- a/include/llbuild/Core/BuildEngine.h
+++ b/include/llbuild/Core/BuildEngine.h
@@ -188,14 +188,24 @@ public:
     SupplyPriorValue = 1
   };
 
+public:
   /// The key computed by the rule.
-  KeyType key;
+  const KeyType key;
 
   /// The signature of the rule.
-  basic::CommandSignature signature;
+  const basic::CommandSignature signature;
+
+private:
+  Rule(const Rule&) LLBUILD_DELETED_FUNCTION;
+  void operator=(const Rule&) LLBUILD_DELETED_FUNCTION;
+
+public:
+  Rule(const KeyType& key, const basic::CommandSignature& signature = {})
+    : key(key), signature(signature) { }
+  virtual ~Rule() = 0;
 
   /// Called to create the task to build the rule, when necessary.
-  std::function<Task*(BuildEngine&)> action;
+  virtual Task* createTask(BuildEngine&) = 0;
 
   /// Called to check whether the previously computed value for this rule is
   /// still valid.
@@ -204,11 +214,10 @@ public:
   /// state managed externally to the build engine. For example, a rule which
   /// computes something on the file system may use this to verify that the
   /// computed output has not changed since it was built.
-  std::function<bool(BuildEngine&, const Rule&,
-                     const ValueType&)> isResultValid;
+  virtual bool isResultValid(BuildEngine&, const ValueType&);
 
   /// Called to indicate a change in the rule status.
-  std::function<void(BuildEngine&, StatusKind)> updateStatus;
+  virtual void updateStatus(BuildEngine&, StatusKind);
 };
 
 /// Delegate interface for use with the build engine.
@@ -223,7 +232,7 @@ public:
   /// Task through mechanisms such as \see BuildEngine::taskNeedsInput(). If a
   /// requested Key cannot be supplied, the delegate should provide a dummy rule
   /// that the client can translate into an error.
-  virtual Rule lookupRule(const KeyType& key) = 0;
+  virtual std::unique_ptr<Rule> lookupRule(const KeyType& key) = 0;
 
   /// Called when a cycle is detected by the build engine to check if it should
   /// attempt to resolve the cycle and continue
@@ -304,7 +313,7 @@ public:
   /// @{
 
   /// Add a rule which the engine can use to produce outputs.
-  void addRule(Rule&& rule);
+  void addRule(std::unique_ptr<Rule>&& rule);
 
   /// @}
 

--- a/lib/Commands/BuildEngineCommand.cpp
+++ b/lib/Commands/BuildEngineCommand.cpp
@@ -204,6 +204,9 @@ static int runAckermannBuild(int m, int n, int recomputeCount,
         auto k = AckermannKey(key);
         return new AckermannTask(engine, k.m, k.n);
       }
+      bool isResultValid(core::BuildEngine&, const core::ValueType&) override {
+        return true;
+      }
     };
 
   public:

--- a/lib/Commands/BuildEngineCommand.cpp
+++ b/lib/Commands/BuildEngineCommand.cpp
@@ -197,15 +197,22 @@ static int runAckermannBuild(int m, int n, int recomputeCount,
   // Define the delegate which will dynamically construct rules of the form
   // "ack(M,N)".
   class AckermannDelegate : public core::BuildEngineDelegate {
+    class AckermannRule : public core::Rule {
+    public:
+      AckermannRule(const core::KeyType& key) : core::Rule(key) { }
+      core::Task* createTask(core::BuildEngine& engine) override {
+        auto k = AckermannKey(key);
+        return new AckermannTask(engine, k.m, k.n);
+      }
+    };
+
   public:
     int numRules = 0;
 
     /// Get the rule to use for the given Key.
-    virtual core::Rule lookupRule(const core::KeyType& keyData) override {
+    virtual std::unique_ptr<core::Rule> lookupRule(const core::KeyType& keyData) override {
       ++numRules;
-      auto key = AckermannKey(keyData);
-      return core::Rule{key, {}, [key] (core::BuildEngine& engine) {
-          return new AckermannTask(engine, key.m, key.n); } };
+      return std::unique_ptr<core::Rule>(new AckermannRule(keyData));
     }
 
     /// Called when a cycle is detected by the build engine and it cannot make

--- a/lib/Core/BuildEngine.cpp
+++ b/lib/Core/BuildEngine.cpp
@@ -41,7 +41,6 @@ using namespace llbuild::core;
 Task::~Task() {}
 
 Rule::~Rule() {}
-bool Rule::isResultValid(BuildEngine&, const ValueType&) { return true; }
 void Rule::updateStatus(BuildEngine&, StatusKind) {}
 
 BuildEngineDelegate::~BuildEngineDelegate() {}

--- a/llbuild.xcodeproj/project.pbxproj
+++ b/llbuild.xcodeproj/project.pbxproj
@@ -912,6 +912,8 @@
 		40B3C91B20D3AF9B007C5847 /* C-API.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "C-API.cpp"; sourceTree = "<group>"; };
 		40C71A8022F0EBCF008FDC9C /* Defer.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Defer.h; sourceTree = "<group>"; };
 		40C71A8122F0FA1D008FDC9C /* Defer.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = Defer.cpp; sourceTree = "<group>"; };
+		40D5A32823AD9C5A004B56EA /* Command.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Command.h; sourceTree = "<group>"; };
+		40D5A32923AD9C5A004B56EA /* Tool.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Tool.h; sourceTree = "<group>"; };
 		40EA26452164253500068954 /* Subprocess.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Subprocess.h; sourceTree = "<group>"; };
 		40EA26462164289500068954 /* ExecutionQueue.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ExecutionQueue.h; sourceTree = "<group>"; };
 		40EA264721651D2C00068954 /* ExecutionQueue.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ExecutionQueue.cpp; sourceTree = "<group>"; };
@@ -2622,6 +2624,7 @@
 				E1AAD28B1BC60A0F00F54680 /* BuildSystemFrontend.h */,
 				E15305922236C8DF0097CDE6 /* BuildSystemHandlers.h */,
 				E11470911B7517C800ED84CF /* BuildValue.h */,
+				40D5A32823AD9C5A004B56EA /* Command.h */,
 				54E187B71CD296EA00F7EC89 /* ExternalCommand.h */,
 				E162C583223315A20078FD2E /* ShellCommand.h */,
 				2D86C6DF238D932B006E61FB /* Tool.h */,

--- a/unittests/BuildSystem/BuildSystemFrontendTest.cpp
+++ b/unittests/BuildSystem/BuildSystemFrontendTest.cpp
@@ -517,15 +517,21 @@ client:
 TEST(BuildSystemInvocationTest, formatCycle) {
   BuildSystemInvocation invocation;
 
-  core::Rule command{BuildKey::makeCommand("c").getKeyData()};
-  core::Rule customtask{BuildKey::makeCustomTask("c","t").getKeyData()};
-  core::Rule dircontents{BuildKey::makeDirectoryContents("/").getKeyData()};
-  core::Rule filtdircontents{BuildKey::makeFilteredDirectoryContents("/", {}).getKeyData()};
-  core::Rule dirtree{BuildKey::makeDirectoryTreeSignature("/", {}).getKeyData()};
-  core::Rule dirtreestruct{BuildKey::makeDirectoryTreeStructureSignature("/").getKeyData()};
-  core::Rule node{BuildKey::makeNode("n").getKeyData()};
-  core::Rule stat{BuildKey::makeStat("f").getKeyData()};
-  core::Rule target{BuildKey::makeTarget("t").getKeyData()};
+  class NullRule : public core::Rule {
+  public:
+    NullRule(const KeyType& key) : Rule(key) { }
+    Task* createTask(core::BuildEngine&) override { return nullptr; }
+  };
+
+  NullRule command{BuildKey::makeCommand("c").getKeyData()};
+  NullRule customtask{BuildKey::makeCustomTask("c","t").getKeyData()};
+  NullRule dircontents{BuildKey::makeDirectoryContents("/").getKeyData()};
+  NullRule filtdircontents{BuildKey::makeFilteredDirectoryContents("/", {}).getKeyData()};
+  NullRule dirtree{BuildKey::makeDirectoryTreeSignature("/", {}).getKeyData()};
+  NullRule dirtreestruct{BuildKey::makeDirectoryTreeStructureSignature("/").getKeyData()};
+  NullRule node{BuildKey::makeNode("n").getKeyData()};
+  NullRule stat{BuildKey::makeStat("f").getKeyData()};
+  NullRule target{BuildKey::makeTarget("t").getKeyData()};
 
   std::vector<core::Rule*> cycle{
     &command,

--- a/unittests/BuildSystem/BuildSystemFrontendTest.cpp
+++ b/unittests/BuildSystem/BuildSystemFrontendTest.cpp
@@ -521,6 +521,9 @@ TEST(BuildSystemInvocationTest, formatCycle) {
   public:
     NullRule(const KeyType& key) : Rule(key) { }
     Task* createTask(core::BuildEngine&) override { return nullptr; }
+    bool isResultValid(core::BuildEngine&, const core::ValueType&) override {
+      return true;
+    }
   };
 
   NullRule command{BuildKey::makeCommand("c").getKeyData()};

--- a/unittests/Core/BuildEngineCancellationTest.cpp
+++ b/unittests/Core/BuildEngineCancellationTest.cpp
@@ -132,6 +132,8 @@ public:
 
     return ret;
   }
+
+  bool isResultValid(BuildEngine&, const ValueType&) override { return true; }
 };
 
 

--- a/unittests/Core/BuildEngineTest.cpp
+++ b/unittests/Core/BuildEngineTest.cpp
@@ -40,12 +40,12 @@ public:
   bool expectedError = false;
 
 private:
-  virtual core::Rule lookupRule(const core::KeyType& key) override {
+  virtual std::unique_ptr<core::Rule> lookupRule(const core::KeyType& key) override {
     // We never expect dynamic rule lookup.
     fprintf(stderr, "error: unexpected rule lookup for \"%s\"\n",
             key.c_str());
     abort();
-    return core::Rule();
+    return nullptr;
   }
 
   virtual void cycleDetected(const std::vector<core::Rule*>& items) override {
@@ -129,36 +129,59 @@ public:
 // Helper function for creating a simple action.
 typedef std::function<Task*(BuildEngine&)> ActionFn;
 
-static ActionFn simpleAction(const std::vector<KeyType>& inputs,
-                             SimpleTask::ComputeFnType compute) {
-  return [=] (BuildEngine& engine) {
-    return new SimpleTask([inputs]{ return inputs; }, compute);
-  };
-}
+class SimpleRule: public Rule {
+public:
+  typedef std::function<bool(const ValueType& value)> ValidFnType;
+  typedef std::function<void(core::Rule::StatusKind status)> StatusFnType;
+
+private:
+  SimpleTask::ComputeFnType compute;
+  std::vector<KeyType> inputs;
+  ValidFnType valid;
+  StatusFnType update;
+public:
+  SimpleRule(const KeyType& key, const std::vector<KeyType>& inputs,
+             SimpleTask::ComputeFnType compute, ValidFnType valid = nullptr,
+             StatusFnType update = nullptr, const basic::CommandSignature& sig = {})
+    : Rule(key, sig), compute(compute), inputs(inputs), valid(valid), update(update) { }
+
+  Task* createTask(BuildEngine&) override { return new SimpleTask([this]{ return inputs; }, compute); }
+
+  bool isResultValid(BuildEngine&, const ValueType& value) override {
+    if (!valid) return true;
+    return valid(value);
+  }
+
+  void updateStatus(BuildEngine&, core::Rule::StatusKind status) override {
+    if (update) update(status);
+  }
+
+};
+
+
 
 TEST(BuildEngineTest, basic) {
   // Check a trivial build graph.
   std::vector<std::string> builtKeys;
   SimpleBuildEngineDelegate delegate;
   core::BuildEngine engine(delegate);
-  engine.addRule({
-    "value-A", {}, simpleAction({}, [&] (const std::vector<int>& inputs) {
+  engine.addRule(std::unique_ptr<core::Rule>(new SimpleRule(
+    "value-A", {}, [&] (const std::vector<int>& inputs) {
           builtKeys.push_back("value-A");
-          return 2; }) });
-  engine.addRule({
-      "value-B", {}, simpleAction({}, [&] (const std::vector<int>& inputs) {
+          return 2; })));
+  engine.addRule(std::unique_ptr<core::Rule>(new SimpleRule(
+      "value-B", {}, [&] (const std::vector<int>& inputs) {
           builtKeys.push_back("value-B");
-          return 3; }) });
-  engine.addRule({
-      "result", {},
-      simpleAction({"value-A", "value-B"},
+          return 3; })));
+  engine.addRule(std::unique_ptr<core::Rule>(new SimpleRule(
+      "result", {"value-A", "value-B"},
                    [&] (const std::vector<int>& inputs) {
                      EXPECT_EQ(2U, inputs.size());
                      EXPECT_EQ(2, inputs[0]);
                      EXPECT_EQ(3, inputs[1]);
                      builtKeys.push_back("result");
                      return inputs[0] * inputs[1] * 5;
-                   }) });
+                   })));
 
   // Build the result.
   EXPECT_EQ(2 * 3 * 5, intFromValue(engine.build("result")));
@@ -186,34 +209,32 @@ TEST(BuildEngineTest, basicWithSharedInput) {
   std::vector<std::string> builtKeys;
   SimpleBuildEngineDelegate delegate;
   core::BuildEngine engine(delegate);
-  engine.addRule({
-      "value-A", {}, simpleAction({}, [&] (const std::vector<int>& inputs) {
+  engine.addRule(std::unique_ptr<core::Rule>(new SimpleRule(
+      "value-A", {}, [&] (const std::vector<int>& inputs) {
           builtKeys.push_back("value-A");
-          return 2; }) });
-  engine.addRule({
-      "value-B", {}, simpleAction({}, [&] (const std::vector<int>& inputs) {
+          return 2; })));
+  engine.addRule(std::unique_ptr<core::Rule>(new SimpleRule(
+      "value-B", {}, [&] (const std::vector<int>& inputs) {
           builtKeys.push_back("value-B");
-          return 3; }) });
-  engine.addRule({
-      "value-C", {},
-      simpleAction({"value-A", "value-B"},
+          return 3; })));
+  engine.addRule(std::unique_ptr<core::Rule>(new SimpleRule(
+      "value-C", {"value-A", "value-B"},
                    [&] (const std::vector<int>& inputs) {
                      EXPECT_EQ(2U, inputs.size());
                      EXPECT_EQ(2, inputs[0]);
                      EXPECT_EQ(3, inputs[1]);
                      builtKeys.push_back("value-C");
                      return inputs[0] * inputs[1] * 5;
-                   }) });
-  engine.addRule({
-      "value-R", {},
-      simpleAction({"value-A", "value-C"},
+                   })));
+  engine.addRule(std::unique_ptr<core::Rule>(new SimpleRule(
+      "value-R", {"value-A", "value-C"},
                    [&] (const std::vector<int>& inputs) {
                      EXPECT_EQ(2U, inputs.size());
                      EXPECT_EQ(2, inputs[0]);
                      EXPECT_EQ(2 * 3 * 5, inputs[1]);
                      builtKeys.push_back("value-R");
                      return inputs[0] * inputs[1] * 7;
-                   }) });
+                   })));
 
   // Build the result.
   EXPECT_EQ(2 * 2 * 3 * 5 * 7, intFromValue(engine.build("value-R")));
@@ -234,30 +255,29 @@ TEST(BuildEngineTest, veryBasicIncremental) {
   core::BuildEngine engine(delegate);
   int valueA = 2;
   int valueB = 3;
-  engine.addRule({
-      "value-A", {}, simpleAction({}, [&] (const std::vector<int>& inputs) {
+  engine.addRule(std::unique_ptr<core::Rule>(new SimpleRule(
+      "value-A", {}, [&] (const std::vector<int>& inputs) {
           builtKeys.push_back("value-A");
-          return valueA; }),
-      [&](core::BuildEngine&, const Rule& rule, const ValueType& value) {
+          return valueA; },
+      [&](const ValueType& value) {
         return valueA == intFromValue(value);
-      } });
-  engine.addRule({
-      "value-B", {}, simpleAction({}, [&] (const std::vector<int>& inputs) {
+      } )));
+  engine.addRule(std::unique_ptr<core::Rule>(new SimpleRule(
+      "value-B", {}, [&] (const std::vector<int>& inputs) {
           builtKeys.push_back("value-B");
-          return valueB; }),
-      [&](core::BuildEngine&, const Rule& rule, const ValueType& value) {
+          return valueB; },
+      [&](const ValueType& value) {
         return valueB == intFromValue(value);
-      } });
-  engine.addRule({
-      "value-R", {},
-      simpleAction({"value-A", "value-B"},
+      } )));
+  engine.addRule(std::unique_ptr<core::Rule>(new SimpleRule(
+      "value-R", {"value-A", "value-B"},
                    [&] (const std::vector<int>& inputs) {
                      EXPECT_EQ(2U, inputs.size());
                      EXPECT_EQ(valueA, inputs[0]);
                      EXPECT_EQ(valueB, inputs[1]);
                      builtKeys.push_back("value-R");
                      return inputs[0] * inputs[1] * 5;
-                   }) });
+                   })));
 
   // Build the first result.
   builtKeys.clear();
@@ -300,60 +320,56 @@ TEST(BuildEngineTest, basicIncremental) {
   core::BuildEngine engine(delegate);
   int valueA = 2;
   int valueB = 3;
-  engine.addRule({
-      "value-A", {}, simpleAction({}, [&] (const std::vector<int>& inputs) {
+  engine.addRule(std::unique_ptr<core::Rule>(new SimpleRule(
+      "value-A", {}, [&] (const std::vector<int>& inputs) {
           builtKeys.push_back("value-A");
-          return valueA; }),
-      [&](core::BuildEngine&, const Rule& rule, const ValueType& value) {
+          return valueA; },
+      [&](const ValueType& value) {
         return valueA == intFromValue(value);
-      } });
-  engine.addRule({
-      "value-B", {}, simpleAction({}, [&] (const std::vector<int>& inputs) {
+      })));
+  engine.addRule(std::unique_ptr<core::Rule>(new SimpleRule(
+      "value-B", {}, [&] (const std::vector<int>& inputs) {
           builtKeys.push_back("value-B");
-          return valueB; }),
-      [&](core::BuildEngine&, const Rule& rule, const ValueType& value) {
+          return valueB; },
+      [&](const ValueType& value) {
         return valueB == intFromValue(value);
-      } });
-  engine.addRule({
-      "value-C", {},
-      simpleAction({"value-A", "value-B"},
+      })));
+  engine.addRule(std::unique_ptr<core::Rule>(new SimpleRule(
+      "value-C", {"value-A", "value-B"},
                    [&] (const std::vector<int>& inputs) {
                      EXPECT_EQ(2U, inputs.size());
                      EXPECT_EQ(valueA, inputs[0]);
                      EXPECT_EQ(valueB, inputs[1]);
                      builtKeys.push_back("value-C");
                      return inputs[0] * inputs[1] * 5;
-                   }) });
-  engine.addRule({
-      "value-R", {},
-      simpleAction({"value-A", "value-C"},
+                   })));
+  engine.addRule(std::unique_ptr<core::Rule>(new SimpleRule(
+      "value-R", {"value-A", "value-C"},
                    [&] (const std::vector<int>& inputs) {
                      EXPECT_EQ(2U, inputs.size());
                      EXPECT_EQ(valueA, inputs[0]);
                      EXPECT_EQ(valueA * valueB * 5, inputs[1]);
                      builtKeys.push_back("value-R");
                      return inputs[0] * inputs[1] * 7;
-                   }) });
-  engine.addRule({
-      "value-D", {},
-      simpleAction({"value-R"},
+                   })));
+  engine.addRule(std::unique_ptr<core::Rule>(new SimpleRule(
+      "value-D", {"value-R"},
                    [&] (const std::vector<int>& inputs) {
                      EXPECT_EQ(1U, inputs.size());
                      EXPECT_EQ(valueA * valueA * valueB * 5 * 7,
                                inputs[0]);
                      builtKeys.push_back("value-D");
                      return inputs[0] * 11;
-                   }) });
-  engine.addRule({
-      "value-R2", {},
-      simpleAction({"value-D"},
+                   })));
+  engine.addRule(std::unique_ptr<core::Rule>(new SimpleRule(
+      "value-R2", {"value-D"},
                    [&] (const std::vector<int>& inputs) {
                      EXPECT_EQ(1U, inputs.size());
                      EXPECT_EQ(valueA * valueA * valueB * 5 * 7 * 11,
                                inputs[0]);
                      builtKeys.push_back("value-R2");
                      return inputs[0] * 13;
-                   }) });
+                   })));
 
   // Build the first result.
   builtKeys.clear();
@@ -469,20 +485,19 @@ TEST(BuildEngineTest, incrementalDependency) {
   engine.attachDB(std::unique_ptr<CustomDB>(db), &error);
 
   int valueA = 2;
-  engine.addRule({
-      "value-A", {}, simpleAction({}, [&] (const std::vector<int>& inputs) {
-          return valueA; }),
-      [&](core::BuildEngine&, const Rule& rule, const ValueType& value) {
+  engine.addRule(std::unique_ptr<core::Rule>(new SimpleRule(
+      "value-A", {}, [&] (const std::vector<int>& inputs) {
+          return valueA; },
+      [&](const ValueType& value) {
         return valueA == intFromValue(value);
-      } });
-  engine.addRule({
-      "value-R", {},
-      simpleAction({"value-A"},
+      })));
+  engine.addRule(std::unique_ptr<core::Rule>(new SimpleRule(
+      "value-R", {"value-A"},
                    [&] (const std::vector<int>& inputs) {
                      EXPECT_EQ(1U, inputs.size());
                      EXPECT_EQ(valueA, inputs[0]);
                      return inputs[0] * 3;
-                   }) });
+                   })));
 
   // Build the first result.
   EXPECT_EQ(valueA * 3, intFromValue(engine.build("value-R")));
@@ -516,22 +531,21 @@ TEST(BuildEngineTest, deepDependencyScanningStack) {
     if (i != depth-1) {
       char inputName[32];
       sprintf(inputName, "input-%d", i+1);
-      engine.addRule({
-          name, {}, simpleAction({ inputName },
+      engine.addRule(std::unique_ptr<core::Rule>(new SimpleRule(
+          name, { inputName },
                              [] (const std::vector<int>& inputs) {
-                               return inputs[0]; }) });
+                               return inputs[0]; })));
     } else {
-      engine.addRule({
+      engine.addRule(std::unique_ptr<core::Rule>(new SimpleRule(
           name, {},
-          simpleAction({},
                        [&] (const std::vector<int>& inputs) {
-                         return lastInputValue; }),
-          [&](core::BuildEngine&, const Rule& rule, const ValueType& value) {
+                         return lastInputValue; },
+          [&](const ValueType& value) {
             // FIXME: Once we have custom ValueType objects, we would like to
             // have timestamps on the value and just compare to a timestamp
             // (similar to what we would do for a file).
             return lastInputValue == intFromValue(value);
-          } });
+          })));
     }
   }
 
@@ -581,32 +595,38 @@ TEST(BuildEngineTest, discoveredDependencies) {
   core::BuildEngine engine(delegate);
   int valueA = 2;
   int valueB = 3;
-  engine.addRule({
-      "value-A", {},
-      simpleAction({ },
+  engine.addRule(std::unique_ptr<core::Rule>(new SimpleRule(
+      "value-A", { },
                    [&] (const std::vector<int>& inputs) {
                      builtKeys.push_back("value-A");
                      return valueA;
-                   }),
-      [&](BuildEngine&, const Rule& rule, const ValueType& value) {
+                   },
+      [&](const ValueType& value) {
         return valueA == intFromValue(value);
-      } });
-  engine.addRule({
-      "value-B", {},
-      simpleAction({ },
+      })));
+  engine.addRule(std::unique_ptr<core::Rule>(new SimpleRule(
+      "value-B", { },
                    [&] (const std::vector<int>& inputs) {
                      builtKeys.push_back("value-B");
                      return valueB;
-                   }),
-      [&](BuildEngine&, const Rule& rule, const ValueType& value) {
+                   },
+      [&](const ValueType& value) {
         return valueB == intFromValue(value);
-      } });
-  engine.addRule({
-      "output", {},
-      [&valueB, &builtKeys] (BuildEngine& engine) {
-        builtKeys.push_back("output");
-        return new TaskWithDiscoveredDependency(valueB);
-      } });
+      })));
+
+  class RuleWithDiscoveredDependency: public Rule {
+    std::vector<std::string>& builtKeys;
+    int& dep;
+  public:
+    RuleWithDiscoveredDependency(const KeyType& key,
+                                 std::vector<std::string>& builtKeys, int& dep)
+      : Rule(key), builtKeys(builtKeys), dep(dep) { }
+    Task* createTask(BuildEngine&) override {
+      builtKeys.push_back(key);
+      return new TaskWithDiscoveredDependency(dep);
+    }
+  };
+  engine.addRule(std::unique_ptr<core::Rule>(new RuleWithDiscoveredDependency("output", builtKeys, valueB)));
 
   // Build the first result.
   builtKeys.clear();
@@ -638,24 +658,22 @@ TEST(BuildEngineTest, unchangedOutputs) {
   std::vector<std::string> builtKeys;
   SimpleBuildEngineDelegate delegate;
   core::BuildEngine engine(delegate);
-  engine.addRule({
-      "value", {},
-      simpleAction({}, [&] (const std::vector<int>& inputs) {
+  engine.addRule(std::unique_ptr<core::Rule>(new SimpleRule(
+      "value", {}, [&] (const std::vector<int>& inputs) {
         builtKeys.push_back("value");
-        return 2; }),
-      [&](BuildEngine&, const Rule&, const ValueType&) {
+        return 2; },
+      [&](const ValueType&) {
         // Always rebuild
         return false;
-      } });
-  engine.addRule({
-      "result", {},
-      simpleAction({"value"},
+      })));
+  engine.addRule(std::unique_ptr<core::Rule>(new SimpleRule(
+      "result", {"value"},
                    [&] (const std::vector<int>& inputs) {
                      EXPECT_EQ(1U, inputs.size());
                      EXPECT_EQ(2, inputs[0]);
                      builtKeys.push_back("result");
                      return inputs[0] * 3;
-                   }) });
+                   })));
 
   // Build the result.
   EXPECT_EQ(2 * 3, intFromValue(engine.build("result")));
@@ -678,34 +696,32 @@ TEST(BuildEngineTest, StatusCallbacks) {
   unsigned numComplete = 0;
   SimpleBuildEngineDelegate delegate;
   core::BuildEngine engine(delegate);
-  engine.addRule({
-      "input", {},
-      simpleAction({}, [&] (const std::vector<int>& inputs) {
-          return 2; }),
+  engine.addRule(std::unique_ptr<core::Rule>(new SimpleRule(
+      "input", {}, [&] (const std::vector<int>& inputs) {
+          return 2; },
       nullptr,
-      [&] (BuildEngine&, core::Rule::StatusKind status) {
+      [&] (core::Rule::StatusKind status) {
         if (status == core::Rule::StatusKind::IsScanning) {
           ++numScanned;
         } else {
           assert(status == core::Rule::StatusKind::IsComplete);
           ++numComplete;
         }
-      } });
-  engine.addRule({
-      "output", {},
-      simpleAction({"input"},
+      } )));
+  engine.addRule(std::unique_ptr<core::Rule>(new SimpleRule(
+      "output", {"input"},
                    [&] (const std::vector<int>& inputs) {
                      return inputs[0] * 3;
-                   }),
+                   },
       nullptr,
-      [&] (BuildEngine&, core::Rule::StatusKind status) {
+      [&] (core::Rule::StatusKind status) {
         if (status == core::Rule::StatusKind::IsScanning) {
           ++numScanned;
         } else {
           assert(status == core::Rule::StatusKind::IsComplete);
           ++numComplete;
         }
-      } });
+      } )));
 
   // Build the result.
   EXPECT_EQ(2 * 3, intFromValue(engine.build("output")));
@@ -717,14 +733,12 @@ TEST(BuildEngineTest, StatusCallbacks) {
 TEST(BuildEngineTest, SimpleCycle) {
   SimpleBuildEngineDelegate delegate;
   core::BuildEngine engine(delegate);
-  engine.addRule({
-      "A", {},
-      simpleAction({"B"}, [&](const std::vector<int>& inputs) {
-          return 2; }) });
-  engine.addRule({
-      "B", {},
-      simpleAction({"A"}, [&](const std::vector<int>& inputs) {
-          return 2; }) });
+  engine.addRule(std::unique_ptr<core::Rule>(new SimpleRule(
+      "A", {"B"}, [&](const std::vector<int>& inputs) {
+          return 2; })));
+  engine.addRule(std::unique_ptr<core::Rule>(new SimpleRule(
+      "B", {"A"}, [&](const std::vector<int>& inputs) {
+          return 2; })));
 
   // Build the result.
   auto result = engine.build("A");
@@ -737,75 +751,67 @@ TEST(BuildEngineTest, CycleDuringScanningFromTop) {
   SimpleBuildEngineDelegate delegate;
   core::BuildEngine engine(delegate);
   unsigned iteration = 0;
-  engine.addRule({
-      "A", {},
-      [&](BuildEngine& engine) {
-        return
-            new SimpleTask(
-                [&]() -> std::vector<std::string> {
-                  switch (iteration) {
-                  case 0:
-                    return { "B", "C" };
-                  case 1:
-                    return { "B" };
-                  default:
-                    llvm::report_fatal_error("unexpected iterator");
-                  }
-                },
-                [&](const std::vector<int>& inputs) {
-                  return 2; });
-        },
-      [&](BuildEngine&, const Rule&, const ValueType&) {
-        // Always rebuild
-        return true;
+  class CycleRule: public Rule {
+  public:
+    typedef std::function<std::vector<std::string>()> InputFnType;
+    typedef std::function<int(const std::vector<int>&)> ComputeFnType;
+  private:
+    InputFnType input;
+    ComputeFnType compute;
+    bool valid;
+  public:
+    CycleRule(const KeyType& key, InputFnType input, ComputeFnType compute, bool valid = true)
+      : Rule(key), input(input), compute(compute), valid(valid) { }
+    Task* createTask(BuildEngine&) override {
+      return new SimpleTask(input, compute);
+    }
+    bool isResultValid(BuildEngine&, const ValueType&) override {
+      return valid;
+    }
+  };
+  engine.addRule(std::unique_ptr<core::Rule>(new CycleRule(
+    "A",
+    [&iteration]() -> std::vector<std::string> {
+      switch (iteration) {
+      case 0:
+        return { "B", "C" };
+      case 1:
+        return { "B" };
+      default:
+        llvm::report_fatal_error("unexpected iterator");
       }
-    });
-  engine.addRule({
-      "B", {},
-      [&](BuildEngine& engine) {
-        return
-            new SimpleTask(
-                [&]() -> std::vector<std::string> {
-                  switch (iteration) {
-                  case 0:
-                    return { "C" };
-                  case 1:
-                    return { "C" };
-                  default:
-                    llvm::report_fatal_error("unexpected iterator");
-                  }
-                },
-                [&](const std::vector<int>& inputs) {
-                  return 2; });
-        },
-      [&](BuildEngine&, const Rule&, const ValueType&) {
-        // Always rebuild
-        return true;
+    },
+    [](const std::vector<int>& inputs) { return 2; }
+  )));
+  engine.addRule(std::unique_ptr<core::Rule>(new CycleRule(
+    "B",
+    [&iteration]() -> std::vector<std::string> {
+      switch (iteration) {
+      case 0:
+        return { "C" };
+      case 1:
+        return { "C" };
+      default:
+        llvm::report_fatal_error("unexpected iterator");
       }
-    });
-  engine.addRule({
-      "C", {},
-      [&](BuildEngine& engine) {
-        return
-            new SimpleTask(
-                [&]() -> std::vector<std::string> {
-                  switch (iteration) {
-                  case 0:
-                    return { };
-                  case 1:
-                    return { "B" };
-                  default:
-                    llvm::report_fatal_error("unexpected iterator");
-                  }
-                },
-                [&](const std::vector<int>& inputs) {
-                  return 2; });
-        },
-      [&](BuildEngine&, const Rule&, const ValueType&) {
-        // Always rebuild
-        return false;
+    },
+    [](const std::vector<int>& inputs) { return 2; }
+  )));
+  engine.addRule(std::unique_ptr<core::Rule>(new CycleRule(
+    "C",
+    [&iteration]() -> std::vector<std::string> {
+      switch (iteration) {
+      case 0:
+        return { };
+      case 1:
+        return { "B" };
+      default:
+        llvm::report_fatal_error("unexpected iterator");
       }
-    });
+    },
+    [](const std::vector<int>& inputs) { return 2; },
+    false // always rebuild
+  )));
 
   // Build the result.
   {
@@ -866,30 +872,29 @@ TEST(BuildEngineTest, basicIncrementalSignatureChange) {
       engine.attachDB(std::move(db), &error);
     }
 
-    engine.addRule({
-      "value-A", basic::CommandSignature(sigA), simpleAction({}, [&] (const std::vector<int>& inputs) {
+    engine.addRule(std::unique_ptr<core::Rule>(new SimpleRule(
+      "value-A", {}, [&] (const std::vector<int>& inputs) {
         builtKeys.push_back("value-A");
-        return valueA; }),
-      [&](core::BuildEngine&, const Rule& rule, const ValueType& value) {
+        return valueA; },
+      [&](const ValueType& value) {
         return valueA == intFromValue(value);
-      } });
-    engine.addRule({
-      "value-B", basic::CommandSignature(sigB), simpleAction({}, [&] (const std::vector<int>& inputs) {
+      }, nullptr, basic::CommandSignature(sigA))));
+    engine.addRule(std::unique_ptr<core::Rule>(new SimpleRule(
+      "value-B", {}, [&] (const std::vector<int>& inputs) {
         builtKeys.push_back("value-B");
-        return valueB; }),
-      [&](core::BuildEngine&, const Rule& rule, const ValueType& value) {
+        return valueB; },
+      [&](const ValueType& value) {
         return valueB == intFromValue(value);
-      } });
-    engine.addRule({
-      "value-R", {},
-      simpleAction({"value-A", "value-B"},
+      }, nullptr, basic::CommandSignature(sigB))));
+    engine.addRule(std::unique_ptr<core::Rule>(new SimpleRule(
+      "value-R", {"value-A", "value-B"},
                    [&] (const std::vector<int>& inputs) {
                      EXPECT_EQ(2U, inputs.size());
                      EXPECT_EQ(valueA, inputs[0]);
                      EXPECT_EQ(valueB, inputs[1]);
                      builtKeys.push_back("value-R");
                      return inputs[0] * inputs[1] * 5;
-                   }) });
+                   })));
   };
 
   std::unique_ptr<core::BuildEngine> engine;
@@ -933,8 +938,8 @@ TEST(BuildEngineTest, concurrentProtection) {
   // Basic 1-rule build graph
   SimpleBuildEngineDelegate delegate;
   core::BuildEngine engine(delegate);
-  engine.addRule({
-    "result", {}, simpleAction({}, [&] (const std::vector<int>& inputs) {
+  engine.addRule(std::unique_ptr<core::Rule>(new SimpleRule(
+    "result", {}, [&] (const std::vector<int>& inputs) {
       auto lock = std::unique_lock<std::mutex>(mutex);
       started = true;
       started_cv.notify_all();
@@ -943,7 +948,7 @@ TEST(BuildEngineTest, concurrentProtection) {
       }
       return 1;
     })
-  });
+  ));
 
   // Start a build on another thread
   auto build1 = std::async( std::launch::async, [&](){

--- a/unittests/Core/BuildEngineTest.cpp
+++ b/unittests/Core/BuildEngineTest.cpp
@@ -625,6 +625,7 @@ TEST(BuildEngineTest, discoveredDependencies) {
       builtKeys.push_back(key);
       return new TaskWithDiscoveredDependency(dep);
     }
+    bool isResultValid(BuildEngine&, const ValueType&) override { return true; }
   };
   engine.addRule(std::unique_ptr<core::Rule>(new RuleWithDiscoveredDependency("output", builtKeys, valueB)));
 

--- a/unittests/Core/DepsBuildEngineTest.cpp
+++ b/unittests/Core/DepsBuildEngineTest.cpp
@@ -225,6 +225,7 @@ TEST(DepsBuildEngineTest, BogusConcurrentDepScan) {
       builtKeys.push_back(key);
       return new DynamicTask();
     }
+    bool isResultValid(BuildEngine&, const ValueType&) override { return true; }
   };
   engine.addRule(std::unique_ptr<core::Rule>(new DynamicRule("output", builtKeys)));
 


### PR DESCRIPTION
In this change, BuildSystem, et al. still use std::function objects.
However, this change lays the foundation for eliminating those.