### PR TITLE
[Swift/C-API] Enable commands to return values

### DIFF
--- a/examples/c-api/buildsystem/main.c
+++ b/examples/c-api/buildsystem/main.c
@@ -92,6 +92,7 @@ fancy_tool_create_command(void *context, const llb_data_t* name) {
   delegate.start = fancy_command_start;
   delegate.provide_value = fancy_command_provide_value;
   delegate.execute_command = fancy_command_execute_command;
+  delegate.execute_command_ex = NULL;
   return llb_buildsystem_external_command_create(name, delegate);
 }
 

--- a/examples/c-api/buildsystem/main.c
+++ b/examples/c-api/buildsystem/main.c
@@ -93,6 +93,7 @@ fancy_tool_create_command(void *context, const llb_data_t* name) {
   delegate.provide_value = fancy_command_provide_value;
   delegate.execute_command = fancy_command_execute_command;
   delegate.execute_command_ex = NULL;
+  delegate.is_result_valid = NULL;
   return llb_buildsystem_external_command_create(name, delegate);
 }
 

--- a/include/llbuild/BuildSystem/ExternalCommand.h
+++ b/include/llbuild/BuildSystem/ExternalCommand.h
@@ -75,9 +75,6 @@ class ExternalCommand : public Command {
   /// Whether a prior result has been found.
   bool hasPriorResult = false;
   
-  /// Compute the output result for the command.
-  BuildValue computeCommandResult(BuildSystemCommandInterface& bsci);
-
   /// Check if it is legal to only update the result (versus rerunning)
   /// because the outputs are newer than all of the inputs.
   bool canUpdateIfNewerWithResult(const BuildValue& result);
@@ -111,6 +108,9 @@ protected:
       basic::QueueJobContext* context,
       llvm::Optional<basic::ProcessCompletionFn> completionFn = {llvm::None}) = 0;
   
+  /// Compute the output result for the command.
+  virtual BuildValue computeCommandResult(BuildSystemCommandInterface& bsci);
+
 public:
   using Command::Command;
 

--- a/products/libllbuild/BuildSystem-C-API.cpp
+++ b/products/libllbuild/BuildSystem-C-API.cpp
@@ -789,6 +789,19 @@ class CAPIExternalCommand : public ExternalCommand {
 
     return ExternalCommand::computeCommandResult(bsci);
   }
