### PR TITLE
Fix the llbuild tests that are broken/flaky and blocking CI

### DIFF
--- a/tests/Examples/buildsystem-capi.llbuild
+++ b/tests/Examples/buildsystem-capi.llbuild
@@ -1,7 +1,7 @@
 # Check that the BuildSystem C API example builds and runs correctly.
 #
 # RUN: %clang -o %t.exe %{srcroot}/examples/c-api/buildsystem/main.c -I %{srcroot}/products/libllbuild/include -lllbuild -L %{llbuild-lib-dir} -Werror
-# RUN: env LD_LIBRARY_PATH=%{llbuild-lib-dir} %t.exe %s > %t.out
+# RUN: env DYLD_LIBRARY_PATH=%{llbuild-lib-dir} LD_LIBRARY_PATH=%{llbuild-lib-dir} %t.exe %s > %t.out
 # RUN: %{FileCheck} %s --input-file %t.out
 #
 # CHECK: -- read file contents: {{.*[/\\]}}buildsystem-capi.llbuild

--- a/tests/Ninja/Build/incremental.ninja
+++ b/tests/Ninja/Build/incremental.ninja
@@ -20,8 +20,8 @@
 
 # Check the first build.
 #
-# CHECK-INITIAL: [1/{{.*}}] "cp input-2 output-2"
-# CHECK-INITIAL: [2/{{.*}}] "cp input-1 output-1"
+# CHECK-INITIAL: [{{1|2}}/{{.*}}] "cp input-2 output-2"
+# CHECK-INITIAL: [{{1|2}}/{{.*}}] "cp input-1 output-1"
 # CHECK-INITIAL: [3/{{.*}}] "cat output-1 output-2 > output"
 
 # Check the second build.


### PR DESCRIPTION
BuildDBBindingsTests: Swift variables are not guaranteed to live to the
end of their declarating scope; extend the lifetime of the database
object in a couple of the test methods to ensure they are not
prematurely deallocated.

buildsystem-capi.llbuild: macOS uses DYLD_LIBRARY_PATH,
not LD_LIBRARY_PATH. Pass the proper environment variable to the test
so that libllbuild.dylib can be found. This only manifested locally, not
on the CI, for some reason.

incremental.ninja: relax the ordering assumption. This is the same fix
done for the similar max-commands-progress.ninja test case back in
f339c9e115816b72bafad1b8a2927a6eccca66b5.