### PR TITLE
[Unittests] Fix lit integration of googletest.

### DIFF
--- a/tests/Unit/lit.cfg
+++ b/tests/Unit/lit.cfg
@@ -16,7 +16,7 @@ config.suffixes = []
 # test_exec_root: The root path where tests should be run.
 llbuild_obj_root = getattr(config, 'llbuild_obj_root', None)
 if llbuild_obj_root is not None:
-    config.test_exec_root = os.path.join(llbuild_obj_root, 'unittests')
+    config.test_exec_root = os.path.join(llbuild_obj_root, 'bin')
     config.test_source_root = config.test_exec_root
 
 # testFormat: The test format to use to interpret tests.


### PR DESCRIPTION
 - It turns out that #532 refactored the output location of unit tests binaries,
   which broke the lit integration with googletest. Thus, all our unit tests
   haven't been running for a couple months 🤦‍♂️.