### PR TITLE
[Test] Relax ordering assumption in max-commands-progress.ninja

### DIFF
--- a/tests/Ninja/Build/max-commands-progress.ninja
+++ b/tests/Ninja/Build/max-commands-progress.ninja
@@ -7,8 +7,8 @@
 # RUN: %{llbuild} ninja build --jobs 1 --chdir %t.build &> %t1.out
 # RUN: %{FileCheck} --check-prefix=CHECK-INITIAL < %t1.out %s
 #
-# CHECK-INITIAL: [1/{{.*}}] cp input-2 output-2
-# CHECK-INITIAL: [2/{{.*}}] cp input-1 output-1
+# CHECK-INITIAL: [{{1|2}}/{{.*}}] cp input-2 output-2
+# CHECK-INITIAL: [{{1|2}}/{{.*}}] cp input-1 output-1
 # CHECK-INITIAL: [3/3] cat output-1 output-2 > output
 
 # RUN: %{adjust-times} -now-plus-ulp %t.build/input-1


### PR DESCRIPTION
While most of the times `output-2` is copied before `output-1`, in some
rare cases the opposite can happen (which seems reasonable since there
is no ordering requirement between the two).

Addresses rdar://72898516