+
+  bool isResultValid(BuildSystem& system, const BuildValue& value) override {
+    if (cAPIDelegate.is_result_valid) {
+      auto value_p = (llb_build_value *)new CAPIBuildValue(BuildValue(value));
+      return cAPIDelegate.is_result_valid(
+        cAPIDelegate.context,
+        (llb_buildsystem_command_t*)this,
+        value_p
+      );
+    }
+
+    return ExternalCommand::isResultValid(system, value);
+  }
   
 public:
   CAPIExternalCommand(StringRef name,

--- a/products/libllbuild/BuildValue-C-API.cpp
+++ b/products/libllbuild/BuildValue-C-API.cpp
@@ -102,6 +102,13 @@ llb_build_value *llb_build_value_make(llb_data_t *data) {
   return (llb_build_value *)new CAPIBuildValue(std::move(buildValue));
 }
 
+llb_build_value *llb_build_value_clone(llb_build_value *value) {
+  // Explictly copy constructing a new BuildValue
+  return (llb_build_value *)new CAPIBuildValue(
+    BuildValue(((CAPIBuildValue *)value)->getInternalBuildValue())
+  );
+}
+
 llb_build_value_kind_t llb_build_value_get_kind(llb_build_value *value) {
   return ((CAPIBuildValue *)value)->getKind();
 }

--- a/products/libllbuild/include/llbuild/buildsystem.h
+++ b/products/libllbuild/include/llbuild/buildsystem.h
@@ -617,10 +617,24 @@ typedef struct llb_buildsystem_external_command_delegate_t_ {
   /// system using the command interface. It can add additional work onto the
   /// execution queue, so long as it arranges to only notify the system of
   /// completion once all that work is complete.
-  bool (*execute_command)(void* context, llb_buildsystem_command_t* command,
+  ///
+  /// If defined, the build value returning `execute_command_ex` variant is
+  /// called first. If an 'invalid' buile value is returned, the bindings will
+  /// then try calling the legacy `execute_command` variant if it is defined.
+  ///
+  /// The C API takes ownership of the value returned by `execute_command_ex`.
+  bool (*execute_command)(void* context,
+                          llb_buildsystem_command_t* command,
                           llb_buildsystem_command_interface_t* bsci,
                           llb_task_t* task,
                           llb_buildsystem_queue_job_context_t* job_context);
+
+  llb_build_value* (*execute_command_ex)(void* context,
+                                         llb_buildsystem_command_t* command,
+                                         llb_buildsystem_command_interface_t* bsci,
+                                         llb_task_t* task,
+                                         llb_buildsystem_queue_job_context_t* job_context);
+
 } llb_buildsystem_external_command_delegate_t;
 
 /// Create a new external command instance.

--- a/products/libllbuild/include/llbuild/buildsystem.h
+++ b/products/libllbuild/include/llbuild/buildsystem.h
@@ -635,6 +635,15 @@ typedef struct llb_buildsystem_external_command_delegate_t_ {
                                          llb_task_t* task,
                                          llb_buildsystem_queue_job_context_t* job_context);
 
+  /// Called by the build system to determine if the current build result
+  /// remains valid.
+  ///
+  /// Clients providing custom build values via execute_command_ex SHOULD supply
+  /// this accompanying method.
+  bool (*is_result_valid)(void* context,
+                          llb_buildsystem_command_t* command,
+                          const llb_build_value* value);
+
 } llb_buildsystem_external_command_delegate_t;
 
 /// Create a new external command instance.

--- a/products/libllbuild/include/llbuild/buildvalue.h
+++ b/products/libllbuild/include/llbuild/buildvalue.h
@@ -103,6 +103,7 @@ typedef uint64_t llb_build_value_command_signature_t LLBUILD_SWIFT_NAME(BuildVal
 typedef struct llb_build_value_ llb_build_value;
 
 LLBUILD_EXPORT llb_build_value * llb_build_value_make(llb_data_t * data);
+LLBUILD_EXPORT llb_build_value * llb_build_value_clone(llb_build_value * value);
 LLBUILD_EXPORT llb_build_value_kind_t llb_build_value_get_kind(llb_build_value * value);
 LLBUILD_EXPORT void llb_build_value_get_value_data(llb_build_value * value, void *_Nullable context, void (*_Nullable iteration)(void *_Nullable context, uint8_t data));
 LLBUILD_EXPORT void llb_build_value_destroy(llb_build_value * value);

--- a/products/llbuildSwift/BuildSystemBindings.swift
+++ b/products/llbuildSwift/BuildSystemBindings.swift
@@ -117,9 +117,17 @@ private final class ToolWrapper {
         _delegate.start = { return BuildSystem.toCommandWrapper($0!).start($1!, $2!, $3!) }
         _delegate.provide_value = { return BuildSystem.toCommandWrapper($0!).provideValue($1!, $2!, $3!, $4!, $5) }
         _delegate.execute_command = { return BuildSystem.toCommandWrapper($0!).executeCommand($1!, $2!, $3!, $4!) }
-        _delegate.execute_command_ex = {
-            var value: BuildValue = BuildSystem.toCommandWrapper($0!).executeCommand($1!, $2!, $3!, $4!)
-            return BuildValue.move(&value)
+        if let _ = command as? ProducesCustomBuildValue {
+            _delegate.execute_command_ex = {
+                var value: BuildValue = BuildSystem.toCommandWrapper($0!).executeCommand($1!, $2!, $3!, $4!)
+                return BuildValue.move(&value)
+            }
+            _delegate.is_result_valid = {
+                return BuildSystem.toCommandWrapper($0!).isResultValid($1!, $2!)
+            }
+        } else {
+            _delegate.execute_command_ex = nil
+            _delegate.is_result_valid = nil
         }
 
         // Create the low-level command.
@@ -166,12 +174,21 @@ public protocol ExternalCommand: class {
     /// - returns: True on success.
     func execute(_ command: Command, _ commandInterface: BuildSystemCommandInterface) -> Bool
 
+}
+
+public protocol ProducesCustomBuildValue: class {
     /// Called to execute the given command that produces a custom build value.
     ///
     /// - command: A handle to the executing command.
     /// - commandInterface: A handle to the build system's command interface.
     /// - returns: Produced build value.
     func execute(_ command: Command, _ commandInterface: BuildSystemCommandInterface) -> BuildValue
+
+    /// Called to check if the current result for this command remains valid.
+    ///
+    /// - command: A handle to the executing command.
+    /// - buildValue: The most recently computed build value.
+    func isResultValid(_ command: Command, _ buildValue: BuildValue) -> Bool
 }
 
 // Extension to provide a default implementation of execute(_ Command, _ commandInterface) to allow clients to
@@ -179,10 +196,6 @@ public protocol ExternalCommand: class {
 public extension ExternalCommand {
     func execute(_ command: Command, _ commandInterface: BuildSystemCommandInterface) -> Bool {
         return execute(command)
-    }
-
-    func execute(_ command: Command, _ commandInterface: BuildSystemCommandInterface) -> BuildValue {
-        return BuildValue.Invalid()
     }
 
     // If this implementation is invoked, it means that the client implementing ExternalCommand did not
@@ -234,7 +247,15 @@ private final class CommandWrapper {
 
     func executeCommand(_: OpaquePointer, _ bsci: OpaquePointer, _ task: OpaquePointer, _ jobContext: OpaquePointer) -> BuildValue {
         let commandInterface = BuildSystemCommandInterface(bsci, task)
-        return command.execute(_command, commandInterface)
+        return (command as! ProducesCustomBuildValue).execute(_command, commandInterface)
+    }
+
+    func isResultValid(_: OpaquePointer, _ value: OpaquePointer) -> Bool {
+        guard let buildValue = BuildValue.construct(from: value) else {
+            fatalError("Could not decode incoming build value.")
+        }
+
+        return (command as! ProducesCustomBuildValue).isResultValid(_command, buildValue)
     }
 }
 

--- a/unittests/CAPI/BuildSystem-C-API.cpp
+++ b/unittests/CAPI/BuildSystem-C-API.cpp
@@ -146,6 +146,7 @@ depinfo_tester_tool_create_command(void *context, const llb_data_t* name) {
   delegate.provide_value = depinfo_tester_command_provide_value;
   delegate.execute_command = depinfo_tester_command_execute_command;
   delegate.execute_command_ex = NULL;
+  delegate.is_result_valid = NULL;
   return llb_buildsystem_external_command_create(name, delegate);
 }
 

--- a/unittests/CAPI/BuildSystem-C-API.cpp
+++ b/unittests/CAPI/BuildSystem-C-API.cpp
@@ -145,6 +145,7 @@ depinfo_tester_tool_create_command(void *context, const llb_data_t* name) {
   delegate.start = depinfo_tester_command_start;
   delegate.provide_value = depinfo_tester_command_provide_value;
   delegate.execute_command = depinfo_tester_command_execute_command;
+  delegate.execute_command_ex = NULL;
   return llb_buildsystem_external_command_create(name, delegate);
 }
 


### PR DESCRIPTION
Adds support returning custom build values from external commands
provided by BuildSystem Swift/C-API clients.

rdar://problem/58553449