### PR TITLE
test: use `lit` to provide `which`

### DIFF
--- a/tests/lit.cfg
+++ b/tests/lit.cfg
@@ -6,14 +6,6 @@ import subprocess
 
 import lit.formats
 
-def which(cmd):
-    if platform.system() == 'Windows':
-        return subprocess.check_output("where " + cmd, shell=True)\
-            .split('\n')[0]\
-            .strip()\
-            .replace('\\', '\\\\')
-    else:
-        return subprocess.check_output(["which", cmd]).strip()
 # Configuration file for the 'lit' test runner.
 
 ###
@@ -104,8 +96,8 @@ config.substitutions.append( ('%{llbuild-tools-dir}', llbuild_tools_dir) )
 config.substitutions.append( ('%{srcroot}', llbuild_src_root) )
 config.substitutions.append( ('%{swiftc-platform-flags}', "" if not config.osx_sysroot else "-sdk " + config.osx_sysroot) )
 config.substitutions.append( ('%{build-dir}', llbuild_obj_root) ) 
-config.substitutions.append( ('%{env}', which('env')) )
-config.substitutions.append( ('%{sort}', which('sort')) )
+config.substitutions.append( ('%{env}', lit.util.which('env')) )
+config.substitutions.append( ('%{sort}', lit.util.which('sort')) )
 config.substitutions.append( ('%{sh-invoke}', os.environ.get("PREFIX", "") + '/bin/sh') )
 
 ###


### PR DESCRIPTION
Rather than attempting to implement the utility finding by hand, which
does not account for builtin utilities, use `lit` properly.