### PR TITLE
Allow clients to indicate that createCommand has failed

### DIFF
--- a/lib/BuildSystem/BuildFile.cpp
+++ b/lib/BuildSystem/BuildFile.cpp
@@ -665,7 +665,10 @@ class BuildFileImpl {
         
       // Create the command.
       auto command = tool->createCommand(name);
-      assert(command && "tool failed to create a command");
+      if (!command) {
+        error(it->getValue(), "tool failed to create a command");
+        return false;
+      }
 
       // Parse the remaining command attributes.
       ++it;

--- a/products/llbuildSwift/BuildSystemBindings.swift
+++ b/products/llbuildSwift/BuildSystemBindings.swift
@@ -63,14 +63,22 @@ public struct BuildSystemCommandInterface {
 }
 
 public protocol Tool: AnyObject {
-    /// Called to create a specific command instance of this tool.
+    @available(*, deprecated, message: "Use the overload that returns an Optional")
     func createCommand(_ name: String) -> ExternalCommand
+
+    /// Called to create a specific command instance of this tool.
+    func createCommand(_ name: String) -> ExternalCommand?
 
     /// Called to create a custom command, if the tool accepts the requested CustomTask BuildKey.
     func createCustomCommand(_ buildKey: BuildKey.CustomTask) -> ExternalCommand?
 }
 
 public extension Tool {
+    @available(*, deprecated, message: "Use the overload that returns an Optional")
+    func createCommand(_ name: String) -> ExternalCommand? {
+        return createCommand(name) as ExternalCommand
+    }
+
     // Default implementation to allow clients to avoid declaring this method if not required.
     func createCustomCommand(_ buildKey: BuildKey.CustomTask) -> ExternalCommand? {
         return nil
@@ -90,8 +98,8 @@ private final class ToolWrapper {
     private var commandWrappers: [CommandWrapper] = []
 
     func createCommand(_ name: UnsafePointer<llb_data_t>) -> OpaquePointer? {
-        let command = tool.createCommand(stringFromData(name.pointee))
-        return buildCommand(name, command)
+        let command = tool.createCommand(stringFromData(name.pointee)) as ExternalCommand?
+        return command.map { command in buildCommand(name, command) } ?? nil
     }
 
     func createCustomCommand(_ key: OpaquePointer) -> OpaquePointer? {

--- a/unittests/Swift/BuildSystemEngineTests.swift
+++ b/unittests/Swift/BuildSystemEngineTests.swift
@@ -102,10 +102,15 @@ final class TestTool: Tool {
         self.expectedCommands = expectedCommands
     }
 
+    @available(*, deprecated, message: "Use the overload that returns an Optional")
     func createCommand(_ name: String) -> ExternalCommand {
+        return (createCommand(name) as ExternalCommand?)!
+    }
+
+    func createCommand(_ name: String) -> ExternalCommand? {
         guard let command = expectedCommands[name] else {
             XCTFail("Command \(name) not expected.")
-            return FailureCommand()
+            return nil
         }
         return command
     }


### PR DESCRIPTION
Some clients may not be able to create commands on-demand and may look
them up in an existing store when requested, which may not have said
command.

rdar://55989748
(cherry picked from commit 47445303f4eeb81183ae64bc9b02413154100a56)