### PR TITLE
[Xcode] Updated the "Install in CommandLineTools" shell script build …

### DIFF
--- a/Xcode/Configs/Common.xcconfig
+++ b/Xcode/Configs/Common.xcconfig
@@ -59,6 +59,10 @@ CLANG_CXX_LIBRARY = libc++
 COMMON_PREPROCESSOR_DEFINITIONS = $(LLBUILD_VERSION_DEFINITIONS)
 OTHER_CPLUSPLUSFLAGS = $(OTHER_CFLAGS) -Wimplicit-fallthrough -Wsign-compare -Wall
 
+// Destination for installing llbuild.framework so it appears in the CommandLineTools package.
+// Clients can override this to the empty string to avoid installing anything.
+COMMANDLINETOOLS_FRAMEWORK_INSTALL_PATH = $(DSTROOT)/Library/Developer/CommandLineTools/usr/lib/swift/pm/llbuild/llbuild.framework
+
 // MARK: Signing Support
 
 // Enable code signing, if appropriate.

--- a/llbuild.xcodeproj/project.pbxproj
+++ b/llbuild.xcodeproj/project.pbxproj
@@ -3789,7 +3789,7 @@
 		};
 		BC92770E1E60449A0020E457 /* Install in CommandLineTools */ = {
 			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 12;
+			buildActionMask = 8;
 			files = (
 			);
 			inputPaths = (
@@ -3797,11 +3797,11 @@
 			);
 			name = "Install in CommandLineTools";
 			outputPaths = (
-				"$(DSTROOT)/Library/Developer/CommandLineTools/usr/lib/swift/pm/llbuild/llbuild.framework",
+				"$(COMMANDLINETOOLS_FRAMEWORK_INSTALL_PATH)",
 			);
-			runOnlyForDeploymentPostprocessing = 0;
+			runOnlyForDeploymentPostprocessing = 1;
 			shellPath = /bin/sh;
-			shellScript = "# This script is used to install llbuild.framework in CommandLineTools.\n\nset -e\nmkdir -p \"$(dirname \"$SCRIPT_OUTPUT_FILE_0\")\"\nrsync -a \"$SCRIPT_INPUT_FILE_0/\" \"$SCRIPT_OUTPUT_FILE_0\"\n";
+			shellScript = "# This script is used to install llbuild.framework in CommandLineTools.\n\nset -e\nif [ \"${SCRIPT_OUTPUT_FILE_0}\" != \"\" ]; then\n    mkdir -p \"$(dirname \"$SCRIPT_OUTPUT_FILE_0\")\"\n    rsync -a \"$SCRIPT_INPUT_FILE_0/\" \"$SCRIPT_OUTPUT_FILE_0\"\nfi\n";
 			showEnvVarsInLog = 0;
 		};
 		E147DF121BA81D330032D08E /* Create Target Link */ = {


### PR DESCRIPTION
…phase to not do anything meaningful if `COMMANDLINETOOLS_OUTPUT_DIR` is unset.

`COMMANDLINETOOLS_OUTPUT_DIR` is a new build setting indicating where in the CommandLineTools package llbuild.framework should be installed.
This is configured in Common.xcconfig, allowing clients to customize this location via CommonOverrides.xcconfig.
Additionally, if set to the empty string, the "Install in CommandLineTools" build phase will effectively do nothing.

As part of this, marked the "Install in CommandLineTools" build phase so it only runs during install builds.

This is for <rdar://problem/84568181>.