### PR TITLE
Fix tracing TSAN warning

### DIFF
--- a/include/llbuild/Basic/Tracing.h
+++ b/include/llbuild/Basic/Tracing.h
@@ -16,6 +16,8 @@
 #include "llbuild/Basic/CrossPlatformCompatibility.h"
 #include "llvm/ADT/StringRef.h"
 
+#include <atomic>
+
 // os_signpost is included in mac OS 10.14, if that header is not available, we don't trace at all.
 #if __has_include(<os/signpost.h>)
 #include <os/signpost.h>
@@ -69,7 +71,7 @@ if (__builtin_available(macOS 10.12, *)) os_log(getLog(), ##__VA_ARGS__); \
 #endif // __has_include(<os/signpost.h>)
 
 namespace llbuild {
-extern bool TracingEnabled;
+extern std::atomic<bool> TracingEnabled;
   
 struct TracingExecutionQueueJob {
   TracingExecutionQueueJob(int laneNumber, llvm::StringRef commandName) {

--- a/lib/Basic/Tracing.cpp
+++ b/lib/Basic/Tracing.cpp
@@ -14,6 +14,6 @@
 
 namespace llbuild {
 
-bool TracingEnabled = false;
+std::atomic<bool> TracingEnabled{false};
 
 }


### PR DESCRIPTION
TracingEnabled was not thread safe. Though not intended to be toggled
from multiple threads, this should appease the sanitizer.

rdar://problem/58939168