### PR TITLE
Fix a warning that occurs when building with -Wdocumentation

### DIFF
--- a/lib/Basic/FileInfo.cpp
+++ b/lib/Basic/FileInfo.cpp
@@ -26,9 +26,6 @@ bool FileInfo::isDirectory() const {
 
 /// Get the information to represent the state of the given node in the file
 /// system.
-///
-/// \param info_out [out] On success, the important path information.
-/// \returns True if information on the path was found.
 FileInfo FileInfo::getInfoForPath(const std::string& path, bool asLink) {
   FileInfo result;
 


### PR DESCRIPTION
This is currently the only warning when building swift-package-manager using its bootstrap script.

Since this is a declaration in a source file and not a header, it seemed reasonable to just remove it.  The include/llbuild/Basic/FileInfo.h header already has the proper comments.