### PR TITLE
Remove iOS as supported platform

### DIFF
--- a/products/llbuild-analyze/Package.swift
+++ b/products/llbuild-analyze/Package.swift
@@ -8,7 +8,7 @@ import PackageDescription
 let package = Package(
     name: "llbuild-analyze",
     platforms: [
-        .macOS(.v10_10), .iOS(.v9),
+        .macOS(.v10_10)
     ],
     products: [
         .executable(


### PR DESCRIPTION
llbuild-analyze is not meant to be run on iOS, it's an executable target to run on macOS for analyzing llbuild databases.
rdar://problem/62300693