### PR TITLE
Provide capability for clients to build a node and walk the rule result info for the node and its dependencies

### DIFF
--- a/include/llbuild/BuildSystem/BuildSystem.h
+++ b/include/llbuild/BuildSystem/BuildSystem.h
@@ -30,6 +30,9 @@ namespace basic {
   class ExecutionQueue;
   class FileSystem;
 }
+namespace core {
+  class RuleResultsWalker;
+}
 
 namespace buildsystem {
 
@@ -262,8 +265,9 @@ public:
   ///
   /// A build description *must* have been loaded before calling this method.
   ///
+  /// \param resultsWalker Optional walker for receiving the rule results of the node and its dependencies.
   /// \returns The result of computing the value, or nil if the build failed.
-  llvm::Optional<BuildValue> build(BuildKey target);
+  llvm::Optional<BuildValue> build(BuildKey target, core::RuleResultsWalker* resultsWalker = nullptr);
 
   /// Reset mutable build state before a new build operation.
   void resetForBuild();

--- a/include/llbuild/BuildSystem/BuildSystemFrontend.h
+++ b/include/llbuild/BuildSystem/BuildSystemFrontend.h
@@ -84,8 +84,9 @@ public:
 
   /// Build a single node using the specified invocation parameters.
   ///
+  /// \param resultsWalker Optional walker for receiving the rule results of the node and its dependencies.
   /// \returns True on success, or false if there were errors.
-  bool buildNode(StringRef nodeToBuild);
+  bool buildNode(StringRef nodeToBuild, core::RuleResultsWalker* resultsWalker = nullptr);
 
   /// @}
 };

--- a/include/llbuild/Core/BuildEngine.h
+++ b/include/llbuild/Core/BuildEngine.h
@@ -389,6 +389,29 @@ public:
 
 };
 
+/// Abstract class for visiting the rule results of a node and its dependencies.
+class RuleResultsWalker {
+public:
+  /// Specifies how node visitation should proceed.
+  enum class ActionKind {
+    /// Continue visiting the rule results of the current node dependencies.
+    VisitDependencies = 0,
+
+    /// Continue visiting but skip the current node dependencies.
+    SkipDependencies = 1,
+
+    /// Stop visitation.
+    Stop = 2
+  };
+
+  /// Accepts the rule result for a node.
+  ///
+  /// \param key The key for the currenly visited node.
+  /// \param key The rule result for the currenly visited node.
+  /// \returns An action kind to indicate how visitation should proceed.
+  virtual ActionKind visitResult(const KeyType& key, const core::Result& result) = 0;
+};
+
 /// A build engine supports fast, incremental, persistent, and parallel
 /// execution of computational graphs.
 ///
@@ -444,10 +467,11 @@ public:
 
   /// Build the result for a particular key.
   ///
+  /// \param resultsWalker Optional walker for receiving the rule results of the node and its dependencies.
   /// \returns The result of computing the key, or the empty value if the key
   /// could not be computed; the latter case only happens if a cycle was
   /// discovered currently.
-  const ValueType& build(const KeyType& key);
+  const ValueType& build(const KeyType& key, RuleResultsWalker* resultsWalker = nullptr);
 
   /// Cancel the currently running build.
   ///

--- a/lib/BuildSystem/BuildSystem.cpp
+++ b/lib/BuildSystem/BuildSystem.cpp
@@ -326,7 +326,7 @@ public:
   }
 
   /// Build the given key, and return the result and an indication of success.
-  llvm::Optional<BuildValue> build(BuildKey key);
+  llvm::Optional<BuildValue> build(BuildKey key, RuleResultsWalker* resultsWalker);
   
   bool build(StringRef target);
 
@@ -1823,7 +1823,7 @@ BuildSystemImpl::lookupNode(StringRef name, bool isImplicit) {
   return BuildNode::makePlain(name);
 }
 
