### PR TITLE
Redirect stderr when calling `swift -version`

### DIFF
--- a/lib/BuildSystem/BuildSystem.cpp
+++ b/lib/BuildSystem/BuildSystem.cpp
@@ -2270,6 +2270,7 @@ public:
     llvm::raw_svector_ostream commandOS(command);
     commandOS << basic::shellEscaped(executable);
     commandOS << " " << "--version";
+    commandOS << " " << "2>/dev/null";
 
     // Read the result.
     FILE *fp = basic::sys::popen(commandOS.str().str().c_str(), "r");


### PR DESCRIPTION
Since this is using `popen`, we were capturing stdout, but stderr could still end up on the terminal. In particular, the Swift driver version could be intermingled with other output in tools using llbuild such as SwiftPM, because it is being printed to stderr: https://github.com/apple/swift-driver/blob/main/Sources/SwiftDriver/Driver/Driver.swift#L989