### PR TITLE
test: enable using lit's internal shell parser

### DIFF
--- a/tests/lit.cfg
+++ b/tests/lit.cfg
@@ -38,6 +38,13 @@ llbuild_lib_dir = os.path.normpath(llbuild_lib_dir)
 # name: The name of this test suite.
 config.name = 'llbuild'
 
+# NOTE: this mirrors kIsWindows from lit.lit.TestRunner in LLVM
+kIsWindows = platform.system() == 'Windows'
+
+use_lit_shell = os.environ.get('LIT_USE_INTERNAL_SHELL', kIsWindows)
+if not use_lit_shell:
+    config.available_features.add('shell')
+
 # testFormat: The test format to use to interpret tests.
 config.test_format = lit.formats.ShTest(execute_external = False)
 


### PR DESCRIPTION
Not all platforms have a full featured shell or a UNIX shell.  Enable
the use of the lit interpreter instead as a shell.