### PR TITLE
[5.3][CMake][llbuildSwift] fix runpath for ELF platforms

### DIFF
--- a/products/llbuildSwift/CMakeLists.txt
+++ b/products/llbuildSwift/CMakeLists.txt
@@ -57,6 +57,7 @@ else()
     swiftDispatch
     Foundation)
   if(NOT CMAKE_SYSTEM_NAME STREQUAL Windows)
+    target_link_options(llbuildSwift PRIVATE "SHELL:-no-toolchain-stdlib-rpath")
     set_target_properties(llbuildSwift PROPERTIES
       INSTALL_RPATH "$ORIGIN:$ORIGIN/../../$<LOWER_CASE:${CMAKE_SYSTEM_NAME}>")
   endif()


### PR DESCRIPTION
Remove the absolute path to the host toolchain's stdlib from libllbuildSwift.so.

It has been suggested to me by some Swift devs that this would be good to get in before the 5.3 release, a cherry-pick from #670.

This should be completely safe for the 5.3 branch, as it's just removing the build toolchain's stdlib rpath, which should be unused by this library.