### PR TITLE
Core/BuildSystem cancellation improvements

### DIFF
--- a/lib/Commands/BuildSystemCommand.cpp
+++ b/lib/Commands/BuildSystemCommand.cpp
@@ -489,7 +489,7 @@ class BasicBuildSystemFrontendDelegate : public BuildSystemFrontendDelegate {
 public:
   BasicBuildSystemFrontendDelegate(llvm::SourceMgr& sourceMgr,
                                    const BuildSystemInvocation& invocation)
-      : BuildSystemFrontendDelegate(sourceMgr, invocation,
+      : BuildSystemFrontendDelegate(sourceMgr,
                                     "basic", /*version=*/0),
         fileSystem(basic::createLocalFileSystem()) {
     // Register an interrupt handler.

--- a/lib/Core/BuildEngine.cpp
+++ b/lib/Core/BuildEngine.cpp
@@ -28,7 +28,6 @@
 #include <cassert>
 #include <cstdio>
 #include <condition_variable>
-#include <iostream>
 #include <memory>
 #include <mutex>
 #include <thread>
@@ -1310,6 +1309,11 @@ private:
     }
 
     // Delete all of the tasks.
+    ruleInfosToScan.clear();
+    inputRequests.clear();
+    finishedInputRequests.clear();
+    readyTaskInfos.clear();
+    finishedTaskInfos.clear();
     taskInfos.clear();
   }
 

--- a/products/libllbuild/BuildSystem-C-API.cpp
+++ b/products/libllbuild/BuildSystem-C-API.cpp
@@ -177,7 +177,7 @@ public:
   CAPIBuildSystemFrontendDelegate(llvm::SourceMgr& sourceMgr,
                                   BuildSystemInvocation& invocation,
                                   llb_buildsystem_delegate_t delegate)
-      : BuildSystemFrontendDelegate(sourceMgr, invocation, "basic", 0),
+      : BuildSystemFrontendDelegate(sourceMgr, "basic", 0),
         cAPIDelegate(delegate) { }
 
   virtual std::unique_ptr<Tool> lookupTool(StringRef name) override {
@@ -574,16 +574,10 @@ public:
   }
 
   bool build(llvm::StringRef key) {
-    // Reset mutable build state.
-    frontendDelegate->resetForBuild();
-
-    // FIXME: We probably should return a context to represent the running
-    // build, instead of keeping state (like cancellation) in the delegate.
     return getFrontend().build(key);
   }
 
   bool buildNode(llvm::StringRef key) {
-    frontendDelegate->resetForBuild();
     return getFrontend().buildNode(key);
   }
 

--- a/products/swift-build-tool/main.cpp
+++ b/products/swift-build-tool/main.cpp
@@ -30,7 +30,7 @@ class BasicBuildSystemFrontendDelegate : public BuildSystemFrontendDelegate {
 public:
   BasicBuildSystemFrontendDelegate(llvm::SourceMgr& sourceMgr,
                                    const BuildSystemInvocation& invocation)
-    : BuildSystemFrontendDelegate(sourceMgr, invocation,
+    : BuildSystemFrontendDelegate(sourceMgr,
                                   "swift-build", /*version=*/0) {}
 
   virtual void hadCommandFailure() override {


### PR DESCRIPTION
Refactor BuildSystemFrontend struture for safer async/multithreaded
operation.

Also clean up full transient engine state during cancelRemainingTasks()

rdar://problem/60340052
rdar://problem/62271674