### PR TITLE
LLVMSupport: disable ABI breaking checks

### DIFF
--- a/include/llvm/Config/abi-breaking.h
+++ b/include/llvm/Config/abi-breaking.h
@@ -13,7 +13,7 @@
 #define LLVM_ABI_BREAKING_CHECKS_H
 
 /* Define to enable checks that alter the LLVM C++ ABI */
-#define LLVM_ENABLE_ABI_BREAKING_CHECKS 1
+#define LLVM_ENABLE_ABI_BREAKING_CHECKS 0
 
 /* Define to enable reverse iteration of unordered llvm containers */
 #define LLVM_ENABLE_REVERSE_ITERATION 0


### PR DESCRIPTION
These are ABI incompatible changes requiring that the build to be
consistent in configuration across all products.  This prevents the
build of SourceKit-LSP on Windows due to the mismatch when building
using swift-package-manager in a debug configuration without local
dependencies.