### PR TITLE
[Core] Refactor key into an encapsulated type

### DIFF
--- a/include/llbuild/Core/BuildEngine.h
+++ b/include/llbuild/Core/BuildEngine.h
@@ -34,8 +34,26 @@
 namespace llbuild {
 namespace core {
 
-// FIXME: Need to abstract KeyType;
-typedef std::string KeyType;
+class KeyType {
+private:
+  std::string key;
+
+public:
+  KeyType() { }
+  KeyType(const std::string& key) : key(key) { }
+  KeyType(const char* key) : key(key) { }
+  KeyType(llvm::StringRef ref) : key(ref) { }
+  KeyType(const char* data, size_t length) : key(data, length) { }
+
+  bool operator==(const KeyType& rhs) const { return key == rhs.key; }
+  bool operator<(const KeyType& rhs) const { return key < rhs.key; }
+
+  const std::string& str() const { return key; }
+  const char* data() const { return key.data(); }
+  const char* c_str() const { return key.c_str(); }
+  size_t size() const { return key.size(); }
+};
+
 typedef std::vector<uint8_t> ValueType;
 
 class BuildDB;
@@ -429,6 +447,18 @@ public:
 };
 
 }
+}
+
+namespace std
+{
+  template<>
+  struct hash<llbuild::core::KeyType>
+  {
+    size_t operator()(const llbuild::core::KeyType& key) const
+    {
+      return hash<std::string>{}(key.str());
+    }
+  };
 }
 
 #endif

