### PR TITLE
build: define `libllbuild_EXPORTS` on Windows

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -68,6 +68,10 @@ let package = Package(
             path: "products/libllbuild",
             cxxSettings: [
               .define("LLVM_ON_WIN32", .when(platforms: [.windows])),
+              // FIXME: we need to define `libllbuild_EXPORTS` to ensure that the
+              // symbols are exported from the DLL that is being built here until
+              // static linking is supported on Windows.
+              .define("libllbuild_EXPORTS", .when(platforms: [.windows])),
             ]
         ),
 


### PR DESCRIPTION
This is required to decorate the public symbols with
`__declspec(dllexport)` as we do not currently support static linking on
Windows with SwiftPM.