### PR TITLE
Call echo with -e in strip-colors.ninja

### DIFF
--- a/tests/Ninja/Build/strip-colors.ninja
+++ b/tests/Ninja/Build/strip-colors.ninja
@@ -17,7 +17,7 @@
 #
 
 rule SHOW
-     command = echo "<\0033[32m$in\033[0m>"
+     command = echo -e "<\0033[32m$in\033[0m>"
 
 build test.out: SHOW test.in
 


### PR DESCRIPTION
On most systems echo will not interpret backslash escapes unless called with -e