### PR TITLE
llbuildSwift: correct a memory corruption issue

### DIFF
--- a/products/llbuildSwift/BuildSystemBindings.swift
+++ b/products/llbuildSwift/BuildSystemBindings.swift
@@ -841,6 +841,10 @@ public final class BuildSystem {
     public func build(target: String? = nil) -> Bool {
         var data = target.map({ copiedDataFromBytes([UInt8]($0.utf8)) }) ?? llb_data_t(length: 0, data: nil)
         defer {
+            if data.data != nil {
+              UnsafeMutablePointer<UInt8>(mutating: data.data).deallocate()
+            }
+            data.data = nil
             llb_data_destroy(&data)
         }
         return llb_buildsystem_build(_system, &data)


### PR DESCRIPTION
The memory allocation for the data here is done via copying the data
from the bytes in the string.  This allocation is done by
`UnsafeMutableBufferPointer.allocate`.  Map the release for that data to
`UnsafeMutableBufferPointer.deallocate`.

This presented itself as a heap buffer corruption on Windows when
building swift-package-manager with swift-package-manager in release
mode on Windows.