### PR TITLE
Adjust TaskInferface passing for easier use

### DIFF
--- a/examples/c-api/buildsystem/main.c
+++ b/examples/c-api/buildsystem/main.c
@@ -63,19 +63,19 @@ static wchar_t* convertToMultiByte(const char* s) {
 static void fancy_command_start(void* context,
                                 llb_buildsystem_command_t* command,
                                 llb_buildsystem_interface_t* bi,
-                                llb_task_interface_t* ti) {}
+                                llb_task_interface_t ti) {}
 
 static void fancy_command_provide_value(void* context,
                                         llb_buildsystem_command_t* command,
                                         llb_buildsystem_interface_t* bi,
-                                        llb_task_interface_t* ti,
+                                        llb_task_interface_t ti,
                                         const llb_build_value* value,
                                         uintptr_t inputID) {}
 
 static bool
 fancy_command_execute_command(void *context, llb_buildsystem_command_t* command,
                               llb_buildsystem_interface_t* bi,
-                              llb_task_interface_t* ti,
+                              llb_task_interface_t ti,
                               llb_buildsystem_queue_job_context_t* job) {
   printf("%s\n", __FUNCTION__);
   fflush(stdout);

--- a/include/llbuild/BuildSystem/BuildSystemHandlers.h
+++ b/include/llbuild/BuildSystem/BuildSystemHandlers.h
@@ -41,10 +41,10 @@ public:
   virtual ~ShellCommandHandler();
   
   virtual std::unique_ptr<HandlerState>
-  start(core::TaskInterface&, ShellCommand* command) const = 0;
+  start(core::TaskInterface, ShellCommand* command) const = 0;
 
   virtual void
-  execute(HandlerState*, ShellCommand* command, core::TaskInterface& ti,
+  execute(HandlerState*, ShellCommand* command, core::TaskInterface ti,
           basic::QueueJobContext* context, basic::ProcessCompletionFn) const = 0;
 };
 

--- a/include/llbuild/BuildSystem/Command.h
+++ b/include/llbuild/BuildSystem/Command.h
@@ -138,12 +138,12 @@ public:
 
   virtual bool isResultValid(BuildSystem& system, const BuildValue& value) = 0;
   
-  virtual void start(BuildSystem& system, core::TaskInterface& ti) = 0;
+  virtual void start(BuildSystem& system, core::TaskInterface ti) = 0;
 
-  virtual void providePriorValue(BuildSystem& system, core::TaskInterface& ti,
+  virtual void providePriorValue(BuildSystem& system, core::TaskInterface ti,
                                  const BuildValue& value) = 0;
 
-  virtual void provideValue(BuildSystem& system, core::TaskInterface&,
+  virtual void provideValue(BuildSystem& system, core::TaskInterface,
                             uintptr_t inputID, const BuildValue& value) = 0;
 
 
@@ -154,7 +154,7 @@ public:
   /// This method will always be executed on the build execution queue.
   ///
   /// Note that resultFn may be executed asynchronously on a separate thread.
-  virtual void execute(BuildSystem& system, core::TaskInterface& ti,
+  virtual void execute(BuildSystem& system, core::TaskInterface ti,
                        basic::QueueJobContext* context, ResultFn resultFn) = 0;
   
   /// @}

--- a/include/llbuild/BuildSystem/ExternalCommand.h
+++ b/include/llbuild/BuildSystem/ExternalCommand.h
@@ -91,24 +91,24 @@ protected:
   virtual basic::CommandSignature getSignature() const override;
 
   /// Extension point for subclases, to modify the command dependencies if needed.
-  virtual void startExternalCommand(BuildSystem& system, core::TaskInterface&) = 0;
+  virtual void startExternalCommand(BuildSystem& system, core::TaskInterface) = 0;
 
   /// Extension point for subclasses, to retrieve the BuildValue requested. May request new keys from this extension.
   virtual void provideValueExternalCommand(
       BuildSystem& system,
-      core::TaskInterface& ti,
+      core::TaskInterface ti,
       uintptr_t inputID,
       const BuildValue& value) = 0;
 
   /// Extension point for subclasses, to actually execute the command after all dependencies have been calculated.
   virtual void executeExternalCommand(
       BuildSystem& system,
-      core::TaskInterface& ti,
+      core::TaskInterface ti,
       basic::QueueJobContext* context,
       llvm::Optional<basic::ProcessCompletionFn> completionFn = {llvm::None}) = 0;
   
   /// Compute the output result for the command.
-  virtual BuildValue computeCommandResult(BuildSystem& system, core::TaskInterface& ti);
+  virtual BuildValue computeCommandResult(BuildSystem& system, core::TaskInterface ti);
 
 public:
   using Command::Command;
@@ -135,19 +135,19 @@ public:
   
   virtual bool isResultValid(BuildSystem&, const BuildValue& value) override;
 
-  virtual void start(BuildSystem& system, core::TaskInterface& ti) override;
+  virtual void start(BuildSystem& system, core::TaskInterface ti) override;
 
   virtual void providePriorValue(BuildSystem& system,
-                                 core::TaskInterface&,
+                                 core::TaskInterface,
                                  const BuildValue&) override;
 
   virtual void provideValue(BuildSystem& system,
-                            core::TaskInterface& ti,
+                            core::TaskInterface ti,
                             uintptr_t inputID,
                             const BuildValue& value) override;
 
   virtual void execute(BuildSystem& system,
-                       core::TaskInterface&,
+                       core::TaskInterface,
                        basic::QueueJobContext* context,
                        ResultFn resultFn) override;
 };

--- a/include/llbuild/BuildSystem/ShellCommand.h
+++ b/include/llbuild/BuildSystem/ShellCommand.h
@@ -92,23 +92,23 @@ class ShellCommand : public ExternalCommand {
   /// The handler state, if used.
   std::unique_ptr<HandlerState> handlerState;
 
-  virtual void start(BuildSystem& system, core::TaskInterface&) override;
+  virtual void start(BuildSystem& system, core::TaskInterface) override;
   
   virtual basic::CommandSignature getSignature() const override;
 
   bool processDiscoveredDependencies(BuildSystem& system,
-                                     core::TaskInterface& ti,
+                                     core::TaskInterface ti,
                                      basic::QueueJobContext* context);
   
   bool processMakefileDiscoveredDependencies(BuildSystem& system,
-                                             core::TaskInterface& ti,
+                                             core::TaskInterface ti,
                                              basic::QueueJobContext* context,
                                              StringRef depsPath,
                                              llvm::MemoryBuffer* input);
 
   bool
   processDependencyInfoDiscoveredDependencies(BuildSystem& system,
-                                              core::TaskInterface& ti,
+                                              core::TaskInterface ti,
                                               basic::QueueJobContext* context,
                                               StringRef depsPath,
                                               llvm::MemoryBuffer* input);
@@ -151,18 +151,18 @@ public:
 
 
   // Shell command doesn't have any dynamic dependencies, so do nothing.
-  void startExternalCommand(BuildSystem& system, core::TaskInterface&) override {};
+  void startExternalCommand(BuildSystem& system, core::TaskInterface) override {};
 
   // Not expecting any dependencies, so do nothing.
   void provideValueExternalCommand(
       BuildSystem& system,
-      core::TaskInterface&,
+      core::TaskInterface,
       uintptr_t inputID,
       const BuildValue& value) override {};
 
   virtual void executeExternalCommand(
       BuildSystem& system,
-      core::TaskInterface& ti,
+      core::TaskInterface ti,
       basic::QueueJobContext* context,
       llvm::Optional<basic::ProcessCompletionFn> completionFn) override;
 };

--- a/include/llbuild/Core/BuildEngine.h
+++ b/include/llbuild/Core/BuildEngine.h
@@ -225,14 +225,14 @@ public:
   virtual ~Task();
 
   /// Executed by the build engine when the task should be started.
-  virtual void start(TaskInterface&) = 0;
+  virtual void start(TaskInterface) = 0;
 
   /// Invoked by the build engine to provide the prior result for the task's
   /// output, if present.
   ///
   /// This callback will always be invoked immediately after the task is
   /// started, and prior to its receipt of any other callbacks.
-  virtual void providePriorValue(TaskInterface&, const ValueType& value) {};
+  virtual void providePriorValue(TaskInterface, const ValueType& value) {};
 
   /// Invoked by the build engine to provide an input value as it becomes
   /// available.
@@ -242,7 +242,7 @@ public:
   /// BuildEngine::taskNeedsInput().
   ///
   /// \param value The computed value for the given input.
-  virtual void provideValue(TaskInterface&, uintptr_t inputID,
+  virtual void provideValue(TaskInterface, uintptr_t inputID,
                             const ValueType& value) = 0;
 
   /// Executed by the build engine to indicate that all inputs have been
@@ -253,7 +253,7 @@ public:
   ///
   /// It is an error for any client to request an additional input for a task
   /// after the last requested input has been provided by the build engine.
-  virtual void inputsAvailable(TaskInterface&) = 0;
+  virtual void inputsAvailable(TaskInterface) = 0;
 };
 
 /// A rule represents an individual element of computation that can be performed

--- a/include/llbuild/Core/BuildEngine.h
+++ b/include/llbuild/Core/BuildEngine.h
@@ -246,7 +246,10 @@ public:
                             const ValueType& value) = 0;
 
   /// Executed by the build engine to indicate that all inputs have been
-  /// provided, and the task should begin its computation.
+  /// provided, and the task should begin its computation. If the client will
+  /// perform non-trivial work for this computation, it should be executed
+  /// asynchronously on separate thread/work queue to prevent stalling the core
+  /// engine.
   ///
   /// The task is expected to call \see BuildEngine::taskIsComplete() when it is
   /// done with its computation.

--- a/lib/BuildSystem/ExternalCommand.cpp
+++ b/lib/BuildSystem/ExternalCommand.cpp
@@ -204,7 +204,7 @@ bool ExternalCommand::isResultValid(BuildSystem& system,
 }
 
 void ExternalCommand::start(BuildSystem& system,
-                            core::TaskInterface& ti) {
+                            core::TaskInterface ti) {
   // Initialize the build state.
   skipValue = llvm::None;
   missingInputNodes.clear();
@@ -220,7 +220,7 @@ void ExternalCommand::start(BuildSystem& system,
 }
 
 void ExternalCommand::providePriorValue(BuildSystem& system,
-                                        core::TaskInterface&,
+                                        core::TaskInterface,
                                         const BuildValue& value) {
   if (value.isSuccessfulCommand()) {
     hasPriorResult = true;
@@ -228,7 +228,7 @@ void ExternalCommand::providePriorValue(BuildSystem& system,
 }
 
 void ExternalCommand::provideValue(BuildSystem& system,
-                                   core::TaskInterface& ti,
+                                   core::TaskInterface ti,
                                    uintptr_t inputID,
                                    const BuildValue& value) {
   if (value.isSuccessfulCommand() || value.isFailedCommand() || value.isPropagatedFailureCommand()) {
@@ -321,7 +321,7 @@ bool ExternalCommand::canUpdateIfNewerWithResult(const BuildValue& result) {
 }
 
 BuildValue
-ExternalCommand::computeCommandResult(BuildSystem& system, core::TaskInterface& ti) {
+ExternalCommand::computeCommandResult(BuildSystem& system, core::TaskInterface ti) {
   // Capture the file information for each of the output nodes.
   //
   // FIXME: We need to delegate to the node here.
@@ -357,7 +357,7 @@ ExternalCommand::computeCommandResult(BuildSystem& system, core::TaskInterface& 
 }
 
 void ExternalCommand::execute(BuildSystem& system,
-                              core::TaskInterface& ti,
+                              core::TaskInterface ti,
                               QueueJobContext* context,
                               ResultFn resultFn) {
   // If this command should be skipped, do nothing.

--- a/lib/BuildSystem/ShellCommand.cpp
+++ b/lib/BuildSystem/ShellCommand.cpp
@@ -27,7 +27,7 @@ using namespace llbuild::basic;
 using namespace llbuild::core;
 using namespace llbuild::buildsystem;
 
-void ShellCommand::start(BuildSystem& system, TaskInterface& ti) {
+void ShellCommand::start(BuildSystem& system, TaskInterface ti) {
   // Resolve the plugin state.
   handler = system.resolveShellCommandHandler(this);
 
@@ -71,7 +71,7 @@ CommandSignature ShellCommand::getSignature() const {
 }
 
 bool ShellCommand::processDiscoveredDependencies(BuildSystem& system,
-                                                 core::TaskInterface& ti,
+                                                 core::TaskInterface ti,
                                                  QueueJobContext* context) {
   // It is an error if the dependencies style is not specified.
   //
@@ -116,7 +116,7 @@ bool ShellCommand::processDiscoveredDependencies(BuildSystem& system,
 }
 
 bool ShellCommand::processMakefileDiscoveredDependencies(BuildSystem& system,
-                                                         TaskInterface& ti,
+                                                         TaskInterface ti,
                                                          QueueJobContext* context,
                                                          StringRef depsPath,
                                                          llvm::MemoryBuffer* input) {
@@ -131,7 +131,7 @@ bool ShellCommand::processMakefileDiscoveredDependencies(BuildSystem& system,
     StringRef depsPath;
     unsigned numErrors{0};
 
-    DepsActions(BuildSystem& system, TaskInterface& ti,
+    DepsActions(BuildSystem& system, TaskInterface ti,
                 ShellCommand* command, StringRef depsPath)
         : system(system), ti(ti), command(command), depsPath(depsPath) {}
 
@@ -178,7 +178,7 @@ bool ShellCommand::processMakefileDiscoveredDependencies(BuildSystem& system,
 
 bool
 ShellCommand::processDependencyInfoDiscoveredDependencies(BuildSystem& system,
-                                                          TaskInterface& ti,
+                                                          TaskInterface ti,
                                                           QueueJobContext* context,
                                                           StringRef depsPath,
                                                           llvm::MemoryBuffer* input) {
@@ -193,7 +193,7 @@ ShellCommand::processDependencyInfoDiscoveredDependencies(BuildSystem& system,
     StringRef depsPath;
     unsigned numErrors{0};
 
-    DepsActions(BuildSystem& system, TaskInterface& ti,
+    DepsActions(BuildSystem& system, TaskInterface ti,
                 ShellCommand* command, StringRef depsPath)
         : system(system), ti(ti), command(command), depsPath(depsPath) {}
 
@@ -329,7 +329,7 @@ bool ShellCommand::configureAttribute(
 
 void ShellCommand::executeExternalCommand(
     BuildSystem& system,
-    TaskInterface& ti,
+    TaskInterface ti,
     QueueJobContext* context,
     llvm::Optional<ProcessCompletionFn> completionFn) {
   auto commandCompletionFn = [this, &system, ti, completionFn](ProcessResult result) mutable {
@@ -345,7 +345,7 @@ void ShellCommand::executeExternalCommand(
       // FIXME: Really want this job to go into a high priority fifo queue
       // so as to not hold up downstream tasks.
       ti.spawn(QueueJob{ this, [this, &system, ti, completionFn, result](QueueJobContext* context) mutable {
-            if (!processDiscoveredDependencies(system, const_cast<TaskInterface&>(ti), context)) {
+            if (!processDiscoveredDependencies(system, ti, context)) {
               // If we were unable to process the dependencies output, report a
               // failure.
               if (completionFn.hasValue())

--- a/lib/Commands/BuildEngineCommand.cpp
+++ b/lib/Commands/BuildEngineCommand.cpp
@@ -144,7 +144,7 @@ struct AckermannTask : core::Task {
   }
 
   /// Called when the task is started.
-  virtual void start(core::TaskInterface& ti) override {
+  virtual void start(core::TaskInterface ti) override {
     // Request the first recursive result, if necessary.
     if (m == 0) {
       ;
@@ -156,7 +156,7 @@ struct AckermannTask : core::Task {
   }
 
   /// Called when a task’s requested input is available.
-  virtual void provideValue(core::TaskInterface& ti, uintptr_t inputID,
+  virtual void provideValue(core::TaskInterface ti, uintptr_t inputID,
                             const core::ValueType& value) override {
     if (inputID == 0) {
       recursiveResultA = value;
@@ -172,7 +172,7 @@ struct AckermannTask : core::Task {
   }
 
   /// Called when all inputs are available.
-  virtual void inputsAvailable(core::TaskInterface& ti) override {
+  virtual void inputsAvailable(core::TaskInterface ti) override {
     if (m == 0) {
       ti.complete(AckermannValue(n + 1));
       return;

--- a/lib/Commands/BuildSystemCommand.cpp
+++ b/lib/Commands/BuildSystemCommand.cpp
@@ -227,13 +227,13 @@ public:
   virtual bool isResultValid(BuildSystem&, const BuildValue&) override {
     return false;
   }
-  virtual void start(BuildSystem&, TaskInterface&) override {}
-  virtual void providePriorValue(BuildSystem&, TaskInterface&, const BuildValue&) override {}
+  virtual void start(BuildSystem&, TaskInterface) override {}
+  virtual void providePriorValue(BuildSystem&, TaskInterface, const BuildValue&) override {}
   virtual void provideValue(BuildSystem&,
-                            TaskInterface&,
+                            TaskInterface,
                             uintptr_t inputID,
                             const BuildValue&) override {}
-  virtual void execute(BuildSystem& system, TaskInterface&,
+  virtual void execute(BuildSystem& system, TaskInterface,
                        basic::QueueJobContext*, ResultFn resultFn) override {
     resultFn(BuildValue::makeFailedCommand());
   }

--- a/lib/Commands/NinjaBuildCommand.cpp
+++ b/lib/Commands/NinjaBuildCommand.cpp
@@ -984,7 +984,7 @@ buildCommand(BuildContext& context, ninja::Command* command) {
         canUpdateIfNewer = false;
     }
 
-    virtual void provideValue(core::TaskInterface&, uintptr_t inputID,
+    virtual void provideValue(core::TaskInterface, uintptr_t inputID,
                               const core::ValueType& valueData) override {
       // Process the input value to see if we should skip this command.
       BuildValue value = BuildValue::fromValue(valueData);
@@ -1027,7 +1027,7 @@ buildCommand(BuildContext& context, ninja::Command* command) {
       return false;
     }
 
-    virtual void start(core::TaskInterface& ti) override {
+    virtual void start(core::TaskInterface ti) override {
       // If this is a phony rule, ignore any immediately cyclic dependencies in
       // non-strict mode, which are generated frequently by CMake, but can be
       // ignored by Ninja. See https://github.com/martine/ninja/issues/935.
@@ -1065,7 +1065,7 @@ buildCommand(BuildContext& context, ninja::Command* command) {
       }
     }
 
-    virtual void providePriorValue(core::TaskInterface&,
+    virtual void providePriorValue(core::TaskInterface,
                                    const core::ValueType& valueData) override {
       BuildValue value = BuildValue::fromValue(valueData);
 
@@ -1133,7 +1133,7 @@ buildCommand(BuildContext& context, ninja::Command* command) {
       return true;
     }
 
-    virtual void inputsAvailable(core::TaskInterface& ti) override {
+    virtual void inputsAvailable(core::TaskInterface ti) override {
       // If the build is cancelled, skip everything.
       if (context.isCancelled) {
         return ti.complete(BuildValue::makeSkippedCommand().toValue());
@@ -1285,7 +1285,7 @@ buildCommand(BuildContext& context, ninja::Command* command) {
       }
     }
 
-    void executeCommand(core::TaskInterface& ti, QueueJobContext* qctx) {
+    void executeCommand(core::TaskInterface ti, QueueJobContext* qctx) {
       // If the build is cancelled, skip the job.
       if (context.isCancelled) {
         return ti.complete(BuildValue::makeSkippedCommand().toValue());
@@ -1382,7 +1382,7 @@ buildCommand(BuildContext& context, ninja::Command* command) {
     }
 
 
-    bool processDiscoveredDependencies(core::TaskInterface& ti) {
+    bool processDiscoveredDependencies(core::TaskInterface ti) {
       // Process the discovered dependencies, if used.
       switch (command->getDepsStyle()) {
       case ninja::Command::DepsStyleKind::None:
@@ -1420,7 +1420,7 @@ buildCommand(BuildContext& context, ninja::Command* command) {
           const StringRef path;
           unsigned numErrors{0};
 
-          DepsActions(BuildContext& context, core::TaskInterface& ti,
+          DepsActions(BuildContext& context, core::TaskInterface ti,
                       const StringRef workingDirectory,
                       const StringRef path)
             : context(context), ti(ti), workingDirectory(workingDirectory), path(path) { }
@@ -1472,12 +1472,12 @@ static core::Task* buildInput(BuildContext& context, ninja::Node* input) {
     NinjaInputTask(BuildContext& context, ninja::Node* node)
         : context(context), node(node) { }
 
-    virtual void provideValue(core::TaskInterface&, uintptr_t inputID,
+    virtual void provideValue(core::TaskInterface, uintptr_t inputID,
                               const core::ValueType& value) override { }
 
-    virtual void start(core::TaskInterface&) override { }
+    virtual void start(core::TaskInterface) override { }
 
-    virtual void inputsAvailable(core::TaskInterface& ti) override {
+    virtual void inputsAvailable(core::TaskInterface ti) override {
       if (context.simulate) {
         ti.complete(BuildValue::makeExistingInput({}).toValue());
         return;
@@ -1507,7 +1507,7 @@ buildTargets(BuildContext& context,
                 const std::vector<std::string>& targetsToBuild)
         : context(context), targetsToBuild(targetsToBuild) { }
 
-    virtual void provideValue(core::TaskInterface&, uintptr_t inputID,
+    virtual void provideValue(core::TaskInterface, uintptr_t inputID,
                               const core::ValueType& valueData) override {
       BuildValue value = BuildValue::fromValue(valueData);
 
@@ -1517,7 +1517,7 @@ buildTargets(BuildContext& context,
       }
     }
 
-    virtual void start(core::TaskInterface& ti) override {
+    virtual void start(core::TaskInterface ti) override {
       // Request all of the targets.
       unsigned id = 0;
       for (const auto& target: targetsToBuild) {
@@ -1525,7 +1525,7 @@ buildTargets(BuildContext& context,
       }
     }
 
-    virtual void inputsAvailable(core::TaskInterface& ti) override {
+    virtual void inputsAvailable(core::TaskInterface ti) override {
       // Complete the job.
       ti.complete(
         BuildValue::makeSuccessfulCommand({}, CommandSignature()).toValue());
@@ -1553,17 +1553,17 @@ selectCompositeBuildResult(BuildContext& context, ninja::Command* command,
         : context(context), command(command),
           inputIndex(inputIndex), compositeRuleName(compositeRuleName) { }
 
-    virtual void start(core::TaskInterface& ti) override {
+    virtual void start(core::TaskInterface ti) override {
       // Request the composite input.
       ti.request(compositeRuleName, 0);
     }
 
-    virtual void provideValue(core::TaskInterface&, uintptr_t inputID,
+    virtual void provideValue(core::TaskInterface, uintptr_t inputID,
                               const core::ValueType& valueData) override {
       compositeValueData = &valueData;
     }
 
-    virtual void inputsAvailable(core::TaskInterface& ti) override {
+    virtual void inputsAvailable(core::TaskInterface ti) override {
       // Construct the appropriate build value from the result.
       assert(compositeValueData);
       BuildValue value(BuildValue::fromValue(*compositeValueData));

--- a/lib/Evo/EvoEngine.cpp
+++ b/lib/Evo/EvoEngine.cpp
@@ -57,9 +57,9 @@ public:
   ~EvoTask();
 
   // core::Task required methods
-  void start(core::TaskInterface&) override;
-  void provideValue(core::TaskInterface&, uintptr_t inputID, const core::ValueType& value) override;
-  void inputsAvailable(core::TaskInterface&) override;
+  void start(core::TaskInterface) override;
+  void provideValue(core::TaskInterface, uintptr_t inputID, const core::ValueType& value) override;
+  void inputsAvailable(core::TaskInterface) override;
 
   // EvoEngine methods
   EvoInputHandle request(const core::KeyType& key) override;
@@ -184,7 +184,7 @@ EvoTask::~EvoTask() {
 
 // MARK: - EvoTask - core::Task Protocol
 
-void EvoTask::start(core::TaskInterface& ti) {
+void EvoTask::start(core::TaskInterface ti) {
   coreInterface = ti;
   taskThread = std::make_unique<std::thread>(&EvoTask::run, this);
 
@@ -199,7 +199,7 @@ void EvoTask::start(core::TaskInterface& ti) {
   }
 }
 
-void EvoTask::provideValue(core::TaskInterface&, uintptr_t inputID,
+void EvoTask::provideValue(core::TaskInterface, uintptr_t inputID,
                   const core::ValueType& value) {
   std::unique_lock<std::mutex> lock(taskMutex);
   inputs[inputID].first = true;
@@ -221,7 +221,7 @@ void EvoTask::provideValue(core::TaskInterface&, uintptr_t inputID,
   }
 }
 
-void EvoTask::inputsAvailable(core::TaskInterface&) {
+void EvoTask::inputsAvailable(core::TaskInterface) {
   {
     std::lock_guard<std::mutex> lock(taskMutex);
     assert(engineState_pendingInputs == 0);

--- a/perftests/Xcode/PerfTests/CorePerfTests.mm
+++ b/perftests/Xcode/PerfTests/CorePerfTests.mm
@@ -68,21 +68,21 @@ public:
     InputValues.resize(Inputs.size());
   }
 
-  virtual void start(TaskInterface& ti) override {
+  virtual void start(TaskInterface ti) override {
     // Request all of the inputs.
     for (int i = 0, e = Inputs.size(); i != e; ++i) {
       ti.request(Inputs[i], i);
     }
   }
 
-  virtual void provideValue(TaskInterface&, uintptr_t InputID,
+  virtual void provideValue(TaskInterface, uintptr_t InputID,
                             const ValueType& Value) override {
     // Update the input values.
     assert(InputID < InputValues.size());
     InputValues[InputID] = IntFromValue(Value);
   }
 
-  virtual void inputsAvailable(TaskInterface& ti) override {
+  virtual void inputsAvailable(TaskInterface ti) override {
       ti.complete(IntToValue(Compute(InputValues)));
   }
 };

--- a/products/libllbuild/BuildSystem-C-API.cpp
+++ b/products/libllbuild/BuildSystem-C-API.cpp
@@ -696,7 +696,7 @@ class CAPIExternalCommand : public ExternalCommand {
     cAPIDelegate.start(cAPIDelegate.context,
                        (llb_buildsystem_command_t*)this,
                        (llb_buildsystem_interface_t*)&system,
-                       (llb_task_interface_t*)&ti);
+                       *reinterpret_cast<llb_task_interface_t*>(&ti));
   }
 
   void provideValueExternalCommand(BuildSystem& system,
@@ -707,7 +707,7 @@ class CAPIExternalCommand : public ExternalCommand {
     cAPIDelegate.provide_value(cAPIDelegate.context,
                                (llb_buildsystem_command_t*)this,
                                (llb_buildsystem_interface_t*)&system,
-                               (llb_task_interface_t*)&ti,
+                               *reinterpret_cast<llb_task_interface_t*>(&ti),
                                value_p,
                                inputID);
   }
@@ -749,7 +749,7 @@ class CAPIExternalCommand : public ExternalCommand {
         cAPIDelegate.context,
         (llb_buildsystem_command_t*)this,
         (llb_buildsystem_interface_t*)&system,
-        (llb_task_interface_t*)&ti,
+        *reinterpret_cast<llb_task_interface_t*>(&ti),
         (llb_buildsystem_queue_job_context_t*)job_context);
 
       currentBuildValue = reinterpret_cast<CAPIBuildValue*>(rvalue);
@@ -772,7 +772,7 @@ class CAPIExternalCommand : public ExternalCommand {
       cAPIDelegate.context,
       (llb_buildsystem_command_t*)this,
       (llb_buildsystem_interface_t*)&system,
-      (llb_task_interface_t*)&ti,
+      *reinterpret_cast<llb_task_interface_t*>(&ti),
       (llb_buildsystem_queue_job_context_t*)job_context);
     doneFn(success ? ProcessStatus::Succeeded : ProcessStatus::Failed);
   }
@@ -948,14 +948,14 @@ char* llb_buildsystem_command_get_verbose_description(
   return strdup(result.c_str());
 }
 
-void llb_buildsystem_command_interface_task_discovered_dependency(llb_task_interface_t* ti_p, llb_build_key_t* key) {
-  auto ti = (core::TaskInterface*)ti_p;
-  ti->discoveredDependency(((CAPIBuildKey *)key)->getInternalBuildKey().toData());
+void llb_buildsystem_command_interface_task_discovered_dependency(llb_task_interface_t ti, llb_build_key_t* key) {
+  auto coreti = reinterpret_cast<core::TaskInterface*>(&ti);
+  coreti->discoveredDependency(((CAPIBuildKey *)key)->getInternalBuildKey().toData());
 }
 
-void llb_buildsystem_command_interface_task_needs_input(llb_task_interface_t* ti_p, llb_build_key_t* key, uintptr_t inputID) {
-  auto ti = (core::TaskInterface*)ti_p;
-  ti->request(((CAPIBuildKey *)key)->getInternalBuildKey().toData(), inputID);
+void llb_buildsystem_command_interface_task_needs_input(llb_task_interface_t ti, llb_build_key_t* key, uintptr_t inputID) {
+  auto coreti = reinterpret_cast<core::TaskInterface*>(&ti);
+  coreti->request(((CAPIBuildKey *)key)->getInternalBuildKey().toData(), inputID);
 }
 
 llb_build_value_file_info_t llb_buildsystem_command_interface_get_file_info(llb_buildsystem_interface_t* bi_p, const char* path) {

--- a/products/libllbuild/BuildSystem-C-API.cpp
+++ b/products/libllbuild/BuildSystem-C-API.cpp
@@ -637,7 +637,7 @@ class CAPIExternalCommand : public ExternalCommand {
   std::string depsPath;
 
   bool processDiscoveredDependencies(BuildSystem& system,
-                                     core::TaskInterface& ti,
+                                     core::TaskInterface ti,
                                      QueueJobContext* context) {
     // Read the dependencies file.
     auto input = system.getFileSystem().getFileContents(depsPath);
@@ -658,7 +658,7 @@ class CAPIExternalCommand : public ExternalCommand {
       unsigned numErrors{0};
       
       DepsActions(BuildSystem& system,
-                  core::TaskInterface& ti,
+                  core::TaskInterface ti,
                   CAPIExternalCommand* command, StringRef depsPath)
       : system(system), ti(ti), command(command), depsPath(depsPath) {}
       
@@ -692,7 +692,7 @@ class CAPIExternalCommand : public ExternalCommand {
   }
 
   virtual void startExternalCommand(BuildSystem& system,
-                                    core::TaskInterface& ti) override {
+                                    core::TaskInterface ti) override {
     cAPIDelegate.start(cAPIDelegate.context,
                        (llb_buildsystem_command_t*)this,
                        (llb_buildsystem_interface_t*)&system,
@@ -700,7 +700,7 @@ class CAPIExternalCommand : public ExternalCommand {
   }
 
   void provideValueExternalCommand(BuildSystem& system,
-                                   core::TaskInterface& ti,
+                                   core::TaskInterface ti,
                                    uintptr_t inputID,
                                    const BuildValue& value) override {
     auto value_p = (llb_build_value *)new CAPIBuildValue(BuildValue(value));
@@ -718,7 +718,7 @@ class CAPIExternalCommand : public ExternalCommand {
   CAPIBuildValue* currentBuildValue = nullptr;
 
   virtual void executeExternalCommand(BuildSystem& system,
-                                      core::TaskInterface& ti,
+                                      core::TaskInterface ti,
                                       QueueJobContext* job_context,
                                       llvm::Optional<ProcessCompletionFn> completionFn) override {
     auto doneFn = [this, &system, ti, job_context, completionFn](ProcessStatus result) mutable {
@@ -777,7 +777,7 @@ class CAPIExternalCommand : public ExternalCommand {
     doneFn(success ? ProcessStatus::Succeeded : ProcessStatus::Failed);
   }
 
-  BuildValue computeCommandResult(BuildSystem& system, core::TaskInterface& ti) override {
+  BuildValue computeCommandResult(BuildSystem& system, core::TaskInterface ti) override {
     if (currentBuildValue)
       return BuildValue(currentBuildValue->getInternalBuildValue());
 

--- a/products/libllbuild/Core-C-API.cpp
+++ b/products/libllbuild/Core-C-API.cpp
@@ -132,7 +132,7 @@ public:
     }
   }
 
-  virtual void start(TaskInterface& ti) override {
+  virtual void start(TaskInterface ti) override {
     CAPIBuildEngineDelegate* delegate =
       static_cast<CAPIBuildEngineDelegate*>(ti.delegate());
     cAPIDelegate.start(cAPIDelegate.context,
@@ -140,7 +140,7 @@ public:
                        (llb_task_interface_t*)(&ti));
   }
 
-  virtual void provideValue(TaskInterface& ti, uintptr_t inputID,
+  virtual void provideValue(TaskInterface ti, uintptr_t inputID,
                             const ValueType& value) override {
     CAPIBuildEngineDelegate* delegate =
       static_cast<CAPIBuildEngineDelegate*>(ti.delegate());
@@ -151,7 +151,7 @@ public:
                                inputID, &valueData);
   }
 
-  virtual void inputsAvailable(TaskInterface& ti) override {
+  virtual void inputsAvailable(TaskInterface ti) override {
     CAPIBuildEngineDelegate* delegate =
       static_cast<CAPIBuildEngineDelegate*>(ti.delegate());
     cAPIDelegate.inputs_available(cAPIDelegate.context,

--- a/products/libllbuild/Core-C-API.cpp
+++ b/products/libllbuild/Core-C-API.cpp
@@ -137,7 +137,7 @@ public:
       static_cast<CAPIBuildEngineDelegate*>(ti.delegate());
     cAPIDelegate.start(cAPIDelegate.context,
                        delegate->cAPIDelegate.context,
-                       (llb_task_interface_t*)(&ti));
+                       *reinterpret_cast<llb_task_interface_t*>(&ti));
   }
 
   virtual void provideValue(TaskInterface ti, uintptr_t inputID,
@@ -147,7 +147,7 @@ public:
     llb_data_t valueData{ value.size(), value.data() };
     cAPIDelegate.provide_value(cAPIDelegate.context,
                                delegate->cAPIDelegate.context,
-                               (llb_task_interface_t*)(&ti),
+                               *reinterpret_cast<llb_task_interface_t*>(&ti),
                                inputID, &valueData);
   }
 
@@ -156,7 +156,7 @@ public:
       static_cast<CAPIBuildEngineDelegate*>(ti.delegate());
     cAPIDelegate.inputs_available(cAPIDelegate.context,
                                   delegate->cAPIDelegate.context,
-                                  (llb_task_interface_t*)(&ti));
+                                  *reinterpret_cast<llb_task_interface_t*>(&ti));
   }
 };
 
@@ -212,32 +212,32 @@ void llb_buildengine_build(llb_buildengine_t* engine_p, const llb_data_t* key,
   *result_out = llb_data_t{ result.size(), result.data() };
 }
 
-void llb_buildengine_task_needs_input(llb_task_interface_t* ti_p,
+void llb_buildengine_task_needs_input(llb_task_interface_t ti,
                                       const llb_data_t* key,
                                       uintptr_t input_id) {
-  auto ti = ((TaskInterface*) ti_p);
-  ti->request(KeyType((const char*)key->data, key->length), input_id);
+  auto coreti = reinterpret_cast<TaskInterface*>(&ti);
+  coreti->request(KeyType((const char*)key->data, key->length), input_id);
 }
 
-void llb_buildengine_task_must_follow(llb_task_interface_t* ti_p,
+void llb_buildengine_task_must_follow(llb_task_interface_t ti,
                                       const llb_data_t* key) {
-  auto ti = ((TaskInterface*) ti_p);
-  ti->mustFollow(KeyType((const char*)key->data, key->length));
+  auto coreti = reinterpret_cast<TaskInterface*>(&ti);
+  coreti->mustFollow(KeyType((const char*)key->data, key->length));
 }
 
-void llb_buildengine_task_discovered_dependency(llb_task_interface_t* ti_p,
+void llb_buildengine_task_discovered_dependency(llb_task_interface_t ti,
                                                 const llb_data_t* key) {
-  auto ti = ((TaskInterface*) ti_p);
-  ti->discoveredDependency(KeyType((const char*)key->data, key->length));
+  auto coreti = reinterpret_cast<TaskInterface*>(&ti);
+  coreti->discoveredDependency(KeyType((const char*)key->data, key->length));
 }
 
-void llb_buildengine_task_is_complete(llb_task_interface_t* ti_p,
+void llb_buildengine_task_is_complete(llb_task_interface_t ti,
                                       const llb_data_t* value,
                                       bool force_change) {
-  auto ti = ((TaskInterface*) ti_p);
+  auto coreti = reinterpret_cast<TaskInterface*>(&ti);
   std::vector<uint8_t> result(value->length);
   memcpy(result.data(), value->data, value->length);
-  ti->complete(std::move(result));
+  coreti->complete(std::move(result));
 }
 
 llb_task_t* llb_task_create(llb_task_delegate_t delegate) {

--- a/products/libllbuild/include/llbuild/buildsystem.h
+++ b/products/libllbuild/include/llbuild/buildsystem.h
@@ -593,7 +593,7 @@ typedef struct llb_buildsystem_external_command_delegate_t_ {
   /// At this point, the command may choose to request more dependencies
   /// through the build system command interface (bsci) reference.
   void (*start)(void* context, llb_buildsystem_command_t* command,
-                llb_buildsystem_interface_t* bi, llb_task_interface_t* ti);
+                llb_buildsystem_interface_t* bi, llb_task_interface_t ti);
 
   /// Called by the build system when one of the requested dependencies has
   /// become available. The command can identify which key the provided value
@@ -602,7 +602,7 @@ typedef struct llb_buildsystem_external_command_delegate_t_ {
   /// value.
   void (*provide_value)(void* context, llb_buildsystem_command_t* command,
                         llb_buildsystem_interface_t* bi,
-                        llb_task_interface_t* ti,
+                        llb_task_interface_t ti,
                         const llb_build_value* value,
                         uintptr_t inputID);
 
@@ -622,13 +622,13 @@ typedef struct llb_buildsystem_external_command_delegate_t_ {
   bool (*execute_command)(void* context,
                           llb_buildsystem_command_t* command,
                           llb_buildsystem_interface_t* bi,
-                          llb_task_interface_t* ti,
+                          llb_task_interface_t ti,
                           llb_buildsystem_queue_job_context_t* job_context);
 
   llb_build_value* (*execute_command_ex)(void* context,
                                          llb_buildsystem_command_t* command,
                                          llb_buildsystem_interface_t* bi,
-                                         llb_task_interface_t* ti,
+                                         llb_task_interface_t ti,
                                          llb_buildsystem_queue_job_context_t* job_context);
 
   /// Called by the build system to determine if the current build result
@@ -693,11 +693,11 @@ llb_buildsystem_command_get_verbose_description(
 /// When this value is available, it will be provided through the provide_value
 /// method.
 LLBUILD_EXPORT void
-llb_buildsystem_command_interface_task_needs_input(llb_task_interface_t* task, llb_build_key_t* key, uintptr_t inputID);
+llb_buildsystem_command_interface_task_needs_input(llb_task_interface_t ti, llb_build_key_t* key, uintptr_t inputID);
 
 /// Marks a key as a discovered dependency for the task.
 LLBUILD_EXPORT void
-llb_buildsystem_command_interface_task_discovered_dependency(llb_task_interface_t* ti_p, llb_build_key_t* key);
+llb_buildsystem_command_interface_task_discovered_dependency(llb_task_interface_t ti, llb_build_key_t* key);
 
 /// Returns the file info struct for the specified path
 LLBUILD_EXPORT llb_build_value_file_info_t

--- a/products/libllbuild/include/llbuild/core.h
+++ b/products/libllbuild/include/llbuild/core.h
@@ -33,8 +33,11 @@ typedef struct llb_buildengine_t_ llb_buildengine_t;
 /// Opaque handle to an executing task.
 typedef struct llb_task_t_ llb_task_t;
 
-/// Opaque handle to a task interface.
-typedef struct llb_task_interface_t_ llb_task_interface_t;
+/// Largely opaque task interface representation.
+typedef struct llb_task_interface_t_ {
+  void* impl;
+  void* ctx;
+} llb_task_interface_t;
 
 /// Representation for a blob of bytes.
 ///
@@ -172,7 +175,7 @@ llb_buildengine_build(llb_buildengine_t* engine, const llb_data_t* key,
 /// input IDs greater than \see kMaximumInputID are reserved for internal use by
 /// the engine.
 LLBUILD_EXPORT void
-llb_buildengine_task_needs_input(llb_task_interface_t* ti,
+llb_buildengine_task_needs_input(llb_task_interface_t ti,
                                  const llb_data_t* key, uintptr_t input_id);
 
 /// Specify that the given \arg task must be built subsequent to the
@@ -182,7 +185,7 @@ llb_buildengine_task_needs_input(llb_task_interface_t* ti,
 /// the only guarantee the engine provides is that if \arg key is computed
 /// during a build, then \arg task will not be computed until after it.
 LLBUILD_EXPORT void
-llb_buildengine_task_must_follow(llb_task_interface_t* ti,
+llb_buildengine_task_must_follow(llb_task_interface_t ti,
                                  const llb_data_t* key);
 
 /// Inform the engine of an input dependency that was discovered by the task
@@ -206,7 +209,7 @@ llb_buildengine_task_must_follow(llb_task_interface_t* ti,
 /// responsible for ensuring that it is never called concurrently for the same
 /// task.
 LLBUILD_EXPORT void
-llb_buildengine_task_discovered_dependency(llb_task_interface_t* ti,
+llb_buildengine_task_discovered_dependency(llb_task_interface_t ti,
                                            const llb_data_t* key);
 
 /// Called by a task to indicate it has completed and to provide its value.
@@ -219,7 +222,7 @@ llb_buildengine_task_discovered_dependency(llb_task_interface_t* ti,
 /// dependents to rebuild, even if the value itself is not different from the
 /// prior result.
 LLBUILD_EXPORT void
-llb_buildengine_task_is_complete(llb_task_interface_t* ti,
+llb_buildengine_task_is_complete(llb_task_interface_t ti,
                                  const llb_data_t* value, bool force_change);
 
 /// @}
@@ -240,7 +243,7 @@ typedef struct llb_task_delegate_t_ {
     /// Xparam context The task context pointer.
     /// Xparam engine_context The context pointer for the engine delegate.
     /// Xparam task The task which is being started.
-    void (*start)(void* context, void* engine_context, llb_task_interface_t* ti);
+    void (*start)(void* context, void* engine_context, llb_task_interface_t ti);
 
     /// The callback to provide a requested input value to the task.
     ///
@@ -248,7 +251,7 @@ typedef struct llb_task_delegate_t_ {
     /// Xparam engine_context The context pointer for the engine delegate.
     /// Xparam task The task which is being started.
     void (*provide_value)(void* context, void* engine_context, 
-                          llb_task_interface_t* ti,
+                          llb_task_interface_t ti,
                           uintptr_t input_id, const llb_data_t* value);
 
     /// The callback indicating that all requested inputs have been provided.
@@ -261,7 +264,7 @@ typedef struct llb_task_delegate_t_ {
     /// Xparam engine_context The context pointer for the engine delegate.
     /// Xparam task The task which is being started.
     void (*inputs_available)(void* context, void* engine_context,
-                             llb_task_interface_t* ti);
+                             llb_task_interface_t ti);
 } llb_task_delegate_t;
 
 /// Create a task object.

--- a/products/libllbuild/include/llbuild/llbuild.h
+++ b/products/libllbuild/include/llbuild/llbuild.h
@@ -81,6 +81,8 @@
 ///
 /// Version History:
 ///
+/// 10: Changed to a llb_task_interface_t copies instead of pointers
+///
 /// 9: Changed the API for build keys to use bridged opaque pointers with access functions
 ///
 /// 8: Move scheduler algorithm and lanes into llb_buildsystem_invocation_t
@@ -100,7 +102,7 @@
 /// 1: Added `environment` parameter to llb_buildsystem_invocation_t.
 ///
 /// 0: Pre-history
-#define LLBUILD_C_API_VERSION 9
+#define LLBUILD_C_API_VERSION 10
 
 /// Get the full version of the llbuild library.
 LLBUILD_EXPORT const char* llb_get_full_version_string(void);

--- a/products/llbuildSwift/CoreBindings.swift
+++ b/products/llbuildSwift/CoreBindings.swift
@@ -292,9 +292,9 @@ extension TaskBuildEngine {
     }
 }
 private class TaskInterfaceWrapper: TaskBuildEngine {
-    var ti: OpaquePointer?
+    var ti: llb_task_interface_t
 
-    init(_ taskInterface: OpaquePointer?) {
+    init(_ taskInterface: llb_task_interface_t) {
         self.ti = taskInterface
     }
 

--- a/unittests/CAPI/BuildSystem-C-API.cpp
+++ b/unittests/CAPI/BuildSystem-C-API.cpp
@@ -59,12 +59,12 @@ static void writeFileContents(std::string path, std::string str) {
 static void depinfo_tester_command_start(void* context,
                                          llb_buildsystem_command_t* command,
                                          llb_buildsystem_interface_t* bi,
-                                         llb_task_interface_t* ti) {}
+                                         llb_task_interface_t ti) {}
 
 static void depinfo_tester_command_provide_value(void* context,
                                                  llb_buildsystem_command_t* command,
                                                  llb_buildsystem_interface_t* bi,
-                                                 llb_task_interface_t* ti,
+                                                 llb_task_interface_t ti,
                                                  const llb_build_value* value,
                                                  uintptr_t inputID) {}
   
@@ -72,7 +72,7 @@ static bool
 depinfo_tester_command_execute_command(void *context,
                                        llb_buildsystem_command_t* command,
                                        llb_buildsystem_interface_t* bi,
-                                       llb_task_interface_t* ti,
+                                       llb_task_interface_t ti,
                                        llb_buildsystem_queue_job_context_t* job) {
   // The tester tool is given a direct input file whose only contents are the
   // path of another, indirect input file.  It is also given the paths to which

--- a/unittests/Core/BuildEngineCancellationTest.cpp
+++ b/unittests/Core/BuildEngineCancellationTest.cpp
@@ -96,7 +96,7 @@ public:
   {
   }
 
-  virtual void start(TaskInterface& ti) override {
+  virtual void start(TaskInterface ti) override {
     // Compute the list of inputs.
     auto inputs = listInputs();
 
@@ -107,14 +107,14 @@ public:
     }
   }
 
-  virtual void provideValue(TaskInterface&, uintptr_t inputID,
+  virtual void provideValue(TaskInterface, uintptr_t inputID,
                             const ValueType& value) override {
     // Update the input values.
     assert(inputID < inputValues.size());
     inputValues[inputID] = intFromValue(value);
   }
 
-  virtual void inputsAvailable(TaskInterface& ti) override {
+  virtual void inputsAvailable(TaskInterface ti) override {
     ti.complete(intToValue(compute(inputValues)));
   }
 };

--- a/unittests/Core/BuildEngineTest.cpp
+++ b/unittests/Core/BuildEngineTest.cpp
@@ -115,7 +115,7 @@ public:
   {
   }
 
-  virtual void start(TaskInterface& ti) override {
+  virtual void start(TaskInterface ti) override {
     // Compute the list of inputs.
     auto inputs = listInputs();
 
@@ -126,14 +126,14 @@ public:
     }
   }
 
-  virtual void provideValue(TaskInterface&, uintptr_t inputID,
+  virtual void provideValue(TaskInterface, uintptr_t inputID,
                             const ValueType& value) override {
     // Update the input values.
     assert(inputID < inputValues.size());
     inputValues[inputID] = intFromValue(value);
   }
 
-  virtual void inputsAvailable(TaskInterface& ti) override {
+  virtual void inputsAvailable(TaskInterface ti) override {
     ti.complete(intToValue(compute(inputValues)));
   }
 };
@@ -600,18 +600,18 @@ TEST(BuildEngineTest, discoveredDependencies) {
   public:
     TaskWithDiscoveredDependency(int& valueB) : valueB(valueB) { }
 
-    virtual void start(TaskInterface& ti) override {
+    virtual void start(TaskInterface ti) override {
       // Request the known input.
       ti.request("value-A", 0);
     }
 
-    virtual void provideValue(TaskInterface&, uintptr_t inputID,
+    virtual void provideValue(TaskInterface, uintptr_t inputID,
                               const ValueType& value) override {
       assert(inputID == 0);
       computedInputValue = intFromValue(value);
     }
 
-    virtual void inputsAvailable(TaskInterface& ti) override {
+    virtual void inputsAvailable(TaskInterface ti) override {
       // Report the discovered dependency.
       ti.discoveredDependency("value-B");
       ti.complete(intToValue(computedInputValue * valueB * 5));

--- a/unittests/Core/DepsBuildEngineTest.cpp
+++ b/unittests/Core/DepsBuildEngineTest.cpp
@@ -96,21 +96,21 @@ public:
     inputValues.resize(inputs.size());
   }
 
-  virtual void start(TaskInterface& ti) override {
+  virtual void start(TaskInterface ti) override {
     // Request all of the inputs.
     for (int i = 0, e = inputs.size(); i != e; ++i) {
       ti.request(inputs[i], i);
     }
   }
 
-  virtual void provideValue(TaskInterface&, uintptr_t inputID,
+  virtual void provideValue(TaskInterface, uintptr_t inputID,
                             const ValueType& value) override {
     // Update the input values.
     assert(inputID < inputValues.size());
     inputValues[inputID] = intFromValue(value);
   }
 
-  virtual void inputsAvailable(TaskInterface& ti) override {
+  virtual void inputsAvailable(TaskInterface ti) override {
     ti.complete(intToValue(compute(inputValues)));
   }
 };
@@ -198,12 +198,12 @@ TEST(DepsBuildEngineTest, BogusConcurrentDepScan) {
     int result = 1;
 
   public:
-    virtual void start(TaskInterface& ti) override {
+    virtual void start(TaskInterface ti) override {
       // Request the known input.
       ti.request("dir-list", 0);
     }
 
-    virtual void provideValue(TaskInterface& ti, uintptr_t inputID,
+    virtual void provideValue(TaskInterface ti, uintptr_t inputID,
                               const ValueType& value) override {
       int N = intFromValue(value);
       result *= N;
@@ -223,7 +223,7 @@ TEST(DepsBuildEngineTest, BogusConcurrentDepScan) {
       }
     }
 
-    virtual void inputsAvailable(TaskInterface& ti) override {
+    virtual void inputsAvailable(TaskInterface ti) override {
       ti.complete(intToValue(result));
     }
   };


### PR DESCRIPTION
Passing a reference to a stack allocated TaskInterface object complicated safe usage of it in clients.  In particular, the Swift/C-API interface made it unsafe to perform work on another thread. This changes to pass-by-value semantics for the small, two pointer class/struct, enabling simpler/safer use of it on other threads.