### PR TITLE
LLVMSupport: make `HandleAbort` static

### DIFF
--- a/lib/llvm/Support/Windows/Signals.inc
+++ b/lib/llvm/Support/Windows/Signals.inc
@@ -404,11 +404,19 @@ AvoidMessageBoxHook(int ReportType, char *Message, int *Return) {
 
 #endif
 
-extern "C" void HandleAbort(int Sig) {
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+static void HandleAbort(int Sig) {
   if (Sig == SIGABRT) {
     LLVM_BUILTIN_TRAP;
   }
 }
+
+#if defined(__cplusplus)
+}
+#endif
 
 static void InitializeThreading() {
   if (CriticalSectionInitialized)


### PR DESCRIPTION
When building SourceKit-LSP on Windows with swift-package-manager, we
end up with multiple definitions of `HandleAbort` due to multiple copies
of `LLVMSupport` being used due to the shared linking model of
swift-package-manager.  Declare the function as static to make it be
COMDATed.