--- a/lib/Commands/BuildEngineCommand.cpp
+++ b/lib/Commands/BuildEngineCommand.cpp
@@ -90,7 +90,7 @@ struct AckermannKey {
 
   /// Create an Ackermann key from the encoded representation.
   AckermannKey(const core::KeyType& key) {
-      auto keyString = StringRef(key);
+      auto keyString = StringRef(key.str());
       assert(keyString.startswith("ack(") && keyString.endswith(")"));
       auto arguments = keyString.split("(").second.split(")").first.split(",");
       m = 0;

--- a/lib/Commands/BuildSystemCommand.cpp
+++ b/lib/Commands/BuildSystemCommand.cpp
@@ -630,7 +630,7 @@ public:
   llvm::StringMap<KeyID> keyTable;
 
   const KeyID getKeyID(const KeyType& key) override {
-    auto it = keyTable.insert(std::make_pair(key, KeyID::novalue())).first;
+    auto it = keyTable.insert(std::make_pair(key.str(), KeyID::novalue())).first;
     return KeyID(it->getKey().data());
   }
 

--- a/lib/Commands/NinjaBuildCommand.cpp
+++ b/lib/Commands/NinjaBuildCommand.cpp
@@ -1681,7 +1681,7 @@ std::unique_ptr<core::Rule> NinjaBuildEngineDelegate::lookupRule(const core::Key
   // FIXME: This is frequently a redundant lookup, given that the caller might
   // well have had the Node* available. This is something that would be nice
   // to avoid when we support generic key types.
-  ninja::Node* node = context->manifest->findOrCreateNode(workingDirectory, key);
+  ninja::Node* node = context->manifest->findOrCreateNode(workingDirectory, key.str());
 
   class NinjaInputRule: public core::Rule {
     BuildContext* context;
@@ -1716,7 +1716,7 @@ void NinjaBuildEngineDelegate::cycleDetected(
   for (const auto* rule: cycle) {
     if (!first)
       messageStream << " ->";
-    messageStream << " \"" << rule->key << '"';
+    messageStream << " \"" << rule->key.str() << '"';
     first = false;
   }
 

--- a/lib/Core/BuildEngineTrace.cpp
+++ b/lib/Core/BuildEngineTrace.cpp
@@ -102,7 +102,7 @@ const char* BuildEngineTrace::getRuleName(const Rule* rule) {
   // Report the newly seen rule.
   // FIXME: This is currently encoding the key by merely stripping the
   // non-printable characters. Should probably encode this into a real encoding.
-  std::string encoded = rule->key;
+  std::string encoded = rule->key.str();
   encoded.erase(
                 std::remove_if(encoded.begin(), encoded.end(),
                                [](char c) -> bool {

--- a/products/libllbuild/BuildDB-C-API.cpp
+++ b/products/libllbuild/BuildDB-C-API.cpp
@@ -126,7 +126,7 @@ public:
     // The RHS of the mapping is actually ignored, we use the StringMap's ptr
     // identity because it allows us to efficiently map back to the key string
     // in `getRuleInfoForKey`.
-    auto it = keyTable.insert(std::make_pair(key, KeyID::novalue())).first;
+    auto it = keyTable.insert(std::make_pair(key.str(), KeyID::novalue())).first;
     return KeyID(it->getKey().data());
   }
   

--- a/products/libllbuild/BuildKey-C-API-Private.h
+++ b/products/libllbuild/BuildKey-C-API-Private.h
@@ -30,11 +30,11 @@ private:
 public:
   
   CAPIBuildKey(const BuildKey &buildKey): hasIdentifier(false), internalBuildKey(buildKey) {
-    hashValue = std::hash<std::string>{}(internalBuildKey.getKeyData());
+    hashValue = std::hash<llbuild::core::KeyType>{}(internalBuildKey.getKeyData());
   }
   
   CAPIBuildKey(const BuildKey &buildKey, llbuild::core::KeyID identifier): identifier(identifier), hasIdentifier(true), internalBuildKey(buildKey) {
-    hashValue = std::hash<std::string>{}(internalBuildKey.getKeyData());
+    hashValue = std::hash<llbuild::core::KeyType>{}(internalBuildKey.getKeyData());
   }
   
   BuildKey &getInternalBuildKey() {

--- a/products/libllbuild/BuildKey-C-API.cpp
+++ b/products/libllbuild/BuildKey-C-API.cpp
@@ -90,7 +90,11 @@ static BuildKey::Kind publicToInternalBuildKeyKind(llb_build_key_kind_t kind) {
 }
 
 llb_build_key_t *llb_build_key_make(const llb_data_t *data) {
-  return (llb_build_key_t *)new CAPIBuildKey(BuildKey::fromData(core::KeyType(data->data, data->data + data->length)));
+  return (llb_build_key_t *)new CAPIBuildKey(
+    BuildKey::fromData(core::KeyType(
+      reinterpret_cast<const char*>(data->data), static_cast<size_t>(data->length)
+    ))
+  );
 }
 
 bool llb_build_key_equal(llb_build_key_t *key1, llb_build_key_t *key2) {

--- a/products/libllbuild/BuildSystem-C-API.cpp
+++ b/products/libllbuild/BuildSystem-C-API.cpp
@@ -572,7 +572,7 @@ public:
     return getFrontend().initialize();
   }
 
-  bool build(const core::KeyType& key) {
+  bool build(llvm::StringRef key) {
     // Reset mutable build state.
     frontendDelegate->resetForBuild();
 
@@ -581,7 +581,7 @@ public:
     return getFrontend().build(key);
   }
 
-  bool buildNode(const core::KeyType& key) {
+  bool buildNode(llvm::StringRef key) {
     frontendDelegate->resetForBuild();
     return getFrontend().buildNode(key);
   }
@@ -843,12 +843,12 @@ bool llb_buildsystem_initialize(llb_buildsystem_t* system_p) {
 
 bool llb_buildsystem_build(llb_buildsystem_t* system_p, const llb_data_t* key) {
   CAPIBuildSystem* system = (CAPIBuildSystem*) system_p;
-  return system->build(core::KeyType((const char*)key->data, key->length));
+  return system->build(llvm::StringRef((const char*)key->data, key->length));
 }
 
 bool llb_buildsystem_build_node(llb_buildsystem_t* system_p, const llb_data_t* key) {
   CAPIBuildSystem* system = (CAPIBuildSystem*) system_p;
-  return system->buildNode(core::KeyType((const char*)key->data, key->length));
+  return system->buildNode(llvm::StringRef((const char*)key->data, key->length));
 }
 
 void llb_buildsystem_cancel(llb_buildsystem_t* system_p) {

--- a/products/libllbuild/Core-C-API.cpp
+++ b/products/libllbuild/Core-C-API.cpp
@@ -67,7 +67,7 @@ class CAPIBuildEngineDelegate : public BuildEngineDelegate {
   virtual std::unique_ptr<Rule> lookupRule(const KeyType& key) override {
     CAPIRule* capiRule = new CAPIRule(key);
     capiRule->engineContext = cAPIDelegate.context;
-    llb_data_t key_data{ key.length(), (const uint8_t*)key.data() };
+    llb_data_t key_data{ key.size(), (const uint8_t*)key.data() };
     cAPIDelegate.lookup_rule(cAPIDelegate.context, &key_data, &capiRule->rule);
 
     // FIXME: Check that the client created the rule appropriately. We should

--- a/unittests/Core/BuildEngineTest.cpp
+++ b/unittests/Core/BuildEngineTest.cpp
@@ -51,7 +51,7 @@ private:
   virtual void cycleDetected(const std::vector<core::Rule*>& items) override {
     cycle.clear();
     std::transform(items.begin(), items.end(), std::back_inserter(cycle),
-                   [](auto rule) { return std::string(rule->key); });
+                   [](auto rule) { return rule->key.str(); });
   }
 
   virtual bool shouldResolveCycle(const std::vector<Rule*>& items,
@@ -638,7 +638,7 @@ TEST(BuildEngineTest, discoveredDependencies) {
                                  std::vector<std::string>& builtKeys, int& dep)
       : Rule(key), builtKeys(builtKeys), dep(dep) { }
     Task* createTask(BuildEngine&) override {
-      builtKeys.push_back(key);
+      builtKeys.push_back(key.str());
       return new TaskWithDiscoveredDependency(dep);
     }
     bool isResultValid(BuildEngine&, const ValueType&) override { return true; }
@@ -770,7 +770,7 @@ TEST(BuildEngineTest, CycleDuringScanningFromTop) {
   unsigned iteration = 0;
   class CycleRule: public Rule {
   public:
-    typedef std::function<std::vector<std::string>()> InputFnType;
+    typedef std::function<std::vector<KeyType>()> InputFnType;
     typedef std::function<int(const std::vector<int>&)> ComputeFnType;
   private:
     InputFnType input;
@@ -788,7 +788,7 @@ TEST(BuildEngineTest, CycleDuringScanningFromTop) {
   };
   engine.addRule(std::unique_ptr<core::Rule>(new CycleRule(
     "A",
-    [&iteration]() -> std::vector<std::string> {
+    [&iteration]() -> std::vector<KeyType> {
       switch (iteration) {
       case 0:
         return { "B", "C" };
@@ -802,7 +802,7 @@ TEST(BuildEngineTest, CycleDuringScanningFromTop) {
   )));
   engine.addRule(std::unique_ptr<core::Rule>(new CycleRule(
     "B",
-    [&iteration]() -> std::vector<std::string> {
+    [&iteration]() -> std::vector<KeyType> {
       switch (iteration) {
       case 0:
         return { "C" };
@@ -816,7 +816,7 @@ TEST(BuildEngineTest, CycleDuringScanningFromTop) {
   )));
   engine.addRule(std::unique_ptr<core::Rule>(new CycleRule(
     "C",
-    [&iteration]() -> std::vector<std::string> {
+    [&iteration]() -> std::vector<KeyType> {
       switch (iteration) {
       case 0:
         return { };

--- a/unittests/Core/DepsBuildEngineTest.cpp
+++ b/unittests/Core/DepsBuildEngineTest.cpp
@@ -137,7 +137,7 @@ public:
 // previously present (and thus recorded as an input dependency) but which is no
 // longer present.
 TEST(DepsBuildEngineTest, BogusConcurrentDepScan) {
-  std::vector<std::string> builtKeys;
+  std::vector<KeyType> builtKeys;
   SimpleBuildEngineDelegate delegate;
   core::BuildEngine engine(delegate);
   
@@ -217,9 +217,9 @@ TEST(DepsBuildEngineTest, BogusConcurrentDepScan) {
   };
 
   class DynamicRule: public Rule {
-    std::vector<std::string>& builtKeys;
+    std::vector<KeyType>& builtKeys;
   public:
-    DynamicRule(const KeyType& key, std::vector<std::string>& builtKeys)
+    DynamicRule(const KeyType& key, std::vector<KeyType>& builtKeys)
       : Rule(key), builtKeys(builtKeys) { }
     Task* createTask(BuildEngine&) override {
       builtKeys.push_back(key);
@@ -232,11 +232,11 @@ TEST(DepsBuildEngineTest, BogusConcurrentDepScan) {
   // Build the first result.
   EXPECT_EQ(2 * 3 * 5 * 7, intFromValue(engine.build("output")));
   EXPECT_EQ(5U, builtKeys.size());
-  EXPECT_EQ("output", builtKeys[0]);
-  EXPECT_EQ("dir-list-input", builtKeys[1]);
-  EXPECT_EQ("dir-list", builtKeys[2]);
-  EXPECT_EQ("input-2", builtKeys[3]);
-  EXPECT_EQ("input-3", builtKeys[4]);
+  EXPECT_EQ(KeyType("output"), builtKeys[0]);
+  EXPECT_EQ(KeyType("dir-list-input"), builtKeys[1]);
+  EXPECT_EQ(KeyType("dir-list"), builtKeys[2]);
+  EXPECT_EQ(KeyType("input-2"), builtKeys[3]);
+  EXPECT_EQ(KeyType("input-3"), builtKeys[4]);
 
   // Now change the dynamic contents and rebuild.
   builtKeys.clear();
@@ -246,10 +246,10 @@ TEST(DepsBuildEngineTest, BogusConcurrentDepScan) {
 #endif
   EXPECT_EQ(3 * 7, intFromValue(engine.build("output")));
   EXPECT_EQ(4U, builtKeys.size());
-  EXPECT_EQ("dir-list-input", builtKeys[0]);
-  EXPECT_EQ("dir-list", builtKeys[1]);
-  EXPECT_EQ("output", builtKeys[2]);
-  EXPECT_EQ("input-3", builtKeys[3]);
+  EXPECT_EQ(KeyType("dir-list-input"), builtKeys[0]);
+  EXPECT_EQ(KeyType("dir-list"), builtKeys[1]);
+  EXPECT_EQ(KeyType("output"), builtKeys[2]);
+  EXPECT_EQ(KeyType("input-3"), builtKeys[3]);
 }
 
 TEST(DepsBuildEngineTest, KeysWithNull) {


### PR DESCRIPTION
Key remains a std::string under the covers, but clients must now be
explicit when they wish to use it as such.