-llvm::Optional<BuildValue> BuildSystemImpl::build(BuildKey key) {
+llvm::Optional<BuildValue> BuildSystemImpl::build(BuildKey key, RuleResultsWalker* resultsWalker) {
 
   if (basic::sys::raiseOpenFileLimit() != 0) {
     error(getMainFilename(), "failed to raise open file limit");
@@ -1832,7 +1832,7 @@ llvm::Optional<BuildValue> BuildSystemImpl::build(BuildKey key) {
 
   // Build the target.
   buildWasAborted = false;
-  auto result = buildEngine.build(key.toData());
+  auto result = buildEngine.build(key.toData(), resultsWalker);
     
   // Clear out the shell handlers, as we do not want to hold on to them across
   // multiple builds.
@@ -1863,7 +1863,7 @@ bool BuildSystemImpl::build(StringRef target) {
     return false;
   }
 
-  return build(BuildKey::makeTarget(target)).hasValue();
+  return build(BuildKey::makeTarget(target), nullptr).hasValue();
 }
 
 #pragma mark - PhonyTool implementation
@@ -3864,8 +3864,8 @@ bool BuildSystem::enableTracing(StringRef path,
   return static_cast<BuildSystemImpl*>(impl)->enableTracing(path, error_out);
 }
 
-llvm::Optional<BuildValue> BuildSystem::build(BuildKey key) {
-  return static_cast<BuildSystemImpl*>(impl)->build(key);
+llvm::Optional<BuildValue> BuildSystem::build(BuildKey key, RuleResultsWalker* resultsWalker) {
+  return static_cast<BuildSystemImpl*>(impl)->build(key, resultsWalker);
 }
 
 bool BuildSystem::build(StringRef name) {

--- a/lib/BuildSystem/BuildSystemFrontend.cpp
+++ b/lib/BuildSystem/BuildSystemFrontend.cpp
@@ -435,7 +435,7 @@ public:
   }
 
 
-  bool buildNode(StringRef nodeToBuild) {
+  bool buildNode(StringRef nodeToBuild, core::RuleResultsWalker* resultsWalker) {
     llbuild_defer {
       resetAfterBuild();
     };
@@ -444,7 +444,7 @@ public:
       return false;
     }
 
-    auto buildValue = system->build(BuildKey::makeNode(nodeToBuild));
+    auto buildValue = system->build(BuildKey::makeNode(nodeToBuild), resultsWalker);
     if (!buildValue.hasValue()) {
       return false;
     }
@@ -808,6 +808,6 @@ bool BuildSystemFrontend::build(StringRef targetToBuild) {
   return static_cast<BuildSystemFrontendImpl*>(impl)->build(targetToBuild);
 }
 
-bool BuildSystemFrontend::buildNode(StringRef nodeToBuild) {
-  return static_cast<BuildSystemFrontendImpl*>(impl)->buildNode(nodeToBuild);
+bool BuildSystemFrontend::buildNode(StringRef nodeToBuild, core::RuleResultsWalker* resultsWalker) {
+  return static_cast<BuildSystemFrontendImpl*>(impl)->buildNode(nodeToBuild, resultsWalker);
 }

--- a/products/llbuildSwift/BuildValue.swift
+++ b/products/llbuildSwift/BuildValue.swift
@@ -19,6 +19,8 @@ import Glibc
 #error("Missing libc or equivalent")
 #endif
 
+import struct Foundation.Date
+
 // We don't need this import if we're building
 // this file as part of the llbuild framework.
 #if !LLBUILD_FRAMEWORK
@@ -70,9 +72,23 @@ extension BuildValueFileTimestamp: Equatable {
     }
 }
 
+extension BuildValueFileTimestamp: Comparable {
+    public static func < (lhs: BuildValueFileTimestamp, rhs: BuildValueFileTimestamp) -> Bool {
+        if lhs.seconds != rhs.seconds { return lhs.seconds < rhs.seconds }
+        return lhs.nanoseconds < rhs.nanoseconds
+    }
+}
+
 extension BuildValueFileTimestamp: CustomStringConvertible {
     public var description: String {
         return "<FileTimestamp seconds=\(seconds) nanoseconds=\(nanoseconds)>"
+    }
+}
+
+public extension Date {
+    init(_ ft: BuildValueFileTimestamp) {
+        // Using reference date, instead of 1970, which offers a bit more nanosecond precision since it is a lower absolute number.
+        self.init(timeIntervalSinceReferenceDate: Double(ft.seconds) - Date.timeIntervalBetween1970AndReferenceDate + (1.0e-9 * Double(ft.nanoseconds)))
     }
 }
 


### PR DESCRIPTION
This is implemented by having the client optionally pass an implementation of a `RuleResultsWalker` which receives the related information for the nodes.
I preferred this method of allowing the client to "hook" in and get the info before the `build` call returns and does its clean up and any related "teardown".
That way we ensure the data is readily available for the client to inspect.
This method also allows to restrict the rule result queries only to the nodes related to the just built node, which simplifies things compared to exposing general APIs for querying any node, even if it wasn't involved in the build.

Related to rdar://67816715