### PR TITLE
Handle interrupts properly on Windows

### DIFF
--- a/lib/Basic/Subprocess.cpp
+++ b/lib/Basic/Subprocess.cpp
@@ -683,7 +683,7 @@ void llbuild::basic::spawnProcess(
 #endif
 
 #if defined(_WIN32)
-  DWORD creationFlags = NORMAL_PRIORITY_CLASS | CREATE_NEW_PROCESS_GROUP |
+  DWORD creationFlags = NORMAL_PRIORITY_CLASS |
                         CREATE_UNICODE_ENVIRONMENT;
   PROCESS_INFORMATION processInfo = {0};
 


### PR DESCRIPTION
Currently SwiftPM ignores Ctrl-C on Windows, this change makes it stop the build process when Ctrl-C is pressed