### PR TITLE
Invoke subclasses of ExternalCommand unfiltered

### DIFF
--- a/lib/BuildSystem/BuildSystem.cpp
+++ b/lib/BuildSystem/BuildSystem.cpp
@@ -1896,11 +1896,7 @@ public:
       BuildSystem&,
       TaskInterface,
       uintptr_t inputID,
-      const BuildValue& value) override {
-    // Should never get here, since we're not requesting inputs in start.
-    assert(0 && "unexpected API call");
-    return;
-  }
+      const BuildValue& value) override { }
 
   virtual void executeExternalCommand(
       BuildSystem&,
@@ -2125,11 +2121,7 @@ public:
       BuildSystem&,
       TaskInterface,
       uintptr_t inputID,
-      const BuildValue& value) override {
-    // Should never get here, since we're not requesting inputs in start.
-    assert(0 && "unexpected API call");
-    return;
-  }
+      const BuildValue& value) override { }
 
   virtual void executeExternalCommand(BuildSystem&,
                                       TaskInterface ti,
@@ -2672,11 +2664,7 @@ public:
       BuildSystem&,
       TaskInterface ti,
       uintptr_t inputID,
-      const BuildValue& value) override {
-    // Should never get here, since we're not requesting inputs in start.
-    assert(0 && "unexpected API call");
-    return;
-  }
+      const BuildValue& value) override { }
 
   virtual void executeExternalCommand(
       BuildSystem& system,
@@ -2861,11 +2849,7 @@ class MkdirCommand : public ExternalCommand {
       BuildSystem&,
       TaskInterface ti,
       uintptr_t inputID,
-      const BuildValue& value) override {
-    // Should never get here, since we're not requesting inputs in start.
-    assert(0 && "unexpected API call");
-    return;
-  }
+      const BuildValue& value) override { }
 
   virtual void executeExternalCommand(
       BuildSystem& system,
@@ -3195,11 +3179,7 @@ class ArchiveShellCommand : public ExternalCommand {
       BuildSystem&,
       TaskInterface ti,
       uintptr_t inputID,
-      const BuildValue& value) override {
-    // Should never get here, since we're not requesting inputs in start.
-    assert(0 && "unexpected API call");
-    return;
-  }
+      const BuildValue& value) override { }
 
   virtual void executeExternalCommand(
       BuildSystem&,
@@ -3342,11 +3322,7 @@ class SharedLibraryShellCommand : public ExternalCommand {
       BuildSystem&,
       TaskInterface ti,
       uintptr_t inputID,
-      const BuildValue& value) override {
-    // Should never get here, since we're not requesting inputs in start.
-    assert(0 && "unexpected API call");
-    return;
-  }
+      const BuildValue& value) override { }
 
   virtual void executeExternalCommand(
       BuildSystem&, TaskInterface ti, QueueJobContext* context,

--- a/lib/BuildSystem/ExternalCommand.cpp
+++ b/lib/BuildSystem/ExternalCommand.cpp
@@ -231,10 +231,12 @@ void ExternalCommand::provideValue(BuildSystem& system,
                                    core::TaskInterface ti,
                                    uintptr_t inputID,
                                    const BuildValue& value) {
+  // Inform subclasses about the value
+  provideValueExternalCommand(system, ti, inputID, value);
+  
   if (value.isSuccessfulCommand() || value.isFailedCommand() || value.isPropagatedFailureCommand()) {
     // If the value is a successful command, it must probably be a value that was requested for a custom task, so
-    // skip the input processing and invoke the subclass instead to process it accordingly.
-    provideValueExternalCommand(system, ti, inputID, value);
+    // skip the input processing
     return;
   }
 


### PR DESCRIPTION
Before this change, subclasses of ExternalCommand were only invoked if the build value has been produced by a command (success or failure). With this change, the subclass gets invoked for all build values to keep track of its dependencies. It can still distinguish between the different inputs by looking for the requested inputID.

rdar://57125025