### PR TITLE
[Core] Fix potential nullptr dereference in addRule

### DIFF
--- a/lib/Core/BuildEngine.cpp
+++ b/lib/Core/BuildEngine.cpp
@@ -1379,12 +1379,13 @@ public:
   RuleInfo& addRule(KeyID keyID, std::unique_ptr<Rule>&& rule) {
     auto result = ruleInfos.emplace(keyID, RuleInfo(keyID, std::move(rule)));
     if (!result.second) {
-      delegate.error("attempt to register duplicate rule \"" + rule->key + "\"\n");
+      RuleInfo& ruleInfo = result.first->second;
+      delegate.error("attempt to register duplicate rule \"" + ruleInfo.rule->key + "\"\n");
 
       // Set cancelled, but return something 'valid' for use until it is
       // processed.
       buildCancelled = true;
-      return result.first->second;
+      return ruleInfo;
     }
 
     // If we have a database attached, retrieve any stored result.

--- a/unittests/Core/BuildEngineTest.cpp
+++ b/unittests/Core/BuildEngineTest.cpp
@@ -200,6 +200,22 @@ TEST(BuildEngineTest, basic) {
   EXPECT_TRUE(builtKeys.empty());
 }
 
+
+TEST(BuildEngineTest, duplicateRule) {
+  SimpleBuildEngineDelegate delegate;
+  delegate.expectedError = true;
+
+  core::BuildEngine engine(delegate);
+  engine.addRule(std::unique_ptr<core::Rule>(new SimpleRule(
+    "value-A", {}, [&] (const std::vector<int>& inputs) { return 1; })));
+  engine.addRule(std::unique_ptr<core::Rule>(new SimpleRule(
+    "value-A", {}, [&] (const std::vector<int>& inputs) { return 2; })));
+
+  EXPECT_EQ(1U, delegate.errors.size());
+  EXPECT_TRUE(delegate.errors[0].find("duplicate") != std::string::npos);
+}
+
+
 TEST(BuildEngineTest, basicWithSharedInput) {
   // Check a build graph with a input key shared by multiple rules.
   //


### PR DESCRIPTION
Duplicate rule registration could trigger nullptr dereference now that
rules are passed as unique_ptr.

rdar://problem/58566350