### PR TITLE
Ninja response files

### DIFF
--- a/include/llbuild/Ninja/Manifest.h
+++ b/include/llbuild/Ninja/Manifest.h
@@ -177,6 +177,8 @@ private:
   std::string commandString;
   std::string description;
   std::string depsFile;
+  std::string rspFile;
+  std::string rspFileContent;
 
   unsigned depsStyle: 2;
   unsigned isGenerator: 1;
@@ -280,6 +282,23 @@ public:
   }
   void setDepsFile(StringRef value) {
     depsFile = value;
+  }
+
+  /// Get the response file to be used by this command.
+  const std::string& getRspFile() const {
+    return rspFile;
+  }
+  void setRspFile(StringRef value) {
+    rspFile = value;
+  }
+
+  /// Get the response file content, it has to be written to response file
+  /// before this command is executed.
+  const std::string& getRspFileContent() const {
+    return rspFileContent;
+  }
+  void setRspFileContent(StringRef value) {
+    rspFileContent = value;
   }
 
   /// Check whether this command should be treated as a generator command.

--- a/tests/Ninja/Build/response-files.ninja
+++ b/tests/Ninja/Build/response-files.ninja
@@ -1,0 +1,46 @@
+# Test for handling response files and related ${in_newline} variable.
+
+# We run the build in a sandbox in the temp directory to ensure we don't
+# interact with the source dirs.
+#
+# RUN: rm -rf %t.build
+# RUN: mkdir -p %t.build
+# RUN: cp %s %t.build/build.ninja
+# RUN: %{llbuild} ninja build --no-db --chdir %t.build &> %t.out || true
+
+# Check that response file is present only for failed rule
+#
+# RUN: test ! -f %t.build/response-PRINT.rsp
+# RUN: test -f %t.build/response-FAIL.rsp
+
+# RUN: %{FileCheck} --check-prefix=CHECK-PRINT < %t.build/dummy-B %s
+# RUN: %{FileCheck} --check-prefix=CHECK-FAIL < %t.build/response-FAIL.rsp %s
+
+# Check content of response-PRINT.rsp response file - it is printed into dummy-B.
+#
+# CHECK-PRINT: content
+
+# Check content of response-FAIL.rsp response file 
+#
+# CHECK-FAIL: dummy-A
+# CHECK-FAIL-NEXT: dummy-B
+
+rule TOUCH
+     command = touch ${out}
+     description = "TOUCH"
+rule PRINT
+     command = cat response-PRINT.rsp > ${out}
+     description = "PRINT"
+     rspfile = response-PRINT.rsp
+     rspfile_content = content
+rule FAIL
+     command = exit 1
+     description = "FAIL"
+     rspfile = response-FAIL.rsp
+     rspfile_content = ${in_newline}
+
+build dummy-A: TOUCH
+build dummy-B: PRINT
+build dummy: FAIL dummy-A dummy-B
+
+default dummy


### PR DESCRIPTION
This PR adds support for `@response` files for llbuild ninja.

Changes:
* `rspfile` and `rspfile_content` rule attributes support
* `${in_newline}` parameter support
* simple test for response file deletion when a rule succeeded and response file content