### PR TITLE
llbuildSwift: follow up to 6c9097625d46

### DIFF
--- a/products/libllbuild/BuildSystem-C-API.cpp
+++ b/products/libllbuild/BuildSystem-C-API.cpp
@@ -836,9 +836,7 @@ public:
       sig = sig.combine(StringRef((const char*)data.data, data.length));
 
       // Release the client memory.
-      //
-      // FIXME: This is gross, come up with a general purpose solution.
-      free((char*)data.data);
+      llb_data_destroy(&data);
     }
     return sig;
   }

--- a/products/llbuildSwift/BuildSystemBindings.swift
+++ b/products/llbuildSwift/BuildSystemBindings.swift
@@ -844,10 +844,6 @@ public final class BuildSystem {
     public func build(target: String? = nil) -> Bool {
         var data = target.map({ copiedDataFromBytes([UInt8]($0.utf8)) }) ?? llb_data_t(length: 0, data: nil)
         defer {
-            if data.data != nil {
-              UnsafeMutablePointer<UInt8>(mutating: data.data).deallocate()
-            }
-            data.data = nil
             llb_data_destroy(&data)
         }
         return llb_buildsystem_build(_system, &data)

--- a/products/llbuildSwift/Internals.swift
+++ b/products/llbuildSwift/Internals.swift
@@ -28,7 +28,8 @@ import llbuild
 /// Create a new `llb_data_t` instance containing an allocated copy of the given `bytes`.
 internal func copiedDataFromBytes(_ bytes: [UInt8]) -> llb_data_t {
     // Create the data.
-    let buf = UnsafeMutableBufferPointer(start: UnsafeMutablePointer<UInt8>.allocate(capacity: bytes.count), count: bytes.count)
+    let allocation: UnsafeMutableRawPointer? = malloc(bytes.count)
+    let buf = UnsafeMutableBufferPointer(start: allocation?.assumingMemoryBound(to: UInt8.self), count: bytes.count)
 
     // Copy the data.
     _ = bytes.withUnsafeBufferPointer { bytesPtr in


### PR DESCRIPTION
This reverts part of the previous commit and adjusts the allocation to
explicitly use `malloc`.  This matches the requirement in
`get_signature` (buildsystem.h:609):

```
  /// The contents *MUST* be returned in a new buffer allocated with \see
  /// malloc().
```

This also repairs a followup heap corruption detected on Windows when
working on `swift test` in release mode for building
swift-package-manager.