### PR TITLE
Add QoS parameter for a build invocation

### DIFF
--- a/include/llbuild/Basic/ExecutionQueue.h
+++ b/include/llbuild/Basic/ExecutionQueue.h
@@ -224,7 +224,7 @@ namespace llbuild {
     /// capped limit on the number of concurrent lanes.
     ExecutionQueue* createLaneBasedExecutionQueue(
         ExecutionQueueDelegate& delegate, int numLanes, SchedulerAlgorithm alg,
-        const char* const* environment);
+        QualityOfService qos, const char* const* environment);
 
     /// Create an execution queue that executes all tasks serially on a single
     /// thread.

--- a/include/llbuild/BuildSystem/BuildSystemFrontend.h
+++ b/include/llbuild/BuildSystem/BuildSystemFrontend.h
@@ -349,6 +349,9 @@ public:
 
   uint32_t schedulerLanes = 0;
 
+  /// The Quality of Service class to use. If not set the global default setting will be used.
+  Optional<basic::QualityOfService> qos;
+
   /// The base environment to use when executing subprocesses.
   ///
   /// The format is expected to match that of `::main()`, i.e. a null-terminated

--- a/lib/Basic/Subprocess.cpp
+++ b/lib/Basic/Subprocess.cpp
@@ -106,7 +106,7 @@ namespace {
 
 #if defined(__APPLE__)
   qos_class_t _getDarwinQOSClass(QualityOfService level) {
-    switch (getDefaultQualityOfService()) {
+    switch (level) {
       case QualityOfService::Normal:
         return QOS_CLASS_DEFAULT;
       case QualityOfService::UserInitiated:
@@ -136,7 +136,7 @@ void llbuild::basic::setDefaultQualityOfService(QualityOfService level) {
 void llbuild::basic::setCurrentThreadQualityOfService(QualityOfService level) {
 #if defined(__APPLE__)
   pthread_set_qos_class_self_np(
-      _getDarwinQOSClass(getDefaultQualityOfService()), 0);
+      _getDarwinQOSClass(level), 0);
 #endif
 
 }
@@ -735,10 +735,9 @@ void llbuild::basic::spawnProcess(
   flags |= POSIX_SPAWN_CLOEXEC_DEFAULT;
 #endif
 
-  // On Darwin, set the QOS of launched processes to the global default.
+  // On Darwin, set the QoS of launched processes to one of the current thread.
 #ifdef __APPLE__
-  posix_spawnattr_set_qos_class_np(
-      &attributes, _getDarwinQOSClass(defaultQualityOfService));
+  posix_spawnattr_set_qos_class_np(&attributes, qos_class_self());
 #endif
 
   posix_spawnattr_setflags(&attributes, flags);

--- a/lib/BuildSystem/BuildSystemFrontend.cpp
+++ b/lib/BuildSystem/BuildSystemFrontend.cpp
@@ -585,11 +585,13 @@ std::unique_ptr<ExecutionQueue>
 BuildSystemFrontendDelegate::createExecutionQueue() {
   auto impl = static_cast<BuildSystemFrontendDelegateImpl*>(this->impl);
   auto invocation = impl->frontend->invocation;
+  QualityOfService qos = invocation.qos.hasValue() ?
+      invocation.qos.getValue() : getDefaultQualityOfService();
   
   if (invocation.useSerialBuild) {
     return std::unique_ptr<ExecutionQueue>(
         createLaneBasedExecutionQueue(impl->executionQueueDelegate, 1,
-                                      invocation.schedulerAlgorithm,
+                                      invocation.schedulerAlgorithm, qos,
                                       invocation.environment));
   }
     
@@ -607,7 +609,7 @@ BuildSystemFrontendDelegate::createExecutionQueue() {
     
   return std::unique_ptr<ExecutionQueue>(
       createLaneBasedExecutionQueue(impl->executionQueueDelegate, numLanes,
-                                    invocation.schedulerAlgorithm,
+                                    invocation.schedulerAlgorithm, qos,
                                     invocation.environment));
 }
 

--- a/lib/Commands/NinjaBuildCommand.cpp
+++ b/lib/Commands/NinjaBuildCommand.cpp
@@ -2370,6 +2370,6 @@ int commands::executeNinjaBuildCommand(std::vector<std::string> args) {
 
 std::unique_ptr<basic::ExecutionQueue> NinjaBuildEngineDelegate::createExecutionQueue() {
   return std::unique_ptr<basic::ExecutionQueue>(
-    createLaneBasedExecutionQueue(*context, context->numJobsInParallel, context->schedulerAlgorithm, nullptr)
+    createLaneBasedExecutionQueue(*context, context->numJobsInParallel, context->schedulerAlgorithm, getDefaultQualityOfService(), nullptr)
   );
 }

--- a/products/libllbuild/include/llbuild/buildsystem.h
+++ b/products/libllbuild/include/llbuild/buildsystem.h
@@ -172,6 +172,26 @@ typedef enum LLBUILD_ENUM_ATTRIBUTES {
   llb_scheduler_algorithm_fifo = 1
 } llb_scheduler_algorithm_t LLBUILD_SWIFT_NAME(SchedulerAlgorithm);
 
+/// Quality of service levels.
+typedef enum LLBUILD_ENUM_ATTRIBUTES {
+    /// A default quality of service (i.e. what the system would use without
+    /// other advisement, generally this would be comparable to what would be
+    /// done by `make`, `ninja`, etc.)
+    llb_quality_of_service_default = 0,
+
+    /// User-initiated, high priority work.
+    llb_quality_of_service_user_initiated LLBUILD_SWIFT_NAME(userInitiated) = 1,
+
+    /// Batch work performed on behalf of the user.
+    llb_quality_of_service_utility = 2,
+
+    /// Background work that is not directly visible to the user.
+    llb_quality_of_service_background = 3,
+
+    /// Not specified for a build invocation; the global default QoS setting will be used.
+    llb_quality_of_service_unspecified = 4
+} llb_quality_of_service_t LLBUILD_SWIFT_NAME(QualityOfService);
+
 /// Invocation parameters for a build system.
 typedef struct llb_buildsystem_invocation_t_ llb_buildsystem_invocation_t;
 struct llb_buildsystem_invocation_t_ {
@@ -206,6 +226,8 @@ struct llb_buildsystem_invocation_t_ {
   llb_scheduler_algorithm_t schedulerAlgorithm;
 
   uint32_t schedulerLanes;
+
+  llb_quality_of_service_t qos;
 };
   
 /// Delegate structure for callbacks required by the build system.
@@ -705,23 +727,6 @@ llb_buildsystem_command_interface_get_file_info(llb_buildsystem_interface_t* bi_
 
 
 // MARK: Quality of Service
-
-/// Quality of service levels.
-typedef enum LLBUILD_ENUM_ATTRIBUTES {
-    /// A default quality of service (i.e. what the system would use without
-    /// other advisement, generally this would be comparable to what would be
-    /// done by `make`, `ninja`, etc.)
-    llb_quality_of_service_default = 0,
-
-    /// User-initiated, high priority work.
-    llb_quality_of_service_user_initiated LLBUILD_SWIFT_NAME(userInitiated) = 1,
-
-    /// Batch work performed on behalf of the user.
-    llb_quality_of_service_utility = 2,
-
-    /// Background work that is not directly visible to the user.
-    llb_quality_of_service_background = 3
-} llb_quality_of_service_t LLBUILD_SWIFT_NAME(QualityOfService);
 
 /// Get the global quality of service level to use for processing.
 LLBUILD_EXPORT llb_quality_of_service_t

--- a/products/libllbuild/include/llbuild/llbuild.h
+++ b/products/libllbuild/include/llbuild/llbuild.h
@@ -81,6 +81,8 @@
 ///
 /// Version History:
 ///
+/// 11: Added QualityOfService field to llb_buildsystem_invocation_t
+///
 /// 10: Changed to a llb_task_interface_t copies instead of pointers
 ///
 /// 9: Changed the API for build keys to use bridged opaque pointers with access functions
@@ -102,7 +104,7 @@
 /// 1: Added `environment` parameter to llb_buildsystem_invocation_t.
 ///
 /// 0: Pre-history
-#define LLBUILD_C_API_VERSION 10
+#define LLBUILD_C_API_VERSION 11
 
 /// Get the full version of the llbuild library.
 LLBUILD_EXPORT const char* llb_get_full_version_string(void);

--- a/products/llbuildSwift/BuildSystemBindings.swift
+++ b/products/llbuildSwift/BuildSystemBindings.swift
@@ -706,6 +706,8 @@ private final class CStyleEnvironment {
 public final class BuildSystem {
     public typealias SchedulerAlgorithm = llbuild.SchedulerAlgorithm
 
+    public typealias QualityOfService = llbuild.QualityOfService
+
     /// The build file that the system is configured with.
     public let buildFile: String
 
@@ -718,7 +720,7 @@ public final class BuildSystem {
     /// The C environment, if used.
     private let _cEnvironment: CStyleEnvironment
 
-    public init(buildFile: String, databaseFile: String, delegate: BuildSystemDelegate, environment: [String: String]? = nil, serial: Bool = false, traceFile: String? = nil, schedulerAlgorithm: SchedulerAlgorithm = .commandNamePriority, schedulerLanes: UInt32 = 0) {
+    public init(buildFile: String, databaseFile: String, delegate: BuildSystemDelegate, environment: [String: String]? = nil, serial: Bool = false, traceFile: String? = nil, schedulerAlgorithm: SchedulerAlgorithm = .commandNamePriority, schedulerLanes: UInt32 = 0, qos: QualityOfService? = nil) {
 
         // Safety check that we have linked against a compatibile llbuild framework version
         if llb_get_api_version() != LLBUILD_C_API_VERSION {
@@ -751,6 +753,7 @@ public final class BuildSystem {
             _invocation.useSerialBuild = serial
             _invocation.schedulerAlgorithm = schedulerAlgorithm
             _invocation.schedulerLanes = schedulerLanes
+            _invocation.qos = qos ?? .unspecified
 
             // Construct the system delegate.
             var _delegate = llb_buildsystem_delegate_t()

--- a/unittests/Basic/LaneBasedExecutionQueueTest.cpp
+++ b/unittests/Basic/LaneBasedExecutionQueueTest.cpp
@@ -63,6 +63,7 @@ namespace {
     auto queue = std::unique_ptr<ExecutionQueue>(
         createLaneBasedExecutionQueue(delegate, 2,
                                       SchedulerAlgorithm::NamePriority,
+                                      getDefaultQualityOfService(),
                                       /*environment=*/nullptr));
 
     auto fn = [&outputFile, &queue](QueueJobContext* context) {
@@ -95,6 +96,7 @@ namespace {
     auto queue = std::unique_ptr<ExecutionQueue>(
         createLaneBasedExecutionQueue(delegate, 2,
                                       SchedulerAlgorithm::NamePriority,
+                                      getDefaultQualityOfService(),
                                       /*environment=*/nullptr));
 
     auto fn = [&tempDir, &queue](QueueJobContext* context) {
@@ -134,6 +136,7 @@ namespace {
     auto queue = std::unique_ptr<ExecutionQueue>(
         createLaneBasedExecutionQueue(delegate, 1,
                                       SchedulerAlgorithm::NamePriority,
+                                      getDefaultQualityOfService(),
                                       /*environment=*/nullptr));
 
     bool buildStarted { false };

--- a/unittests/BuildSystem/MockBuildSystemDelegate.h
+++ b/unittests/BuildSystem/MockBuildSystemDelegate.h
@@ -93,6 +93,7 @@ public:
     return std::unique_ptr<ExecutionQueue>(
         createLaneBasedExecutionQueue(executionQueueDelegate, /*numLanes=*/1,
                                       SchedulerAlgorithm::NamePriority,
+                                      getDefaultQualityOfService(),
                                       /*environment=*/nullptr));
   }
   


### PR DESCRIPTION
This allows controlling the QoS execution per BuildSystem instance.

Part of rdar://63197398