### PR TITLE
[Package] Add a potentially necessary linked library on Linux.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -197,7 +197,9 @@ let package = Package(
             name: "llvmSupport",
             dependencies: ["llvmDemangle"],
             path: "lib/llvm/Support",
-            linkerSettings: [.linkedLibrary("ncurses", .when(platforms: [.linux, .macOS]))]
+            linkerSettings: [
+                .linkedLibrary("m", .when(platforms: [.linux])),
+                .linkedLibrary("ncurses", .when(platforms: [.linux, .macOS]))]
         ),
     ],
     cxxLanguageStandard: .cxx14


### PR DESCRIPTION
 - In some cases, the LLVM support library ends up needing to be linked against
   libm.