### PR TITLE
[Python3] Update scripts to support Python3

### DIFF
--- a/examples/simple-make/count-lines-1
+++ b/examples/simple-make/count-lines-1
@@ -25,6 +25,6 @@ _,path = sys.argv
 engine = DataDrivenEngine(globals())
 engine.attach_db(".count-lines.db")
 result = engine.build(CountLinesRule.asKey(path))
-print result
+print(result)
 
 

--- a/examples/simple-make/count-lines-2
+++ b/examples/simple-make/count-lines-2
@@ -53,4 +53,4 @@ engine = DataDrivenEngine(globals())
 engine.attach_db(".count-lines.db")
 
 result = engine.build(CountLinesRule.asKey(path))
-print result
+print(result)

--- a/examples/simple-make/count-lines-3
+++ b/examples/simple-make/count-lines-3
@@ -80,4 +80,4 @@ engine = DataDrivenEngine(globals())
 engine.attach_db(".count-source-lines.db")
 
 result = engine.build(CountSourceLinesRule.asKey(path))
-print result
+print(result)

--- a/examples/simple-make/count-lines-4
+++ b/examples/simple-make/count-lines-4
@@ -128,4 +128,4 @@ engine = DataDrivenEngine(globals())
 engine.attach_db(".count-source-lines-with-wc.db")
 
 result = engine.build(CountSourceLinesRule.asKey(path))
-print result
+print(result)

--- a/examples/simple-make/simple-make
+++ b/examples/simple-make/simple-make
@@ -131,4 +131,4 @@ _,path = sys.argv
 engine = DataDrivenEngine(globals())
 engine.attach_db(".build.db")
 result = engine.build(BuildDirectoryRule.asKey(path))
-print result
+print(result)

--- a/tests/BuildSystem/Build/Inputs/get-file-permissions
+++ b/tests/BuildSystem/Build/Inputs/get-file-permissions
@@ -4,4 +4,4 @@ import os
 import stat
 import sys
 
-print(oct(stat.S_IMODE(os.stat(sys.argv[1]).st_mode)))
+print(oct(stat.S_IMODE(os.stat(sys.argv[1]).st_mode)).replace('o',''))

--- a/tests/Ninja/Build/Inputs/check-open-fds
+++ b/tests/Ninja/Build/Inputs/check-open-fds
@@ -24,4 +24,4 @@ def is_fd(fd):
 
 max_fd_soft,max_fd_hard = resource.getrlimit(resource.RLIMIT_NOFILE)
 num_valid_fds = [i for i in range(max_fd_soft) if is_fd(i)]
-print "open FDs: %s" % (num_valid_fds,)
+print("open FDs: %s" % (num_valid_fds,))

--- a/tests/Ninja/Build/Inputs/split-numbers
+++ b/tests/Ninja/Build/Inputs/split-numbers
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+from __future__ import print_function
 import errno
 import sys
 
@@ -8,8 +9,8 @@ def write_data_to_path_if_changed(data, path):
     try:
         with open(path) as f:
             if f.read() == data:
-                print >>sys.stderr, "note: %s: file contents unchanged" % (
-                    path,)
+                print("note: %s: file contents unchanged" % (
+                    path,), file=sys.stderr)
                 return
     except IOError as e:
         if e.errno != errno.ENOENT:
@@ -18,7 +19,7 @@ def write_data_to_path_if_changed(data, path):
     # Otherwise, write the data.
     with open(path, 'wb') as f:
         f.write(data)
-    print >>sys.stderr, "note: %s: updated file" % (path,)
+    print("note: %s: updated file" % (path,), file=sys.stderr)
 
 # Split the input into even and odd numbers.
 even = []

--- a/tests/SwiftBuildTool/Inputs/pseudo-swiftc
+++ b/tests/SwiftBuildTool/Inputs/pseudo-swiftc
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+from __future__ import print_function
 import argparse
 import json
 import os
@@ -38,16 +39,16 @@ def main():
 
     # If run in verbose mode, print a fake version.
     if args.verbose or args.version:
-        print "Pseudo Swift version 1.2.3 (%s)" % (
-            os.environ.get("PSEUDO_SWIFT_VERSION", "12.1"),)
+        print("Pseudo Swift version 1.2.3 (%s)" % (
+            os.environ.get("PSEUDO_SWIFT_VERSION", "12.1"),))
         print("Target: bla bla bla")
         if args.version:
             return
     
     # If run in show commands mode, print some dummy output.
     if args.show_commands:
-        print ' '.join(map(pipes.quote, [
-            sys.argv[0], "-frontend", "...blablabla..."]))
+        print(' '.join(map(pipes.quote, [
+            sys.argv[0], "-frontend", "...blablabla..."])))
         return
         
     # Write dummy outputs.

--- a/utils/create-dummy-ninja-from-DB.py
+++ b/utils/create-dummy-ninja-from-DB.py
@@ -77,10 +77,10 @@ def main():
 
     # We create a dummy build file with one target "make-inputs", which creates
     # dummy input files, and all the other rules just cat those files together.
-    print "rule CAT"
-    print "    command = cat ${in} > ${out}"
-    print "    description = ${command}"
-    print
+    print("rule CAT")
+    print("    command = cat ${in} > ${out}")
+    print("    description = ${command}")
+    print()
     node_names = {}
     def get_key_name(key):
         name = node_names.get(key)
@@ -108,27 +108,27 @@ def main():
         if not dep_names:
             seen_inputs.add(name)
         else:
-            print "build %s: CAT %s" % (name, " ".join(dep_names))
+            print("build %s: CAT %s" % (name, " ".join(dep_names)))
         seen_rules.add(name)
         seen_nodes.update(dep_names)
-    print
+    print()
 
     # Write a build statement to create all the inputs, so we can actually
     # execute the build.
-    print "rule make-inputs"
-    print "  command = touch %s" % " ".join(sorted(seen_inputs))
-    print "build make-inputs: make-inputs"
-    print
+    print("rule make-inputs")
+    print("  command = touch %s" % " ".join(sorted(seen_inputs)))
+    print("build make-inputs: make-inputs")
+    print()
 
     # Write out a default target with the roots.
     roots = seen_rules - seen_nodes
-    print "default %s" % (" ".join(roots),)
+    print("default %s" % (" ".join(roots),))
 
     # Write the mappings, if requested.
     if args.show_mapping:
-        print
+        print()
         for key,name in sorted(node_names.items()):
-            print "# %s -> %s" % (key, name)
+            print("# %s -> %s" % (key, name))
 
 if __name__ == '__main__':
     main()

--- a/utils/docker/docker-utils
+++ b/utils/docker/docker-utils
@@ -27,7 +27,7 @@ defaultTarget = "16.04"
 
 def call(args):
     """Prints and executes a command."""
-    print " ".join(args)
+    print(" ".join(args))
     return subprocess.call(args)
 
 def build(args):
@@ -60,7 +60,7 @@ def build(args):
 
         # Download latest snapshot (if necessary).
         if len(curImages.split()) == 1:
-            print "Image exists for {} with {}".format(target, snapshot_name)
+            print("Image exists for {} with {}".format(target, snapshot_name))
             exit(0)
         else:
             result = call([
@@ -70,7 +70,7 @@ def build(args):
             ])
 
             if result != 0:
-                print "Unable to clean prior images"
+                print("Unable to clean prior images")
                 exit(1)
 
             result = call([
@@ -81,7 +81,7 @@ def build(args):
             ])
 
             if result != 0:
-                print "Unable to fetch snapshot"
+                print("Unable to fetch snapshot")
                 exit(1)
 
         # Create docker image.

--- a/utils/import-llvm/import-llvm
+++ b/utils/import-llvm/import-llvm
@@ -6,6 +6,7 @@
 # dependency surface area, so if you run this to update the sources, please
 # examine the diffs to remove things that don't make sense.
 
+from __future__ import print_function
 import errno
 import optparse
 import os
@@ -71,7 +72,7 @@ llbuild_srcroot = None
 def note(msg):
     msg = msg.replace(llvm_srcroot, "<LLVM>")
     msg = msg.replace(llbuild_srcroot, "<LLBUILD>")
-    print >>sys.stderr, "note: %s" % (msg,)
+    print("note: %s" % (msg,), file=sys.stderr)
 
 def mkdir_p(path):
     try:
@@ -129,7 +130,7 @@ def main():
             mkdir_p(os.path.dirname(dst))
             copyfile(src, dst)
 
-    print "note: importing from %r to %r" % (llvm_srcroot, llbuild_srcroot)
+    print("note: importing from %r to %r" % (llvm_srcroot, llbuild_srcroot))
 
     for name in ADT_imports:
         import_header('ADT', name+'.h')

--- a/utils/manifest-generator/generate-llbuild-manifest
+++ b/utils/manifest-generator/generate-llbuild-manifest
@@ -40,19 +40,19 @@ class Command:
 
 class LLBuildManifest:
   def __init__(self, manifestPath, expectedLLBuildOutputPath, clientName, clientVersion, density, maxAdditionalInputs=sys.maxsize, minDepth = -1, maxDepth = -1, minWidth = -1, maxWidth = -1, levelWidths = []):
-    print "Writing llbuild manifest to " + manifestPath
+    print("Writing llbuild manifest to " + manifestPath)
 
     try:
       self.manifestFile = open(manifestPath, 'w+')
     except:
-      print "Failed to open manifest file at " + manifestPath
+      print("Failed to open manifest file at " + manifestPath)
       raise Exception
 
-    print "Writing expected llbuild results to " + expectedLLBuildOutputPath
+    print("Writing expected llbuild results to " + expectedLLBuildOutputPath)
     try:
       self.expectedLLBuildOutputFile = open(expectedLLBuildOutputPath, 'w+')
     except:
-      print "Failed to open expected llbuild file at " + expectedLLBuildOutputPath
+      print("Failed to open expected llbuild file at " + expectedLLBuildOutputPath)
       raise Exception
 
     self.nextCommandID = 0
@@ -92,7 +92,7 @@ class LLBuildManifest:
       depth = random.randint(minDepth, maxDepth)
       
       if minDepth < 0 or maxDepth < 0 or minWidth < 0 or maxWidth < 0:
-        print "ERROR: Missing necessary arguments for building the manifest or one of parameters was unexpectedly less than zero. Please provide -minWidth <INT>, -maxWidth <INT>, -minDepth <INT>, -maxDepth <INT> OR -levelWidths <LIST>."
+        print("ERROR: Missing necessary arguments for building the manifest or one of parameters was unexpectedly less than zero. Please provide -minWidth <INT>, -maxWidth <INT>, -minDepth <INT>, -maxDepth <INT> OR -levelWidths <LIST>.")
         raise Exception
 
       for levelIndex in range(depth-1):
@@ -103,13 +103,13 @@ class LLBuildManifest:
       self.levelWidths.append(1)
 
     if self.levelWidths[len(self.levelWidths)-1] != 1:
-      print "ERROR: Last LevelWidths Index must be set to 1 as there can only be one default target."
+      print("ERROR: Last LevelWidths Index must be set to 1 as there can only be one default target.")
       raise Exception
 
-    print "Level widths: %s" % self.levelWidths
+    print("Level widths: %s" % self.levelWidths)
   
   def generateBuildGraph(self):
-    print "Generating Build Graph"
+    print("Generating Build Graph")
     
     self.writeLine("client:", indentLevel=0)
     self.writeLine("name: " + self.clientName, indentLevel=1)
@@ -247,7 +247,7 @@ if float(args.density) > 100:
 try:
   if args.levelWidths != "":
     if args.minDepth != "-1" or args.maxDepth != "-1" or args.minWidth != "-1" or args.maxWidth != "-1":
-      print "WARNING: Level Width will override any width/depth parameters"
+      print("WARNING: Level Width will override any width/depth parameters")
 
     manifest = LLBuildManifest(args.manifestPath, 
       args.expectedLLBuildOutputPath,


### PR DESCRIPTION
Most of the changes here just convert `print` statements (which are no longer supported in Python3) to `print()` function calls (which exists in both Python 2 and 3).

The only other change of note is to strip the `o` character from the output of `oct()`.  In Python 3, `oct()` outputs octal values with a leading `0o` as 0o123 and these scripts expect C-style octal format `0123` instead.