### PR TITLE
Expose TaskInterface's spawn API to clients

### DIFF
--- a/include/llbuild/Basic/Subprocess.h
+++ b/include/llbuild/Basic/Subprocess.h
@@ -187,7 +187,8 @@ namespace llbuild {
       /// different status calls relating to the same process. It is only
       /// guaranteed to be unique from when it has been provided here to when it
       /// has been provided to the \see processFinished() call.
-      virtual void processStarted(ProcessContext* ctx, ProcessHandle handle) = 0;
+      /// \param pid - The subprocess' identifier, can be -1 for failure reasons.
+      virtual void processStarted(ProcessContext* ctx, ProcessHandle handle, llbuild_pid_t pid) = 0;
 
       /// Called to report an error in the management of a command process.
       ///

--- a/include/llbuild/Core/BuildEngine.h
+++ b/include/llbuild/Core/BuildEngine.h
@@ -187,7 +187,8 @@ public:
              ArrayRef<StringRef> commandLine,
              ArrayRef<std::pair<StringRef, StringRef>> environment,
              basic::ProcessAttributes attributes = {true},
-             llvm::Optional<basic::ProcessCompletionFn> completionFn = {llvm::None});
+             llvm::Optional<basic::ProcessCompletionFn> completionFn = {llvm::None},
+             basic::ProcessDelegate* delegate = nullptr);
 
   basic::ProcessStatus spawn(basic::QueueJobContext* context,
                              ArrayRef<StringRef> commandLine);

