### PR TITLE
[Core] Record dependencies in order requested

### DIFF
--- a/include/llbuild/Core/BuildEngine.h
+++ b/include/llbuild/Core/BuildEngine.h
@@ -121,6 +121,8 @@ public:
   /// @{
 
   /// Specify the task depends upon the result of computing \arg Key.
+  /// The order in which these inputs are requested will be preserved in
+  /// subsequent builds when scanning dependencies.
   ///
   /// The result, when available, will be provided to the task via \see
   /// Task::provideValue(), supplying the provided \arg InputID to allow the

--- a/tests/BuildSystem/Build/basic.llbuild
+++ b/tests/BuildSystem/Build/basic.llbuild
@@ -25,7 +25,7 @@
 # CHECK-TRACE: "new-rule", "R1", "Tbasic"
 # CHECK-TRACE: "new-rule", "R2", "Noutput"
 # CHECK-TRACE: "new-rule", "R3", "Ccp-output"
-# CHECK-TRACE: "new-rule", "R4", "N<env-2>"
+# CHECK-TRACE: "new-rule", "R4", "Ninput A"
 # CHECK-TRACE: "build-ended"
 
 # Check that a null build does nothing.

--- a/tests/BuildSystem/Build/file-system-opts.llbuild
+++ b/tests/BuildSystem/Build/file-system-opts.llbuild
@@ -25,7 +25,7 @@
 # CHECK-TRACE: "new-rule", "R1", "Tbasic"
 # CHECK-TRACE: "new-rule", "R2", "Noutput"
 # CHECK-TRACE: "new-rule", "R3", "Ccp-output"
-# CHECK-TRACE: "new-rule", "R4", "N<env-2>"
+# CHECK-TRACE: "new-rule", "R4", "Ninput A"
 # CHECK-TRACE: "build-ended"
 
 # Check that a null build does nothing.

--- a/tests/Ninja/Build/graphviz-output.ninja
+++ b/tests/Ninja/Build/graphviz-output.ninja
@@ -19,7 +19,7 @@
 # CHECK: "{{/.*/}}a.out" -> "{{/.*/}}a.o"
 #
 # CHECK: "{{/.*/}}b.o"
-# CHECK-NEXT: "{{/.*/}}b.o" -> "b.c"
+# CHECK: "{{/.*/}}b.o" -> "b.c"
 #
 # CHECK: "a.c"
 #

--- a/unittests/Core/BuildEngineTest.cpp
+++ b/unittests/Core/BuildEngineTest.cpp
@@ -853,7 +853,7 @@ TEST(BuildEngineTest, CycleDuringScanningFromTop) {
     iteration = 1;
     auto result = engine.build("A");
     EXPECT_EQ(ValueType{}, result);
-    EXPECT_EQ(std::vector<std::string>({ "A", "C", "B", "C" }), delegate.cycle);
+    EXPECT_EQ(std::vector<std::string>({ "A", "B", "C", "B" }), delegate.cycle);
   }
 
   // Rebuild, allowing the engine to resolve the cycle


### PR DESCRIPTION
This changes the core engine processing order to preserve the order in which tasks/the client have requested input dependencies. This ensures that subsequent builds scan those dependencies in a similar ordering.