### PR TITLE
tests: do not assume `cc` is valid

### DIFF
--- a/tests/Examples/buildsystem-capi.llbuild
+++ b/tests/Examples/buildsystem-capi.llbuild
@@ -1,6 +1,6 @@
 # Check that the BuildSystem C API example builds and runs correctly.
 #
-# RUN: cc -o %t.exe %{srcroot}/examples/c-api/buildsystem/main.c -I %{srcroot}/products/libllbuild/include -lllbuild -L %{llbuild-lib-dir} -Werror
+# RUN: %clang -o %t.exe %{srcroot}/examples/c-api/buildsystem/main.c -I %{srcroot}/products/libllbuild/include -lllbuild -L %{llbuild-lib-dir} -Werror
 # RUN: env LD_LIBRARY_PATH=%{llbuild-lib-dir} %t.exe %s > %t.out
 # RUN: %{FileCheck} %s --input-file %t.out
 #

--- a/tests/lit.cfg
+++ b/tests/lit.cfg
@@ -89,6 +89,33 @@ else:
 
 ###
 
+def inferSwiftBinary(binaryName):
+    # Determine which executable to use
+    envVarName = binaryName.upper().replace("-", "_")
+    execPath = os.getenv(envVarName)
+
+    # If the user set the variable in the environment, definitely use that and
+    # don't try to validate.
+    if execPath:
+        return execPath
+
+    # Otherwise look in the path.
+    PATH = config.environment['PATH']
+    execPath = lit.util.which(binaryName, PATH)
+
+    if execPath:
+        if not lit_config.quiet:
+            lit_config.note('using {}: {}'.format(binaryName, execPath))
+    else:
+        msg = "couldn't find '{}' program, try setting {} in your environment"
+        lit_config.warning(msg.format(binaryName, envVarName))
+
+        # Just substitute the plain executable name, so the run line remains
+        # reasonable.
+        execPath = binaryName
+
+    return execPath
+
 # Define our supported substitutions.
 config.substitutions.append( ('%{llbuild}', "%r" % (
             os.path.join(llbuild_tools_dir, 'llbuild'),)) )
@@ -107,6 +134,7 @@ config.substitutions.append( ('%{build-dir}', llbuild_obj_root) )
 config.substitutions.append( ('%{env}', which('env')) )
 config.substitutions.append( ('%{sort}', which('sort')) )
 config.substitutions.append( ('%{sh-invoke}', os.environ.get("PREFIX", "") + '/bin/sh') )
+config.substitutions.append( ('%clang', inferSwiftBinary('clang')) )
 
 ###
 


### PR DESCRIPTION
On Windows, the default compiler is spelt `cl` as MSVC is the proffered
compiler in that environment.  `cc` is a unicism for the C compiler.
Explicitly use `clang` as the compiler as the test uses GNU command line
options.

This replicates the `swiftInferBinary` function from Swift to replicate
the environment handling and logging.