### PR TITLE
[Ninja] Fix a crash in the parser.

### DIFF
--- a/lib/Ninja/Parser.cpp
+++ b/lib/Ninja/Parser.cpp
@@ -100,7 +100,8 @@ class ParserImpl {
   /// value.
   ///
   /// \returns True on success. On failure, the lexer will be advanced past the
-  /// next newline (see \see skipPastEOL()).
+  /// next newline (see \see skipPastEOL()). In either case, the lexer will be
+  /// taken out of any specific parsing mode.
   bool parseBindingInternal(Token* name_out, Token* value_out);
 
   void parseBindingDecl();
@@ -181,6 +182,7 @@ bool ParserImpl::parseBindingInternal(Token* name_out, Token* value_out) {
   // The leading token should be an identifier.
   if (tok.tokenKind != Token::Kind::Identifier) {
     error("expected variable name");
+    lexer.setMode(Lexer::LexingMode::None);
     skipPastEOL();
     return false;
   }
@@ -190,6 +192,7 @@ bool ParserImpl::parseBindingInternal(Token* name_out, Token* value_out) {
   // Expect the variable name to be followed by '='.
   if (tok.tokenKind != Token::Kind::Equals) {
     error("expected '=' token");
+    lexer.setMode(Lexer::LexingMode::None);
     skipPastEOL();
     return false;
   }

--- a/tests/Ninja/Parser/basic.ninja
+++ b/tests/Ninja/Parser/basic.ninja
@@ -62,6 +62,13 @@ build a.o: cc b.o | c.o || d.o
 # CHECK: basic.ninja:[[@LINE+1]]:14: error: expected newline token
 build a.o: cc :
 
+# Check for handling of malformed statements.
+# CHECK: basic.ninja:[[@LINE+3]]:4: error: expected variable name
+# CHECK: basic.ninja:[[@LINE+3]]:11: error: expected '=' token
+build a.o: cc
+    :
+    token1 token2 token3
+
 # Check "pool" parsing.
 #
 # CHECK: basic.ninja:[[@LINE+1]]:4: error: expected pool name identifier


### PR DESCRIPTION
 - In certain cases, the lexer wouldn't be properly taken out of the customized
   lexing mode for particular errors.