### PR TITLE
test: use idiomatic python for conditional evaluation

### DIFF
--- a/tests/lit.cfg
+++ b/tests/lit.cfg
@@ -102,7 +102,12 @@ config.substitutions.append( ('%{llbuild-lib-dir}', llbuild_lib_dir) )
 config.substitutions.append( ('%{llbuild-output-dir}', llbuild_output_dir) )
 config.substitutions.append( ('%{llbuild-tools-dir}', llbuild_tools_dir) )
 config.substitutions.append( ('%{srcroot}', llbuild_src_root) )
-config.substitutions.append( ('%{swiftc-platform-flags}', "" if not config.osx_sysroot else "-sdk " + config.osx_sysroot) )
+
+if config.osx_sysroot:
+    config.substitutions.append( ('%{swiftc-platform-flags}', "-sdk " + config.osx_sysroot) )
+else:
+    config.substitutions.append( ('%{swiftc-platform-flags}', "") )
+
 config.substitutions.append( ('%{build-dir}', llbuild_obj_root) ) 
 config.substitutions.append( ('%{env}', which('env')) )
 config.substitutions.append( ('%{sort}', which('sort')) )


### PR DESCRIPTION
Use the more traditional `if` condition checks for the flag computation.
This will become more useful as more platforms are added.