### PR TITLE
llbuildSwift: replace unnecessary import of `MSVCRT`

### DIFF
--- a/products/llbuildSwift/BuildDBBindings.swift
+++ b/products/llbuildSwift/BuildDBBindings.swift
@@ -11,7 +11,7 @@
 #if canImport(Darwin)
 import Darwin.C
 #elseif os(Windows)
-import MSVCRT
+import ucrt
 import WinSDK
 #elseif canImport(Glibc)
 import Glibc

--- a/products/llbuildSwift/BuildKey.swift
+++ b/products/llbuildSwift/BuildKey.swift
@@ -11,7 +11,7 @@
 #if canImport(Darwin)
 import Darwin.C
 #elseif os(Windows)
-import MSVCRT
+import ucrt
 import WinSDK
 #elseif canImport(Glibc)
 import Glibc

--- a/products/llbuildSwift/BuildSystemBindings.swift
+++ b/products/llbuildSwift/BuildSystemBindings.swift
@@ -11,7 +11,7 @@
 #if canImport(Darwin)
 import Darwin.C
 #elseif os(Windows)
-import MSVCRT
+import ucrt
 import WinSDK
 #elseif canImport(Glibc)
 import Glibc

--- a/products/llbuildSwift/BuildValue.swift
+++ b/products/llbuildSwift/BuildValue.swift
@@ -11,7 +11,7 @@
 #if canImport(Darwin)
 import Darwin.C
 #elseif os(Windows)
-import MSVCRT
+import ucrt
 import WinSDK
 #elseif canImport(Glibc)
 import Glibc

--- a/products/llbuildSwift/Internals.swift
+++ b/products/llbuildSwift/Internals.swift
@@ -11,7 +11,7 @@
 #if canImport(Darwin)
 import Darwin.C
 #elseif os(Windows)
-import MSVCRT
+import ucrt
 import WinSDK
 #elseif canImport(Glibc)
 import Glibc


### PR DESCRIPTION
Replace the use of `MSVCRT` with `ucrt` as only the standard C
interfaces are needed.  This is in preparation to move away from
`MSVCRT`.