### PR TITLE
[Swift/C-API] Add getFileInfo support

### DIFF
--- a/examples/c-api/buildsystem/main.c
+++ b/examples/c-api/buildsystem/main.c
@@ -61,20 +61,22 @@ static wchar_t* convertToMultiByte(const char* s) {
 // "Fancy" Command Implementation
 
 static void fancy_command_start(void* context,
-                                         llb_buildsystem_command_t* command,
-                                         llb_task_interface_t* ti) {}
+                                llb_buildsystem_command_t* command,
+                                llb_buildsystem_interface_t* bi,
+                                llb_task_interface_t* ti) {}
 
 static void fancy_command_provide_value(void* context,
-                                                 llb_buildsystem_command_t* command,
-                                                 llb_task_interface_t* ti,
-                                                 const llb_build_value* value,
-                                                 uintptr_t inputID) {}
+                                        llb_buildsystem_command_t* command,
+                                        llb_buildsystem_interface_t* bi,
+                                        llb_task_interface_t* ti,
+                                        const llb_build_value* value,
+                                        uintptr_t inputID) {}
 
 static bool
-fancy_command_execute_command(
-    void *context, llb_buildsystem_command_t* command,
-    llb_task_interface_t* ti,
-    llb_buildsystem_queue_job_context_t* job) {
+fancy_command_execute_command(void *context, llb_buildsystem_command_t* command,
+                              llb_buildsystem_interface_t* bi,
+                              llb_task_interface_t* ti,
+                              llb_buildsystem_queue_job_context_t* job) {
   printf("%s\n", __FUNCTION__);
   fflush(stdout);
   return true;

--- a/products/libllbuild/BuildSystem-C-API.cpp
+++ b/products/libllbuild/BuildSystem-C-API.cpp
@@ -701,6 +701,7 @@ class CAPIExternalCommand : public ExternalCommand {
                                     core::TaskInterface& ti) override {
     cAPIDelegate.start(cAPIDelegate.context,
                        (llb_buildsystem_command_t*)this,
+                       (llb_buildsystem_interface_t*)&system,
                        (llb_task_interface_t*)&ti);
   }
 
@@ -711,6 +712,7 @@ class CAPIExternalCommand : public ExternalCommand {
     auto value_p = (llb_build_value *)new CAPIBuildValue(BuildValue(value));
     cAPIDelegate.provide_value(cAPIDelegate.context,
                                (llb_buildsystem_command_t*)this,
+                               (llb_buildsystem_interface_t*)&system,
                                (llb_task_interface_t*)&ti,
                                value_p,
                                inputID);
@@ -752,6 +754,7 @@ class CAPIExternalCommand : public ExternalCommand {
       llb_build_value* rvalue = cAPIDelegate.execute_command_ex(
         cAPIDelegate.context,
         (llb_buildsystem_command_t*)this,
+        (llb_buildsystem_interface_t*)&system,
         (llb_task_interface_t*)&ti,
         (llb_buildsystem_queue_job_context_t*)job_context);
 
@@ -774,6 +777,7 @@ class CAPIExternalCommand : public ExternalCommand {
     bool success = cAPIDelegate.execute_command(
       cAPIDelegate.context,
       (llb_buildsystem_command_t*)this,
+      (llb_buildsystem_interface_t*)&system,
       (llb_task_interface_t*)&ti,
       (llb_buildsystem_queue_job_context_t*)job_context);
     doneFn(success ? ProcessStatus::Succeeded : ProcessStatus::Failed);
@@ -959,6 +963,12 @@ void llb_buildsystem_command_interface_task_needs_input(llb_task_interface_t* ti
   auto ti = (core::TaskInterface*)ti_p;
   ti->request(((CAPIBuildKey *)key)->getInternalBuildKey().toData(), inputID);
 }
+
+llb_build_value_file_info_t llb_buildsystem_command_interface_get_file_info(llb_buildsystem_interface_t* bi_p, const char* path) {
+  auto bi = (BuildSystem*)bi_p;
+  return llbuild::capi::convertFileInfo(bi->getFileSystem().getFileInfo(path));
+}
+
 
 llb_quality_of_service_t llb_get_quality_of_service() {
   switch (getDefaultQualityOfService()) {

--- a/products/libllbuild/BuildValue-C-API-Private.h
+++ b/products/libllbuild/BuildValue-C-API-Private.h
@@ -35,4 +35,12 @@ public:
 };
 }
 
+namespace llbuild {
+namespace capi {
+
+const llb_build_value_file_info_t convertFileInfo(const llbuild::basic::FileInfo &fileInfo);
+
+}
+}
+
 #endif /* BuildValue_C_API_Private_h */

--- a/products/libllbuild/BuildValue-C-API.cpp
+++ b/products/libllbuild/BuildValue-C-API.cpp
@@ -83,7 +83,7 @@ static const basic::FileInfo convertFileInfo(const llb_build_value_file_info_t &
   };
 }
 
-static const llb_build_value_file_info_t convertFileInfo(const basic::FileInfo &fileInfo) {
+const llb_build_value_file_info_t llbuild::capi::convertFileInfo(const basic::FileInfo &fileInfo) {
   return llb_build_value_file_info_t {
     fileInfo.device,
     fileInfo.inode,
@@ -139,7 +139,7 @@ llb_build_value *llb_build_value_make_existing_input(llb_build_value_file_info_t
 
 llb_build_value_file_info_t llb_build_value_get_output_info(llb_build_value *_Nonnull value) {
   auto fileInfo = ((CAPIBuildValue *)value)->getInternalBuildValue().getOutputInfo();
-  return convertFileInfo(fileInfo);
+  return llbuild::capi::convertFileInfo(fileInfo);
 }
 
 llb_build_value *_Nonnull llb_build_value_make_missing_input() {
@@ -203,7 +203,7 @@ void llb_build_value_get_file_infos(llb_build_value *_Nonnull value, void *_Null
   auto count = internalBuildValue->getNumOutputs();
   for (unsigned index = 0; index < count; index++) {
     auto fileInfo = internalBuildValue->getNthOutputInfo(index);
-    iterator(context, convertFileInfo(fileInfo));
+    iterator(context, llbuild::capi::convertFileInfo(fileInfo));
   }
 }
 

--- a/products/libllbuild/include/llbuild/buildsystem.h
+++ b/products/libllbuild/include/llbuild/buildsystem.h
@@ -114,6 +114,9 @@ typedef struct llb_buildsystem_tool_t_ llb_buildsystem_tool_t;
 /// Opaque handle to a build system command's launched process.
 typedef struct llb_buildsystem_process_t_ llb_buildsystem_process_t;
 
+/// Opaque handle to a build system interface.
+typedef struct llb_buildsystem_interface_t_ llb_buildsystem_interface_t;
+
 /// Result of a command execution.
 typedef enum LLBUILD_ENUM_ATTRIBUTES {
   llb_buildsystem_command_result_succeeded = 0,
@@ -590,7 +593,7 @@ typedef struct llb_buildsystem_external_command_delegate_t_ {
   /// At this point, the command may choose to request more dependencies
   /// through the build system command interface (bsci) reference.
   void (*start)(void* context, llb_buildsystem_command_t* command,
-                llb_task_interface_t* ti);
+                llb_buildsystem_interface_t* bi, llb_task_interface_t* ti);
 
   /// Called by the build system when one of the requested dependencies has
   /// become available. The command can identify which key the provided value
@@ -598,6 +601,7 @@ typedef struct llb_buildsystem_external_command_delegate_t_ {
   /// to request additional dependencies based on the contents of the provided
   /// value.
   void (*provide_value)(void* context, llb_buildsystem_command_t* command,
+                        llb_buildsystem_interface_t* bi,
                         llb_task_interface_t* ti,
                         const llb_build_value* value,
                         uintptr_t inputID);
@@ -617,11 +621,13 @@ typedef struct llb_buildsystem_external_command_delegate_t_ {
   /// The C API takes ownership of the value returned by `execute_command_ex`.
   bool (*execute_command)(void* context,
                           llb_buildsystem_command_t* command,
+                          llb_buildsystem_interface_t* bi,
                           llb_task_interface_t* ti,
                           llb_buildsystem_queue_job_context_t* job_context);
 
   llb_build_value* (*execute_command_ex)(void* context,
                                          llb_buildsystem_command_t* command,
+                                         llb_buildsystem_interface_t* bi,
                                          llb_task_interface_t* ti,
                                          llb_buildsystem_queue_job_context_t* job_context);
 
@@ -692,6 +698,11 @@ llb_buildsystem_command_interface_task_needs_input(llb_task_interface_t* task, l
 /// Marks a key as a discovered dependency for the task.
 LLBUILD_EXPORT void
 llb_buildsystem_command_interface_task_discovered_dependency(llb_task_interface_t* ti_p, llb_build_key_t* key);
+
+/// Returns the file info struct for the specified path
+LLBUILD_EXPORT llb_build_value_file_info_t
+llb_buildsystem_command_interface_get_file_info(llb_buildsystem_interface_t* bi_p, const char* path);
+
 
 // MARK: Quality of Service
 

--- a/products/llbuildSwift/BuildSystemBindings.swift
+++ b/products/llbuildSwift/BuildSystemBindings.swift
@@ -38,9 +38,11 @@ public struct BuildSystemCommandInterface {
     // This struct wraps a bsci object, which should be global, and a task object, which is different for each command.
     // At this time, it is not required to expose the task to the client, so this wrapper abstracts from the task itself.
     // and each command will get a personalized instance of the command interface.
+    private let _buildsystemInterface: OpaquePointer
     private let _taskInterface: OpaquePointer
 
-    fileprivate init(_ taskInterface: OpaquePointer) {
+    fileprivate init(_ buildsystemInterface: OpaquePointer, _ taskInterface: OpaquePointer) {
+        _buildsystemInterface = buildsystemInterface
         _taskInterface = taskInterface
     }
 
@@ -53,6 +55,10 @@ public struct BuildSystemCommandInterface {
     /// Marks a build key as a runtime found dependency for the command.
     public func commandDiscoveredDependency(key: BuildKey) {
         llb_buildsystem_command_interface_task_discovered_dependency(_taskInterface, key.internalBuildKey)
+    }
+
+    func getFileInfo(_ path: String) throws -> BuildValueFileInfo {
+        return llb_buildsystem_command_interface_get_file_info(_buildsystemInterface, path)
     }
 }
 
@@ -112,12 +118,12 @@ private final class ToolWrapper {
         var _delegate = llb_buildsystem_external_command_delegate_t()
         _delegate.context = Unmanaged.passUnretained(wrapper).toOpaque()
         _delegate.get_signature = { return BuildSystem.toCommandWrapper($0!).getSignature($1!, $2!) }
-        _delegate.start = { return BuildSystem.toCommandWrapper($0!).start($1!, $2!) }
-        _delegate.provide_value = { return BuildSystem.toCommandWrapper($0!).provideValue($1!, $2!, $3!, $4) }
-        _delegate.execute_command = { return BuildSystem.toCommandWrapper($0!).executeCommand($1!, $2!, $3!) }
+        _delegate.start = { return BuildSystem.toCommandWrapper($0!).start($1!, $2!, $3!) }
+        _delegate.provide_value = { return BuildSystem.toCommandWrapper($0!).provideValue($1!, $2!, $3!, $4!, $5) }
+        _delegate.execute_command = { return BuildSystem.toCommandWrapper($0!).executeCommand($1!, $2!, $3!, $4!) }
         if let _ = command as? ProducesCustomBuildValue {
             _delegate.execute_command_ex = {
-                var value: BuildValue = BuildSystem.toCommandWrapper($0!).executeCommand($1!, $2!, $3!)
+                var value: BuildValue = BuildSystem.toCommandWrapper($0!).executeCommand($1!, $2!, $3!, $4!)
                 return BuildValue.move(&value)
             }
             _delegate.is_result_valid = {
@@ -223,28 +229,28 @@ private final class CommandWrapper {
         data.pointee = copiedDataFromBytes(command.getSignature(_command))
     }
 
-    func start(_: OpaquePointer, _ taskInterface: OpaquePointer) {
-        let commandInterface = BuildSystemCommandInterface(taskInterface)
+    func start(_: OpaquePointer, _ buildsystemInterface: OpaquePointer, _ taskInterface: OpaquePointer) {
+        let commandInterface = BuildSystemCommandInterface(buildsystemInterface, taskInterface)
         return command.start(_command, commandInterface)
     }
 
-    func provideValue(_: OpaquePointer, _ taskInterface: OpaquePointer, _ value: OpaquePointer, _ inputID: UInt) {
+    func provideValue(_: OpaquePointer, _ buildsystemInterface: OpaquePointer, _ taskInterface: OpaquePointer, _ value: OpaquePointer, _ inputID: UInt) {
 
         guard let buildValue = BuildValue.construct(from: value) else {
             fatalError("Could not decode incoming build value.")
         }
 
-        let commandInterface = BuildSystemCommandInterface(taskInterface)
+        let commandInterface = BuildSystemCommandInterface(buildsystemInterface, taskInterface)
         return command.provideValue(_command, commandInterface, buildValue, inputID)
     }
 
-    func executeCommand(_: OpaquePointer, _ taskInterface: OpaquePointer, _ jobContext: OpaquePointer) -> Bool {
-        let commandInterface = BuildSystemCommandInterface(taskInterface)
+    func executeCommand(_: OpaquePointer, _ buildsystemInterface: OpaquePointer, _ taskInterface: OpaquePointer, _ jobContext: OpaquePointer) -> Bool {
+        let commandInterface = BuildSystemCommandInterface(buildsystemInterface, taskInterface)
         return command.execute(_command, commandInterface)
     }
 
-    func executeCommand(_: OpaquePointer, _ taskInterface: OpaquePointer, _ jobContext: OpaquePointer) -> BuildValue {
-        let commandInterface = BuildSystemCommandInterface(taskInterface)
+    func executeCommand(_: OpaquePointer, _ buildsystemInterface: OpaquePointer, _ taskInterface: OpaquePointer, _ jobContext: OpaquePointer) -> BuildValue {
+        let commandInterface = BuildSystemCommandInterface(buildsystemInterface, taskInterface)
         return (command as! ProducesCustomBuildValue).execute(_command, commandInterface)
     }
 

--- a/unittests/CAPI/BuildSystem-C-API.cpp
+++ b/unittests/CAPI/BuildSystem-C-API.cpp
@@ -58,10 +58,12 @@ static void writeFileContents(std::string path, std::string str) {
 
 static void depinfo_tester_command_start(void* context,
                                          llb_buildsystem_command_t* command,
+                                         llb_buildsystem_interface_t* bi,
                                          llb_task_interface_t* ti) {}
 
 static void depinfo_tester_command_provide_value(void* context,
                                                  llb_buildsystem_command_t* command,
+                                                 llb_buildsystem_interface_t* bi,
                                                  llb_task_interface_t* ti,
                                                  const llb_build_value* value,
                                                  uintptr_t inputID) {}
@@ -69,6 +71,7 @@ static void depinfo_tester_command_provide_value(void* context,
 static bool
 depinfo_tester_command_execute_command(void *context,
                                        llb_buildsystem_command_t* command,
+                                       llb_buildsystem_interface_t* bi,
                                        llb_task_interface_t* ti,
                                        llb_buildsystem_queue_job_context_t* job) {
   // The tester tool is given a direct input file whose only contents are the


### PR DESCRIPTION
Allow tasks to defer to llbuild to get file info, specifically for use
in generating custom build values.

rdar://problem/59433735