### PR TITLE
On Windows, use 2>NUL to ignore stderr output

### DIFF
--- a/lib/BuildSystem/BuildSystem.cpp
+++ b/lib/BuildSystem/BuildSystem.cpp
@@ -2284,7 +2284,12 @@ public:
     llvm::raw_svector_ostream commandOS(command);
     commandOS << basic::shellEscaped(executable);
     commandOS << " " << "--version";
+#if defined(_WIN32)
+    // FIXME:  cmd.exe uses different syntax for I/O redirection to null.
+    commandOS << " 2>NUL";
+#else
     commandOS << " " << "2>/dev/null";
+#endif
 
     // Read the result.
     FILE *fp = basic::sys::popen(commandOS.str().str().c_str(), "r");


### PR DESCRIPTION
This fixes a nagging bug on Windows; the persistent error message generated whenever swift-build runs:

'The system cannot find the path specified.'

(Coincidentally, it was also creating a file called "null" in my "C:/dev" directory.)