### PR TITLE
[libllbuild] Added a build engine delegate callback for reporting cyc…

### DIFF
--- a/products/libllbuild/Core-C-API.cpp
+++ b/products/libllbuild/Core-C-API.cpp
@@ -80,8 +80,14 @@ class CAPIBuildEngineDelegate : public BuildEngineDelegate, public basic::Execut
   }
 
   virtual void cycleDetected(const std::vector<core::Rule*>& items) override {
-    // FIXME.
-    assert(0 && "unexpected cycle!");
+    std::vector<llb_data_t> keys;
+    keys.reserve(items.size());
+    for (auto item : items) {
+      const KeyType &key = item->key;
+      keys.push_back({ key.size(), (const uint8_t*)key.data() });
+    }
+
+    cAPIDelegate.cycle_detected(cAPIDelegate.context, keys.data(), keys.size());
   }
 
   virtual void error(const Twine& message) override {

--- a/products/libllbuild/include/llbuild/core.h
+++ b/products/libllbuild/include/llbuild/core.h
@@ -125,6 +125,18 @@ typedef struct llb_buildengine_delegate_t_ {
     /// Xparam context The user context pointer.
     /// Xparam message Error message.
     void (*error)(void* context, const char* message);
+
+    /// Callback for cycles detected by the build engine.
+    ///
+    /// Xparam context The user context pointer.
+    /// Xparam keys The ordered list of keys for rules comprising the cycle,
+    /// starting from the rule which was requested to build and ending with the
+    /// first rule in the cycle (i.e., the rule participating in the cycle will
+    /// appear twice).
+    /// Xparam key_count The number of keys involved in the cycle.
+    void (*cycle_detected)(void* context,
+                           const llb_data_t* keys,
+                           uint64_t key_count);
 } llb_buildengine_delegate_t;
 
 /// Create a new build engine object.


### PR DESCRIPTION
…les.

This callback provides all of the keys involved in the cycle, starting with the key that was initially requested up to the first repeated key.
This is to allow clients of the build engine component to report cycles as errors when they occur instead of crashing.

This is part of <rdar://problem/43870963>.