### PR TITLE
[llbuild-analyze] Update dependencies to be compatible with Swift 5.5

### DIFF
--- a/products/llbuild-analyze/Package.resolved
+++ b/products/llbuild-analyze/Package.resolved
@@ -6,16 +6,16 @@
         "repositoryURL": "https://github.com/apple/swift-argument-parser.git",
         "state": {
           "branch": null,
-          "revision": "f6ac7b8118ff5d1bc0faee7f37bf6f8fd8f95602",
-          "version": "0.0.1"
+          "revision": "986d191f94cec88f6350056da59c2e59e83d1229",
+          "version": "0.4.3"
         }
       },
       {
         "package": "swift-tools-support-core",
         "repositoryURL": "https://github.com/apple/swift-tools-support-core.git",
         "state": {
-          "branch": "master",
-          "revision": "fcaa2ce5a852b5355aed5808a6610dc8b6dcf27e",
+          "branch": "main",
+          "revision": "3b6b97d612b56e25d80d0807f5bc38ea08b7bdf3",
           "version": null
         }
       }

--- a/products/llbuild-analyze/Package.swift
+++ b/products/llbuild-analyze/Package.swift
@@ -16,8 +16,8 @@ let package = Package(
             targets: ["llbuildAnalyzeTool"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-argument-parser.git", from: "0.0.1"),
-        .package(url: "https://github.com/apple/swift-tools-support-core.git", .branch("master")),
+        .package(url: "https://github.com/apple/swift-argument-parser.git", from: "0.4.3"),
+        .package(url: "https://github.com/apple/swift-tools-support-core.git", .branch("main")),
         .package(path: "../../"),
     ],
     targets: [

--- a/products/llbuild-analyze/Sources/CriticalPathTool.swift
+++ b/products/llbuild-analyze/Sources/CriticalPathTool.swift
@@ -33,21 +33,21 @@ struct CriticalPathTool: ParsableCommand {
     @Option(name: .shortAndLong, help: "Path to generate exported output to.", transform: { AbsolutePath($0) })
     var output: AbsolutePath?
     
-    @Option(default: 9)
-    var clientSchemaVersion: Int
+    @Option
+    var clientSchemaVersion: Int = 9
     
-    @Option(name: [.customShort("f"), .customLong("outputFormat")], default: .json, help: "The format of the output file.")
-    var outputFormat: OutputFormat
+    @Option(name: [.customShort("f"), .customLong("outputFormat")], help: "The format of the output file.")
+    var outputFormat: OutputFormat = .json
     
-    @Option(name: .customLong("graphvizOutput"), default: .criticalPath)
-    var graphvizDisplay: GraphvizDisplay
+    @Option(name: .customLong("graphvizOutput"))
+    var graphvizDisplay: GraphvizDisplay = .criticalPath
     
     @Flag(help: "If outputFormat is set to json, it will be pretty formatted.")
-    var pretty: Bool
+    var pretty: Bool = false
     
     @Flag(name: .shortAndLong, help: "Set to hide output to stdout and export only.")
-    var quiet: Bool
-
+    var quiet: Bool = false
+    
     func run() throws {
         let db = try BuildDB(path: database.pathString, clientSchemaVersion: UInt32(clientSchemaVersion))
         let allKeysWithResult = try db.getKeysWithResult()


### PR DESCRIPTION
This PR aims to restore compatibility of `llbuild-analyze` with newer versions of Swift by updating its package dependencies.

* Bumped `swift-argument-parser` to version `0.4.3`
  * This version required syntax changes in `CriticalPathTool.swift` as the property wrapper initializers for `@Option` and `@Flag` have changed.
* Changed the branch of `swift-tools-support-core` as `master` has been renamed to  `main`
  * With the revision previously defined in `Package.resolved`, the package would now fail to build with Swift 5.5 as `TSCBasic` defined a function named `await` which is now a reserved keyword in Swift. This has already been addressed in the swift-tools-support-core repository (https://github.com/apple/swift-tools-support-core/pull/164) and will be included with this update.