### PR TITLE
Forwarding reference passed to std::move(), which may unexpectedly cause lvalues to be moved; use std::forward() instead

### DIFF
--- a/include/llbuild/Basic/Defer.h
+++ b/include/llbuild/Basic/Defer.h
@@ -31,14 +31,14 @@ public:
 
 template <typename T>
 ScopeDefer<T> makeScopeDefer(T&& work) {
-  return ScopeDefer<typename std::decay<T>::type>(std::move(work));
+  return ScopeDefer<typename std::decay<T>::type>(std::forward<T>(work));
 }
 
 namespace impl {
   struct ScopeDeferTask {};
   template<typename T>
   ScopeDefer<typename std::decay<T>::type> operator+(ScopeDeferTask, T&& work) {
-    return ScopeDefer<typename std::decay<T>::type>(std::move(work));
+    return ScopeDefer<typename std::decay<T>::type>(std::forward<T>(work));
   }
 }
 


### PR DESCRIPTION
https://clang.llvm.org/extra/clang-tidy/checks/bugprone-move-forwarding-reference.html

rdar://75914198