### PR TITLE
[Package] add ncurses dependency for Android

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -204,7 +204,7 @@ let package = Package(
             path: "lib/llvm/Support",
             linkerSettings: [
                 .linkedLibrary("m", .when(platforms: [.linux])),
-                .linkedLibrary("ncurses", .when(platforms: [.linux, .macOS]))]
+                .linkedLibrary("ncurses", .when(platforms: [.linux, .macOS, .android]))]
         ),
     ],
     cxxLanguageStandard: .cxx14


### PR DESCRIPTION
I've been [using this patch for Android](https://github.com/termux/termux-packages/commit/5e6418f935dff04592ac046fa76b24d52c974933#diff-3e4d7e12295ed3c5dd4a544329edc3a5R16) since last year, but couldn't upstream it till the `swift-tools-version` was bumped to 5.2, which finally happened with 1f45b1106 a couple weeks ago. This is needed because [I didn't add Android to SPM as a platform till before the 5.2 branch](https://github.com/apple/swift-package-manager/pull/2396/files#diff-b1cc9168051b688bafb8ae050c4f6c7bR42).