### PR TITLE
[CMake][llbuildSwift] fix runpath for ELF platforms

### DIFF
--- a/products/llbuildSwift/CMakeLists.txt
+++ b/products/llbuildSwift/CMakeLists.txt
@@ -57,6 +57,7 @@ else()
     swiftDispatch
     Foundation)
   if(NOT CMAKE_SYSTEM_NAME STREQUAL Windows)
+    target_link_options(llbuildSwift PRIVATE "SHELL:-no-toolchain-stdlib-rpath")
     set_target_properties(llbuildSwift PROPERTIES
       INSTALL_RPATH "$ORIGIN:$ORIGIN/../../$<LOWER_CASE:${CMAKE_SYSTEM_NAME}>")
   endif()


### PR DESCRIPTION
Remove the absolute path to the host toolchain's stdlib from libllbuildSwift.so.

Otherwise, you see the following in the latest official 5.3 snapshot release for linux:
```
> readelf -d swift-5.3-DEVELOPMENT-SNAPSHOT-2020-05-04-a-ubuntu18.04/usr/lib/swift/pm/llbuild/libllbuildSwift.so | ag runpath
0x000000000000001d (RUNPATH)            Library runpath: [/home/buildnode/jenkins/workspace/oss-swift-5.3-package-linux-ubuntu-18_04/build/buildbot_linux/swift-linux-x86_64/lib/swift/linux:$ORIGIN:$ORIGIN/../../linux]
```