### PR TITLE
Add llbuildNinja to list of llvm targets

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -198,10 +198,11 @@ let package = Package(
 // FIXME: Conditionalize these flags since SwiftPM 5.3 and earlier will crash for platforms they don't know about.
 #if os(Windows)
 
-["llvmSupport", "llvmDemangle", "llbuildBuildSystem", "llbuildBasic"].forEach { target in
-    package.targets.first(where: { $0.name == target })?.cxxSettings = [
-        .define("LLVM_ON_WIN32", .when(platforms: [.windows])),
-    ]
+do {
+    let llvmTargets : Set<String> = ["llvmSupport", "llvmDemangle", "llbuildBuildSystem", "llbuildBasic", "llbuildNinja"]
+    package.targets.filter({ llvmTargets.contains($0.name) }).forEach { target in
+        target.cxxSettings = [ .define("LLVM_ON_WIN32", .when(platforms: [.windows])) ]
+    }
 }
 
 package.targets.first{ $0.name == "libllbuild" }?.cxxSettings = [


### PR DESCRIPTION
Since swift-package-manager depends on this target, it needs to have LLVM_ON_WIN32 defined in the Windows build.

Define llvmTargets as a set to avoid O(n^2) search of package.targets.

This is a fix for SR-15295.

I tested these changes on Windows, by turning on the environment variable `SWIFTCI_USE_LOCAL_DEPS=1`, cloning local copies of:  swift-tools-support-core, swift-argument-parser, swift-driver, swift-crypto, and Yams, and checking out the necessary tags (see below). Since there seems to be a bug in SPM in the 5.5 toolchain, when processing relative paths, I changed all of the ../ relative paths to S:/ absolute Windows paths, and this made everything build.

Here were the tags/branches I used:

swift-tools-support-core:  .branch("main")
swift-argument-parser: .upToNextMinor(from: "0.4.3")
swift-driver: .branch("main")
swift-crypto: .upToNextMinor(from: "1.1.4")
Yams:  .upToNextMinor(from: "4.0.0")
