### PR TITLE
Improve modification detection by adding content comparison

### DIFF
--- a/include/llbuild/Basic/FileInfo.h
+++ b/include/llbuild/Basic/FileInfo.h
@@ -75,6 +75,8 @@ struct FileInfo {
   uint64_t size;
   /// The modification time of the file.
   FileTimestamp modTime;
+  /// The MD5 hash of the file.
+  std::pair<uint64_t, uint64_t> digest;
 
   /// Check if this is a FileInfo representing a missing file.
   bool isMissing() const {
@@ -88,10 +90,8 @@ struct FileInfo {
   bool isDirectory() const;
   
   bool operator==(const FileInfo& rhs) const {
-    return (device == rhs.device &&
-            inode == rhs.inode &&
-            size == rhs.size &&
-            modTime == rhs.modTime);
+    return (size == rhs.size &&
+            digest == rhs.digest);
   }
   bool operator!=(const FileInfo& rhs) const {
     return !(*this == rhs);
@@ -128,6 +128,8 @@ struct BinaryCodingTraits<FileInfo> {
     coder.write(value.mode);
     coder.write(value.size);
     coder.write(value.modTime);
+    coder.write(value.digest.first);
+    coder.write(value.digest.second);
   }
   static inline void decode(FileInfo& value, BinaryDecoder& coder) {
     coder.read(value.device);
@@ -135,6 +137,8 @@ struct BinaryCodingTraits<FileInfo> {
     coder.read(value.mode);
     coder.read(value.size);
     coder.read(value.modTime);
+    coder.read(value.digest.first);
+    coder.read(value.digest.second);
   }
 };
 

--- a/lib/Basic/FileInfo.cpp
+++ b/lib/Basic/FileInfo.cpp
@@ -13,7 +13,7 @@
 #include "llbuild/Basic/FileInfo.h"
 
 #include "llbuild/Basic/Stat.h"
-
+#include "llvm/Support/FileSystem.h"
 #include <cassert>
 #include <cstring>
 
@@ -63,6 +63,8 @@ FileInfo FileInfo::getInfoForPath(const std::string& path, bool asLink) {
     result.modTime.nanoseconds = 1;
     assert(!result.isMissing());
   }
+
+  result.digest = llvm::sys::fs::md5_contents(Twine(path))->words();
 
   return result;
 }

--- a/lib/Basic/FileInfo.cpp
+++ b/lib/Basic/FileInfo.cpp
@@ -64,7 +64,8 @@ FileInfo FileInfo::getInfoForPath(const std::string& path, bool asLink) {
     assert(!result.isMissing());
   }
 
-  result.digest = llvm::sys::fs::md5_contents(Twine(path))->words();
+  result.digest.path = path;
+  result.digest.needsCalculation = true;
 
   return result;
 }

--- a/lib/BuildSystem/BuildSystem.cpp
+++ b/lib/BuildSystem/BuildSystem.cpp
@@ -168,13 +168,14 @@ public:
   /// The internal schema version.
   ///
   /// Version History:
+  /// * 10: Use MD5 hashes in FileInfo
   /// * 9: Added filters to Directory* BuildKeys
   /// * 8: Added DirectoryTreeStructureSignature to BuildValue
   /// * 7: Added StaleFileRemoval to BuildValue
   /// * 6: Added DirectoryContents to BuildKey
   /// * 5: Switch BuildValue to be BinaryCoding based
   /// * 4: Pre-history
-  static const uint32_t internalSchemaVersion = 9;
+  static const uint32_t internalSchemaVersion = 10;
 
 private:
   BuildSystem& buildSystem;

--- a/unittests/Swift/BuildSystemEngineTests.swift
+++ b/unittests/Swift/BuildSystemEngineTests.swift
@@ -414,7 +414,7 @@ commands:
 
         // Validate that the custom build value was collected by checking the
         // database contents.
-        let db = try BuildDB(path: databaseFile, clientSchemaVersion: 9)
+        let db = try BuildDB(path: databaseFile, clientSchemaVersion: 10)
         guard let maincommandResult = try db.lookupRuleResult(buildKey: BuildKey.Command(name: "maincommand")) else {
             return XCTFail("Unable to load command value from db")
         }


### PR DESCRIPTION
This PR revises the way the `BuildSystem` detects file modification for rebuild. 

Prior to this, the definition of a modified files was through `fstat` properties: `device`, `inode`, `mode`, `size` and `mtime`.

This approach is very robust, but has false positives in several common cases:

* git operations - when you move between branches, sometimes you end up with exactly the same file tree content, but git will have touched the files several times.
* Scripts generating code - the contents would be the same, but the file might be completely different by `mtime`, `inode` etc.
* Accidental edits to files - you type in the wrong window and fix it a moment later, but the file was modified.
* Compiler generated files - you rebuild some module, causing the ObjC interface header to be rebuilt, which cascades the other parts of the project regardless of whether the file is actually different.

The current PR changes the way file modification is defined:
* `device`, `inode`, `mode` are no longer used.
* The file is compared by `size` and then by `mtime`.
* If and only if the `mtime` comparison fails, the MD5 hash of the file's contents is compared to the previous value.

This follows a [forum discussion](https://forums.swift.org/t/using-md5-of-the-file-contents-as-a-proxy-for-modification/33858). 
Issues raised in the discussion but not addressed by the PR:

* MD5 performance - while this is a reasonable concern, the calculation will be performed lazily and not affect build system performance. I couldn't find a better hashing function in the confines of the project, and one can be swapped in later.
* Non-content attribute cases.