### PR TITLE
Add support for OpenBSD.

### DIFF
--- a/include/llbuild/Basic/CrossPlatformCompatibility.h
+++ b/include/llbuild/Basic/CrossPlatformCompatibility.h
@@ -22,6 +22,8 @@
 #define NOMINMAX
 #include <windows.h>
 #else
+#include <inttypes.h>
+#include <sys/cdefs.h>
 #include <sys/resource.h>
 #include <unistd.h>
 #if defined(__linux__) || defined(__GNU__)

--- a/include/llvm/Config/config.h
+++ b/include/llvm/Config/config.h
@@ -14,7 +14,7 @@
 #define ENABLE_CRASH_OVERRIDES 1
 
 /* Define to 1 if you have the `backtrace' function. */
-#if !defined(__ANDROID__)
+#if !defined(__ANDROID__) && !defined(__OpenBSD__)
 #define HAVE_BACKTRACE TRUE
 #endif
 

--- a/lib/llvm/Demangle/Utility.h
+++ b/lib/llvm/Demangle/Utility.h
@@ -14,6 +14,7 @@
 
 #include "StringView.h"
 
+#include <inttypes.h>
 #include <cstdint>
 #include <cstdlib>
 #include <cstring>

--- a/products/libllbuild/include/llbuild/core.h
+++ b/products/libllbuild/include/llbuild/core.h
@@ -23,6 +23,9 @@
 
 #include "llbuild-defines.h"
 #include <stdbool.h>
+#if defined(__OpenBSD__)
+#include <inttypes.h>
+#endif
 #include <stdint.h>
 
 /// @name Build Engine

--- a/utils/adjust-times/adjust-times.cpp
+++ b/utils/adjust-times/adjust-times.cpp
@@ -16,6 +16,10 @@
   #define UTIME_NOW ((1l << 30) - 1l)
   #define UTIME_OMIT ((1l << 30) - 2l)
 #else
+#if defined(__OpenBSD__)
+  #include <sys/types.h>
+  #include <utime.h>
+#endif
   #include <sys/time.h>
 #endif
 


### PR DESCRIPTION
OpenBSD doesn't have backtrace in the base system, and requires these
headers for calling utime(3). While we can install libexecinfo on this
platform to get backtraces and that this platform has obsoleted utime(3)
for utimes(2), make llbuild compile on this platform as-is first.

Some of these other includes are also required to satisfy missing type
declarations only visible once bootstrapped and modules used.