### PR TITLE
llbuild ninja test binary links against ncurses

### DIFF
--- a/lib/llvm/Support/CMakeLists.txt
+++ b/lib/llvm/Support/CMakeLists.txt
@@ -64,3 +64,6 @@ if(${CMAKE_SYSTEM_NAME} MATCHES "FreeBSD")
     execinfo)
 endif()
 
+if(${CMAKE_SYSTEM_NAME} MATCHES "Android|Darwin|Linux")
+  target_link_libraries(llvmSupport PRIVATE curses)
+endif()


### PR DESCRIPTION
llbuild ninja test binary needs to link against ncurses:
https://github.com/apple/swift-llbuild/blob/a9f4b75cf7288156ed1880f98cebe17da1543a38/Package.swift#L207