### PR TITLE
build: repair the windows build after #683

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -213,8 +213,8 @@ let package = Package(
 // FIXME: Conditionalize these flags since SwiftPM 5.3 and earlier will crash for platforms they don't know about.
 #if os(Windows)
 
-["llvmSupport", "llvmDemangle", "llbuildBuildSystem", "llbuildBasic"].forEach {
-    package.targets.first{ $0.name == $0 }?.cxxSettings = [
+["llvmSupport", "llvmDemangle", "llbuildBuildSystem", "llbuildBasic"].forEach { target in
+    package.targets.first(where: { $0.name == target })?.cxxSettings = [
         .define("LLVM_ON_WIN32", .when(platforms: [.windows])),
     ]
 }


### PR DESCRIPTION
The original alteration would not compile since the anonymous binding
for the outer closure was lost.  This should hopefully repair the build.