--- a/lib/BuildSystem/BuildSystemExtensionManager.cpp
+++ b/lib/BuildSystem/BuildSystemExtensionManager.cpp
@@ -54,7 +54,8 @@ BuildSystemExtensionManager::lookupByCommandPath(StringRef path) {
     SmallString<1024> output;
     bool success;
     
-    virtual void processStarted(ProcessContext* ctx, ProcessHandle handle) {}
+    virtual void processStarted(ProcessContext* ctx, ProcessHandle handle,
+                                llbuild_pid_t pid) {}
 
     virtual void processHadError(ProcessContext* ctx, ProcessHandle handle,
                                  const Twine& message) {};

--- a/lib/BuildSystem/BuildSystemFrontend.cpp
+++ b/lib/BuildSystem/BuildSystemFrontend.cpp
@@ -251,7 +251,8 @@ public:
   }
 
   virtual void processStarted(ProcessContext* command,
-                              ProcessHandle handle) override {
+                              ProcessHandle handle,
+                              llbuild_pid_t pid) override {
     static_cast<BuildSystemFrontendDelegate*>(&getSystem().getDelegate())->
       commandProcessStarted(
           reinterpret_cast<Command*>(command),

--- a/lib/Commands/BuildEngineCommand.cpp
+++ b/lib/Commands/BuildEngineCommand.cpp
@@ -231,7 +231,7 @@ static int runAckermannBuild(int m, int n, int recomputeCount,
       assert(0 && ("error:" + message.str()).c_str());
     }
 
-    void processStarted(basic::ProcessContext*, basic::ProcessHandle) override { }
+    void processStarted(basic::ProcessContext*, basic::ProcessHandle, llbuild_pid_t) override { }
     void processHadError(basic::ProcessContext*, basic::ProcessHandle, const Twine&) override { }
     void processHadOutput(basic::ProcessContext*, basic::ProcessHandle, StringRef) override { }
     void processFinished(basic::ProcessContext*, basic::ProcessHandle, const basic::ProcessResult&) override { }
@@ -336,7 +336,7 @@ static int runEvoAckermann(int m, int n, int recomputeCount,
       assert(0 && ("error:" + message.str()).c_str());
     }
 
-    void processStarted(basic::ProcessContext*, basic::ProcessHandle) override { }
+    void processStarted(basic::ProcessContext*, basic::ProcessHandle, llbuild_pid_t) override { }
     void processHadError(basic::ProcessContext*, basic::ProcessHandle, const Twine&) override { }
     void processHadOutput(basic::ProcessContext*, basic::ProcessHandle, StringRef) override { }
     void processFinished(basic::ProcessContext*, basic::ProcessHandle, const basic::ProcessResult&) override { }

--- a/lib/Commands/NinjaBuildCommand.cpp
+++ b/lib/Commands/NinjaBuildCommand.cpp
@@ -666,7 +666,7 @@ public:
 
   void queueJobStarted(JobDescriptor*) override {}
   void queueJobFinished(JobDescriptor*) override {}
-  void processStarted(ProcessContext* ctx, ProcessHandle handle) override {
+  void processStarted(ProcessContext* ctx, ProcessHandle handle, llbuild_pid_t pid) override {
     std::lock_guard<std::mutex> lock(outputBufferMutex);
     outputBuffers.emplace(handle.id, SmallString<1024>());
   }

--- a/lib/Core/BuildEngine.cpp
+++ b/lib/Core/BuildEngine.cpp
@@ -1830,10 +1830,10 @@ void TaskInterface::spawn(basic::QueueJobContext *context,
                           ArrayRef<StringRef> commandLine,
                           ArrayRef<std::pair<StringRef, StringRef> > environment,
                           basic::ProcessAttributes attributes,
-                          llvm::Optional<basic::ProcessCompletionFn> completionFn) {
-  // FIXME: handle environment
+                          llvm::Optional<basic::ProcessCompletionFn> completionFn,
+                          basic::ProcessDelegate* delegate) {
   static_cast<BuildEngineImpl*>(impl)->getExecutionQueue().executeProcess(
-    context, commandLine, environment, attributes, completionFn);
+    context, commandLine, environment, attributes, completionFn, delegate);
 }
 
 basic::ProcessStatus TaskInterface::spawn(basic::QueueJobContext *context,

--- a/lib/Evo/EvoEngine.cpp
+++ b/lib/Evo/EvoEngine.cpp
@@ -109,7 +109,8 @@ private:
     }
 
     void processStarted(basic::ProcessContext* ctx,
-                        basic::ProcessHandle handle) override { }
+                        basic::ProcessHandle handle,
+                        llbuild_pid_t pid) override { }
 
     void processHadError(basic::ProcessContext* ctx,
                          basic::ProcessHandle handle,

--- a/perftests/Xcode/PerfTests/BuildSystemPerfTests.mm
+++ b/perftests/Xcode/PerfTests/BuildSystemPerfTests.mm
@@ -74,7 +74,7 @@ static void ExecuteShellCommand(const char *String) {
 
 
 class PerfTestProcessDelegate : public ProcessDelegate {
-    void processStarted(ProcessContext*, ProcessHandle) {}
+    void processStarted(ProcessContext*, ProcessHandle, llbuild_pid_t) {}
     void processHadError(ProcessContext*, ProcessHandle, const Twine&) {}
     void processHadOutput(ProcessContext*, ProcessHandle, StringRef) {}
     void processFinished(ProcessContext*, ProcessHandle, const ProcessResult&) {}

--- a/perftests/Xcode/PerfTests/CorePerfTests.mm
+++ b/perftests/Xcode/PerfTests/CorePerfTests.mm
@@ -176,7 +176,7 @@ public:
       abort();
     }
 
-    void processStarted(basic::ProcessContext*, basic::ProcessHandle) override { }
+    void processStarted(basic::ProcessContext*, basic::ProcessHandle, llbuild_pid_t) override { }
     void processHadError(basic::ProcessContext*, basic::ProcessHandle, const Twine&) override { }
     void processHadOutput(basic::ProcessContext*, basic::ProcessHandle, StringRef) override { }
     void processFinished(basic::ProcessContext*, basic::ProcessHandle, const basic::ProcessResult&) override { }
@@ -267,7 +267,7 @@ static int64_t i64pow(int64_t Value, int64_t Exponent) {
       abort();
     }
 
-    void processStarted(basic::ProcessContext*, basic::ProcessHandle) override { }
+    void processStarted(basic::ProcessContext*, basic::ProcessHandle, llbuild_pid_t) override { }
     void processHadError(basic::ProcessContext*, basic::ProcessHandle, const Twine&) override { }
     void processHadOutput(basic::ProcessContext*, basic::ProcessHandle, StringRef) override { }
     void processFinished(basic::ProcessContext*, basic::ProcessHandle, const basic::ProcessResult&) override { }
@@ -361,7 +361,7 @@ static int64_t i64pow(int64_t Value, int64_t Exponent) {
       abort();
     }
 
-    void processStarted(basic::ProcessContext*, basic::ProcessHandle) override { }
+    void processStarted(basic::ProcessContext*, basic::ProcessHandle, llbuild_pid_t) override { }
     void processHadError(basic::ProcessContext*, basic::ProcessHandle, const Twine&) override { }
     void processHadOutput(basic::ProcessContext*, basic::ProcessHandle, StringRef) override { }
     void processFinished(basic::ProcessContext*, basic::ProcessHandle, const basic::ProcessResult&) override { }

--- a/products/libllbuild/BuildSystem-C-API.cpp
+++ b/products/libllbuild/BuildSystem-C-API.cpp
@@ -34,6 +34,7 @@
 
 #include <atomic>
 #include <cassert>
+#include <future>
 #include <memory>
 
 using namespace llbuild;
@@ -149,25 +150,25 @@ public:
   }
 };
   
+llb_buildsystem_command_result_t get_command_result(ProcessStatus commandResult) {
+  switch (commandResult) {
+    case ProcessStatus::Succeeded:
+      return llb_buildsystem_command_result_succeeded;
+    case ProcessStatus::Cancelled:
+      return llb_buildsystem_command_result_cancelled;
+    case ProcessStatus::Failed:
+      return llb_buildsystem_command_result_failed;
+    case ProcessStatus::Skipped:
+      return llb_buildsystem_command_result_skipped;
+    default:
+      assert(0 && "unknown command result");
+      break;
+  }
+  return llb_buildsystem_command_result_failed;
+}
+
 class CAPIBuildSystemFrontendDelegate : public BuildSystemFrontendDelegate {
   llb_buildsystem_delegate_t cAPIDelegate;
-
-  llb_buildsystem_command_result_t get_command_result(ProcessStatus commandResult) {
-    switch (commandResult) {
-      case ProcessStatus::Succeeded:
-        return llb_buildsystem_command_result_succeeded;
-      case ProcessStatus::Cancelled:
-        return llb_buildsystem_command_result_cancelled;
-      case ProcessStatus::Failed:
-        return llb_buildsystem_command_result_failed;
-      case ProcessStatus::Skipped:
-        return llb_buildsystem_command_result_skipped;
-      default:
-        assert(0 && "unknown command result");
-        break;
-    }
-    return llb_buildsystem_command_result_failed;
-  }
 
 public:
   CAPIBuildSystemFrontendDelegate(llvm::SourceMgr& sourceMgr,
@@ -998,6 +999,73 @@ llb_build_value_file_info_t llb_buildsystem_command_interface_get_file_info(llb_
   return llbuild::capi::convertFileInfo(bi->getFileSystem().getFileInfo(path));
 }
 
+bool llb_buildsystem_command_interface_spawn(llb_task_interface_t ti, llb_buildsystem_queue_job_context_t *job_context, const char * const*args, int32_t arg_count, const char * const *env_keys, const char * const *env_values, int32_t env_count, llb_data_t *working_dir, llb_buildsystem_spawn_delegate_t *delegate) {
+  auto coreti = reinterpret_cast<core::TaskInterface*>(&ti);
+  auto arguments = std::vector<StringRef>();
+  for (int32_t i = 0; i < arg_count; i++) {
+    arguments.push_back(StringRef(args[i]));
+  }
+  auto environment = std::vector<std::pair<StringRef, StringRef>>();
+  for (int32_t i = 0; i < env_count; i++) {
+    environment.push_back(std::pair<StringRef, StringRef>(StringRef(env_keys[i]), StringRef(env_values[i])));
+  }
+  
+  std::promise<ProcessResult> p;
+  auto result = p.get_future();
+  auto commandCompletionFn = [&p](ProcessResult processResult) mutable {
+    p.set_value(processResult);
+  };
+  
+  class ForwardingProcessDelegate: public basic::ProcessDelegate {
+    llb_buildsystem_spawn_delegate_t *delegate;
+    
+  public:
+    ForwardingProcessDelegate(llb_buildsystem_spawn_delegate_t *delegate): delegate(delegate) {}
+    
+    virtual void processStarted(ProcessContext* ctx, ProcessHandle handle,
+                                llbuild_pid_t pid) {
+      if (delegate != NULL) {
+        delegate->process_started(delegate->context, pid);
+      }
+    }
+
+    virtual void processHadError(ProcessContext* ctx, ProcessHandle handle,
+                                 const Twine& message) {
+      if (delegate != NULL) {
+        auto errStr = message.str();
+        llb_data_t err{ errStr.size(), (const uint8_t*) errStr.data() };
+        delegate->process_had_error(delegate->context, &err);
+      }
+    };
+
+    virtual void processHadOutput(ProcessContext* ctx, ProcessHandle handle,
+                                  StringRef data) {
+      if (delegate != NULL) {
+        llb_data_t message{ data.size(), (const uint8_t*) data.data() };
+        delegate->process_had_output(delegate->context, &message);
+      }
+    };
+
+    virtual void processFinished(ProcessContext* ctx, ProcessHandle handle,
+                                 const ProcessResult& result) {
+      if (delegate != NULL) {
+        llb_buildsystem_command_extended_result_t res;
+        res.result = get_command_result(result.status);
+        res.exit_status = result.exitCode;
+        res.pid = result.pid;
+        res.utime = result.utime;
+        res.stime = result.stime;
+        res.maxrss = result.maxrss;
+        delegate->process_finished(delegate->context, &res);
+      }
+    }
+
+  };
+  
+  coreti->spawn((QueueJobContext*)job_context, ArrayRef<StringRef>(arguments), ArrayRef<std::pair<StringRef, StringRef>>(environment), {true, false, StringRef((const char*)working_dir->data, working_dir->length)}, {commandCompletionFn}, new ForwardingProcessDelegate(delegate));
+  
+  return result.get().status == ProcessStatus::Succeeded;  
+}
 
 llb_quality_of_service_t llb_get_quality_of_service() {
   switch (getDefaultQualityOfService()) {

--- a/products/libllbuild/Core-C-API.cpp
+++ b/products/libllbuild/Core-C-API.cpp
@@ -94,7 +94,7 @@ class CAPIBuildEngineDelegate : public BuildEngineDelegate, public basic::Execut
     cAPIDelegate.error(cAPIDelegate.context, message.str().c_str());
   }
 
-  void processStarted(basic::ProcessContext*, basic::ProcessHandle) override { }
+  void processStarted(basic::ProcessContext*, basic::ProcessHandle, llbuild_pid_t pid) override { }
   void processHadError(basic::ProcessContext*, basic::ProcessHandle, const Twine&) override { }
   void processHadOutput(basic::ProcessContext*, basic::ProcessHandle, StringRef) override { }
   void processFinished(basic::ProcessContext*, basic::ProcessHandle, const basic::ProcessResult&) override { }

--- a/products/libllbuild/include/llbuild/buildsystem.h
+++ b/products/libllbuild/include/llbuild/buildsystem.h
@@ -610,6 +610,25 @@ llb_buildsystem_tool_create(const llb_data_t* name,
 typedef struct llb_buildsystem_queue_job_context_t_
   llb_buildsystem_queue_job_context_t;
 
+/// Delegate for process spawning
+typedef struct llb_buildsystem_spawn_delegate_t_ {
+  /// User context pointer.
+  void* context;
+  
+  /// Called when the spawned process started
+  void (*process_started)(void* context, llbuild_pid_t pid);
+  
+  /// Called to report an error in the management of the process
+  void (*process_had_error)(void* context, const llb_data_t* error);
+  
+  /// Called to report command output (stdout and stderr)
+  void (*process_had_output)(void* context, const llb_data_t* data);
+  
+  /// Called when the process finished running
+  void (*process_finished)(void* context, const llb_buildsystem_command_extended_result_t *result);
+  
+} llb_buildsystem_spawn_delegate_t;
+
 /// Delegate structure for callbacks required by an external build command.
 typedef struct llb_buildsystem_external_command_delegate_t_ {
   /// User context pointer.
@@ -740,6 +759,9 @@ llb_buildsystem_command_interface_task_discovered_dependency(llb_task_interface_
 LLBUILD_EXPORT llb_build_value_file_info_t
 llb_buildsystem_command_interface_get_file_info(llb_buildsystem_interface_t* bi_p, const char* path);
 
+/// Spawns a process using the task interface and a job's context
+LLBUILD_EXPORT bool
+llb_buildsystem_command_interface_spawn(llb_task_interface_t ti, llb_buildsystem_queue_job_context_t *job_context, const char * const*args, int32_t arg_count, const char * const *env_keys, const char * const *env_values, int32_t env_count, llb_data_t *working_dir, llb_buildsystem_spawn_delegate_t *delegate);
 
 // MARK: Quality of Service
 

--- a/products/llbuildSwift/BuildSystemBindings.swift
+++ b/products/llbuildSwift/BuildSystemBindings.swift
@@ -31,6 +31,46 @@ private func bytesFromData(_ data: llb_data_t) -> [UInt8] {
     return Array(UnsafeBufferPointer(start: data.data, count: Int(data.length)))
 }
 
+/// Delegate for spawning processes through `BuildSystemCommandInterface`.
+public protocol ProcessDelegate {
+    /// Called when the external process has started executing.
+    ///
+    /// - pid: The subprocess' identifier, can be -1 for failure reasons.
+    func processStarted(pid: llbuild_pid_t)
+    
+    /// Called to report an error in the management of a command process.
+    ///
+    /// - error: The error message.
+    func processHadError(error: String)
+    
+    /// Called to report a command processes' (merged) standard output and error.
+    ///
+    /// - output: The process output.
+    func processHadOutput(output: String)
+    
+    /// Called when a command's job has finished executing an external process.
+    ///
+    /// - result: Whether the process suceeded, failed or was cancelled.
+    func processFinished(result: CommandExtendedResult)
+}
+
+private class ProcessDelegateWrapper {
+    private let delegate: ProcessDelegate
+    fileprivate var wrappedDelegate: llb_buildsystem_spawn_delegate_t!
+    
+    fileprivate init(delegate: ProcessDelegate) {
+        self.delegate = delegate
+        let wrappedDelegate = llb_buildsystem_spawn_delegate_t(
+            context: Unmanaged.passUnretained(self).toOpaque(),
+            process_started: { BuildSystem.toProcessDelegateWrapper($0!).delegate.processStarted(pid: $1) },
+            process_had_error: { BuildSystem.toProcessDelegateWrapper($0!).delegate.processHadError(error: stringFromData($1!.pointee)) },
+            process_had_output: { BuildSystem.toProcessDelegateWrapper($0!).delegate.processHadOutput(output: stringFromData($1!.pointee)) },
+            process_finished: { BuildSystem.toProcessDelegateWrapper($0!).delegate.processFinished(result: CommandExtendedResult($1!)) }
+        )
+        self.wrappedDelegate = wrappedDelegate
+    }
+}
+
 /// Interface into the build system to modify the dependencies of a command.
 public struct BuildSystemCommandInterface {
     // This struct wraps a bsci object, which should be global, and a task object, which is different for each command.
@@ -57,6 +97,41 @@ public struct BuildSystemCommandInterface {
 
     func getFileInfo(_ path: String) throws -> BuildValueFileInfo {
         return llb_buildsystem_command_interface_get_file_info(_buildsystemInterface, path)
+    }
+    
+    /// Spawns a process in the given context
+    ///
+    /// - commandLine: All command line arguments
+    /// - environment: The environment the process will be executed in
+    /// - workingDirectory: The path to the directory the process will use
+    /// - processDelegate: An instace that handles delegate callbacks about the execution of the process
+    public func spawn(_ jobContext: JobContext, commandLine: [String], environment: [String: String], workingDirectory: String, processDelegate: ProcessDelegate) -> Bool {
+        let keys = Array(environment.keys)
+        let values = Array(environment.values)        
+        let wrappedDelegate = ProcessDelegateWrapper(delegate: processDelegate)
+        
+        var workingDirData = copiedDataFromBytes([UInt8](workingDirectory.utf8))
+        
+        defer {
+            llb_data_destroy(&workingDirData)
+        }
+        
+        return commandLine.withCArrayOfOptionalStrings { commandLinePtr in
+            keys.withCArrayOfOptionalStrings { keysPtr in
+                values.withCArrayOfOptionalStrings { valuesPtr in
+                    llb_buildsystem_command_interface_spawn(_taskInterface, jobContext._context, commandLinePtr, Int32(commandLine.count), keysPtr, valuesPtr, Int32(environment.count), &workingDirData, &wrappedDelegate.wrappedDelegate)
+                }
+            }
+        }
+    }
+}
+
+/// Opaque object for the context of a job's execution
+public struct JobContext {
+    fileprivate let _context: OpaquePointer
+    
+    fileprivate init(_ context: OpaquePointer) {
+        _context = context
     }
 }
 
@@ -183,7 +258,14 @@ public protocol ExternalCommand: AnyObject {
     /// - commandInterface: A handle to the build system's command interface.
     /// - returns: True on success.
     func execute(_ command: Command, _ commandInterface: BuildSystemCommandInterface) -> Bool
-
+    
+    /// Called to execute the given command.
+    ///
+    /// - command: A handle to the executing command.
+    /// - commandInterface: A handle to the build system's command interface.
+    /// - jobContext: A handle to opaque context of the executing job for spawning external processes.
+    /// - returns: True on success.
+    func execute(_ command: Command, _ commandInterface: BuildSystemCommandInterface, _ jobContext: JobContext) -> Bool
 }
 
 public protocol ProducesCustomBuildValue: AnyObject {
@@ -201,11 +283,16 @@ public protocol ProducesCustomBuildValue: AnyObject {
     func isResultValid(_ command: Command, _ buildValue: BuildValue) -> Bool
 }
 
-// Extension to provide a default implementation of execute(_ Command, _ commandInterface) to allow clients to
-// migrate in a staggered manner.
+// Extension to provide a default implementation of execute(_ Command, _ commandInterface) and
+// execute(_ Command, _ commandInterface, _ jobContext) to allow clients to migrate in a staggered
+// manner.
 public extension ExternalCommand {
     func execute(_ command: Command, _ commandInterface: BuildSystemCommandInterface) -> Bool {
         return execute(command)
+    }
+    
+    func execute(_ command: Command, _ commandInterface: BuildSystemCommandInterface, _ jobContext: JobContext) -> Bool {
+        return execute(command, commandInterface)
     }
 
     // If this implementation is invoked, it means that the client implementing ExternalCommand did not
@@ -252,7 +339,7 @@ private final class CommandWrapper {
 
     func executeCommand(_: OpaquePointer, _ buildsystemInterface: OpaquePointer, _ taskInterface: llb_task_interface_t, _ jobContext: OpaquePointer) -> Bool {
         let commandInterface = BuildSystemCommandInterface(buildsystemInterface, taskInterface)
-        return command.execute(_command, commandInterface)
+        return command.execute(_command, commandInterface, JobContext(jobContext))
     }
 
     func executeCommand(_: OpaquePointer, _ buildsystemInterface: OpaquePointer, _ taskInterface: llb_task_interface_t, _ jobContext: OpaquePointer) -> BuildValue {
@@ -914,6 +1001,11 @@ public final class BuildSystem {
     /// Helper function for getting the command wrapper from the delegate context.
     static fileprivate func toCommandWrapper(_ context: UnsafeMutableRawPointer) -> CommandWrapper {
         return Unmanaged<CommandWrapper>.fromOpaque(UnsafeRawPointer(context)).takeUnretainedValue()
+    }
+    
+    /// Helper function for getting the process delegate wrapper from the delegate context.
+    static fileprivate func toProcessDelegateWrapper(_ context: UnsafeMutableRawPointer) -> ProcessDelegateWrapper {
+        return Unmanaged<ProcessDelegateWrapper>.fromOpaque(UnsafeRawPointer(context)).takeUnretainedValue()
     }
 
     private func fsGetFileContents(_ path: String, _ data: UnsafeMutablePointer<llb_data_t>) -> Bool {

--- a/products/llbuildSwift/Internals.swift
+++ b/products/llbuildSwift/Internals.swift
@@ -63,4 +63,22 @@ extension Array where Element == String {
 
         return appendPointer(self.startIndex, to: &elements)
     }
+    
+    internal func withCArrayOfOptionalStrings<T>(_ body: @escaping (UnsafePointer<UnsafePointer<CChar>?>) -> T) -> T {
+        func appendPointer(_ index: Array.Index, to target: inout Array<UnsafePointer<CChar>?>) -> T {
+            if index == self.endIndex {
+                return body(&target)
+            } else {
+                return self[index].withCString { cStringPtr in
+                    target.append(cStringPtr)
+                    return appendPointer(self.index(after: index), to: &target)
+                }
+            }
+        }
+
+        var elements = Array<UnsafePointer<CChar>?>()
+        elements.reserveCapacity(self.count)
+
+        return appendPointer(self.startIndex, to: &elements)
+    }
 }

--- a/unittests/Basic/LaneBasedExecutionQueueTest.cpp
+++ b/unittests/Basic/LaneBasedExecutionQueueTest.cpp
@@ -37,7 +37,7 @@ namespace {
 
     virtual void queueJobStarted(JobDescriptor*) override {}
     virtual void queueJobFinished(JobDescriptor*) override {}
-    virtual void processStarted(ProcessContext*, ProcessHandle) override {}
+    virtual void processStarted(ProcessContext*, ProcessHandle, llbuild_pid_t) override {}
     virtual void processHadError(ProcessContext*, ProcessHandle,
                                  const Twine& message) override {}
     virtual void processHadOutput(ProcessContext*, ProcessHandle,

--- a/unittests/BuildSystem/MockBuildSystemDelegate.h
+++ b/unittests/BuildSystem/MockBuildSystemDelegate.h
@@ -43,7 +43,8 @@ private:
 
   virtual void queueJobFinished(JobDescriptor*) override {}
 
-  virtual void processStarted(ProcessContext*, ProcessHandle handle) override {}
+  virtual void processStarted(ProcessContext*, ProcessHandle,
+                              llbuild_pid_t) override {}
 
   virtual void processHadError(ProcessContext*, ProcessHandle handle,
                                const Twine& message) override {}

--- a/unittests/Core/BuildEngineCancellationTest.cpp
+++ b/unittests/Core/BuildEngineCancellationTest.cpp
@@ -50,7 +50,7 @@ private:
       abort();
   }
 
-  void processStarted(basic::ProcessContext*, basic::ProcessHandle) override { }
+  void processStarted(basic::ProcessContext*, basic::ProcessHandle, llbuild_pid_t) override { }
   void processHadError(basic::ProcessContext*, basic::ProcessHandle, const Twine&) override { }
   void processHadOutput(basic::ProcessContext*, basic::ProcessHandle, StringRef) override { }
   void processFinished(basic::ProcessContext*, basic::ProcessHandle, const basic::ProcessResult&) override { }

--- a/unittests/Core/BuildEngineTest.cpp
+++ b/unittests/Core/BuildEngineTest.cpp
@@ -69,7 +69,7 @@ private:
     }
   }
 
-  void processStarted(basic::ProcessContext*, basic::ProcessHandle) override { }
+  void processStarted(basic::ProcessContext*, basic::ProcessHandle, llbuild_pid_t) override { }
   void processHadError(basic::ProcessContext*, basic::ProcessHandle, const Twine&) override { }
   void processHadOutput(basic::ProcessContext*, basic::ProcessHandle, StringRef) override { }
   void processFinished(basic::ProcessContext*, basic::ProcessHandle, const basic::ProcessResult&) override { }

--- a/unittests/Core/DepsBuildEngineTest.cpp
+++ b/unittests/Core/DepsBuildEngineTest.cpp
@@ -50,7 +50,7 @@ class SimpleBuildEngineDelegate : public core::BuildEngineDelegate, public basic
     abort();
   }
 
-  void processStarted(basic::ProcessContext*, basic::ProcessHandle) override { }
+  void processStarted(basic::ProcessContext*, basic::ProcessHandle, llbuild_pid_t) override { }
   void processHadError(basic::ProcessContext*, basic::ProcessHandle, const Twine&) override { }
   void processHadOutput(basic::ProcessContext*, basic::ProcessHandle, StringRef) override { }
   void processFinished(basic::ProcessContext*, basic::ProcessHandle, const basic::ProcessResult&) override { }

--- a/unittests/Evo/EvoEngineTest.cpp
+++ b/unittests/Evo/EvoEngineTest.cpp
@@ -69,7 +69,7 @@ private:
     }
   }
 
-  void processStarted(basic::ProcessContext*, basic::ProcessHandle) override { }
+  void processStarted(basic::ProcessContext*, basic::ProcessHandle, llbuild_pid_t) override { }
   void processHadError(basic::ProcessContext*, basic::ProcessHandle, const Twine&) override { }
   void processHadOutput(basic::ProcessContext*, basic::ProcessHandle, StringRef) override { }
   void processFinished(basic::ProcessContext*, basic::ProcessHandle, const basic::ProcessResult&) override { }


### PR DESCRIPTION
TaskInterface offers an API to spawn sub-processes for ExternalCommands' executeExternalCommand method. This API was not exposed to Swift clients before. With this change, Swift (and C) clients can spawn sub-processes from within the ExternalCommand context enabling custom commands with custom dependency and lifecycle logic while still using llbuild for the execution of processes.

rdar://58130781