### PR TITLE
Implement update status for rules representing custom tasks

### DIFF
--- a/lib/BuildSystem/BuildSystem.cpp
+++ b/lib/BuildSystem/BuildSystem.cpp
@@ -1557,6 +1557,11 @@ std::unique_ptr<Rule> BuildSystemEngineDelegate::lookupRule(const KeyType& keyDa
                                const ValueType& value) -> bool {
           return CommandTask::isResultValid(
               engine, *command, BuildValue::fromData(value));
+        },
+        /*UpdateStatus=*/ [command](BuildEngine& engine,
+                                    core::Rule::StatusKind status) {
+          return ::getBuildSystem(engine).getDelegate().commandStatusChanged(
+              command, convertStatusKind(status));
         }
       ));
     }
@@ -2205,6 +2210,8 @@ public:
   // FIXME: Should create a CustomCommand class, to avoid all the boilerplate
   // required implementations.
 
+  bool shouldShowStatus() override { return false; }
+    
   virtual void getShortDescription(SmallVectorImpl<char> &result) const override {
     llvm::raw_svector_ostream(result) << "Checking Swift Compiler Version";
   }

--- a/products/libllbuild/include/llbuild/llbuild-defines.h
+++ b/products/libllbuild/include/llbuild/llbuild-defines.h
@@ -85,6 +85,10 @@
 ///
 /// Version History:
 ///
+/// 13: Update command status for custom tasks as well
+///
+/// 12: Invoke provideValue on ExternalCommand for all build values
+///
 /// 11: Added QualityOfService field to llb_buildsystem_invocation_t
 ///
 /// 10: Changed to a llb_task_interface_t copies instead of pointers
@@ -108,6 +112,6 @@
 /// 1: Added `environment` parameter to llb_buildsystem_invocation_t.
 ///
 /// 0: Pre-history
-#define LLBUILD_C_API_VERSION 11
+#define LLBUILD_C_API_VERSION 13
 
 #endif


### PR DESCRIPTION
Also make 'Checking Swift Compiler Version' not show its status (SwiftPM expects it that way).

rdar://82651879