### PR TITLE
[FIX] Update Game of Life example for master branch renaming

### DIFF
--- a/examples/GameOfLife/Package.swift
+++ b/examples/GameOfLife/Package.swift
@@ -10,7 +10,7 @@ let package = Package(
             targets: ["game-of-life"])
     ],
     dependencies: [
-        .package(url: "../..", .branch("master")),
+        .package(url: "../..", .branch("main")),
     ],
     targets: [
         .target(


### PR DESCRIPTION
`swift run` no longer successfully run the example because the `master` branch renamed into `main`.  This is a tiny fix to simply correct the branch name for example. 