### PR TITLE
[BuildSystemDelegate] Introduce `BuildSystemDelegate::chooseCommandFromMultipleProducers()`

### DIFF
--- a/include/llbuild/BuildSystem/BuildSystem.h
+++ b/include/llbuild/BuildSystem/BuildSystem.h
@@ -214,6 +214,13 @@ public:
   virtual void commandCannotBuildOutputDueToMissingInputs(Command*,
                Node* output, SmallPtrSet<Node*, 1> inputs) = 0;
 
+  /// Called by the build system when a node has multiple commands that are producing it.
+  /// The delegate can return one of the commands for the build system to use or return \p nullptr
+  /// for the build system to treat the node as invalid.
+  /// If \p nullptr is returned \p cannotBuildNodeDueToMultipleProducers is going to be called next.
+  virtual Command* chooseCommandFromMultipleProducers(Node* output,
+                   std::vector<Command*>) = 0;
+
   /// Called by the build system to report a node could not be built
   /// because multiple commands are producing it.
   virtual void cannotBuildNodeDueToMultipleProducers(Node* output,

--- a/include/llbuild/BuildSystem/BuildSystemFrontend.h
+++ b/include/llbuild/BuildSystem/BuildSystemFrontend.h
@@ -221,6 +221,13 @@ public:
   virtual void commandCannotBuildOutputDueToMissingInputs(Command*,
                Node* output, SmallPtrSet<Node*, 1> inputs) override;
 
+  /// Called by the build system when a node has multiple commands that are producing it.
+  /// The delegate can return one of the commands for the build system to use or return \p nullptr
+  /// for the build system to treat the node as invalid.
+  /// If \p nullptr is returned \p cannotBuildNodeDueToMultipleProducers is going to be called next.
+  virtual Command* chooseCommandFromMultipleProducers(Node* output,
+                   std::vector<Command*>) override;
+
   /// Called by the build system to report a node could not be built
   /// because multiple commands are producing it.
   virtual void cannotBuildNodeDueToMultipleProducers(Node* output,

--- a/lib/BuildSystem/BuildSystemFrontend.cpp
+++ b/lib/BuildSystem/BuildSystemFrontend.cpp
@@ -704,6 +704,11 @@ void BuildSystemFrontendDelegate::commandCannotBuildOutputDueToMissingInputs(
   fflush(stderr);
 }
 
+Command* BuildSystemFrontendDelegate::chooseCommandFromMultipleProducers(
+     Node *output, std::vector<Command*> commands) {
+  return nullptr;
+}
+
 void BuildSystemFrontendDelegate::cannotBuildNodeDueToMultipleProducers(
      Node *output, std::vector<Command*> commands) {
   std::string message;

--- a/products/libllbuild/BuildSystem-C-API.cpp
+++ b/products/libllbuild/BuildSystem-C-API.cpp
@@ -350,6 +350,27 @@ public:
     uint64_t count() { return keys.size(); }
   };
 
+  virtual Command* chooseCommandFromMultipleProducers(Node* outputNode,
+                   std::vector<Command*> commands) override {
+    if (cAPIDelegate.choose_command_from_multiple_producers) {
+      auto str = outputNode->getName().str();
+      auto output = (llb_build_key_t *)new CAPIBuildKey(BuildKey::makeNode(str));
+
+      llb_buildsystem_command_t* command = cAPIDelegate.choose_command_from_multiple_producers(
+        cAPIDelegate.context,
+        &output,
+        (llb_buildsystem_command_t**)commands.data(),
+        commands.size()
+      );
+
+      llb_build_key_destroy(output);
+
+      return (Command*)command;
+    } else {
+      return nullptr;
+    }
+  }
+
   virtual void cannotBuildNodeDueToMultipleProducers(Node* outputNode,
                std::vector<Command*> commands) override {
     if (cAPIDelegate.cannot_build_node_due_to_multiple_producers) {

--- a/products/libllbuild/include/llbuild/buildsystem.h
+++ b/products/libllbuild/include/llbuild/buildsystem.h
@@ -415,6 +415,15 @@ typedef struct llb_buildsystem_delegate_t_ {
                            llb_build_key_t** inputs,
                            uint64_t input_count);
 
+  /// Called by the build system when a node has multiple commands that are producing it.
+  /// The delegate can return one of the commands for the build system to use or return \p nullptr
+  /// for the build system to treat the node as invalid.
+  /// If \p nullptr is returned \p cannot_build_node_due_to_multiple_producers is going to be called next.
+  llb_buildsystem_command_t* (*choose_command_from_multiple_producers)(void *context,
+                           llb_build_key_t** output,
+                           llb_buildsystem_command_t** commands,
+                           uint64_t command_count);
+
   /// Called by the build system to report a node could not be built
   /// because multiple commands are producing it.
   void (*cannot_build_node_due_to_multiple_producers)(void *context,

--- a/unittests/BuildSystem/MockBuildSystemDelegate.h
+++ b/unittests/BuildSystem/MockBuildSystemDelegate.h
@@ -185,6 +185,11 @@ public:
     }
   }
 
+  virtual Command* chooseCommandFromMultipleProducers(Node *output,
+                                                      std::vector<Command*> commands) {
+    return nullptr;
+  }
+
   virtual void cannotBuildNodeDueToMultipleProducers(Node *output,
                                                      std::vector<Command*> commands) {
     std::string message = "cannot build '" + output->getName().str() + "' node is produced "


### PR DESCRIPTION
For certain kinds of build operations, it is useful to be able to continue even after errors are occurring.
For the case of a node having multiple producers, give the option to the client delegate to choose the most appropriate command,
and allow the build to continue.

Part of rdar://80341017