### PR TITLE
Fix remaining tests for Android

### DIFF
--- a/lib/Basic/PlatformUtility.cpp
+++ b/lib/Basic/PlatformUtility.cpp
@@ -348,8 +348,17 @@ std::string sys::makeTmpDir() {
   CreateDirectoryW((LPCWSTR)wPath.data(), NULL);
   return std::string(path);
 #else
-  char tmpDirPathBuf[] = "/tmp/fileXXXXXX";
-  return std::string(mkdtemp(tmpDirPathBuf));
+  if (const char *tmpDir = std::getenv("TMPDIR")) {
+    char *tmpDirPath = nullptr;
+    asprintf(&tmpDirPath, "%s/fileXXXXXX", tmpDir);
+    auto tmpDirString = std::string(mkdtemp(tmpDirPath));
+    free(tmpDirPath);
+    return tmpDirString;
+  }
+  else {
+    char tmpDirPathBuf[] = "/tmp/fileXXXXXX";
+    return std::string(mkdtemp(tmpDirPathBuf));
+  }
 #endif
 }
 

--- a/tests/BuildSystem/Build/dep-scan-order.llbuild
+++ b/tests/BuildSystem/Build/dep-scan-order.llbuild
@@ -37,7 +37,7 @@
 # Check that a modification triggers both uses.
 #
 # RUN: echo "MOD" >> %t.build/input
-# RUN: %{llbuild} buildsystem build --serial --chdir %t.build --trace /tmp/x.trace > %t3.out
+# RUN: %{llbuild} buildsystem build --serial --chdir %t.build --trace %t.trace > %t3.out
 # RUN: %{FileCheck} --input-file=%t3.out %s --check-prefix=CHECK-AFTER-MOD
 # RUN: diff %t.build/input %t.build/generated-input
 # RUN: diff %t.build/input %t.build/output

--- a/tests/lit.cfg
+++ b/tests/lit.cfg
@@ -106,7 +106,7 @@ config.substitutions.append( ('%{swiftc-platform-flags}', "" if not config.osx_s
 config.substitutions.append( ('%{build-dir}', llbuild_obj_root) ) 
 config.substitutions.append( ('%{env}', which('env')) )
 config.substitutions.append( ('%{sort}', which('sort')) )
-config.substitutions.append( ('%{sh-invoke}', '/bin/sh') )
+config.substitutions.append( ('%{sh-invoke}', os.environ.get("PREFIX", "") + '/bin/sh') )
 
 ###
 


### PR DESCRIPTION
Used to build and test llbuild and SPM natively on Android in [the Termux app](https://termux.com/). I can modify lit.cfg to only check the `PREFIX` env var on Android if there's any worry that it might be spuriously set on other platforms.

`makeTmpDir` is only checked by the unit tests, which I noticed are not run by the CI anymore, maybe because those llbuild test binaries were moved around? I see the following warning on both the linux and mac CI for recent pulls:
```
lit.py: /home/buildnode/jenkins/workspace/swift-llbuild-PR-Linux-smoke-test/llvm-project/llvm/utils/lit/lit/discovery.py:210: warning: test suite 'llbuild-unit' contained no tests
```
Running them manually shows that no tests fail after this pull on Android.