### PR TITLE
Revert "Expose TaskInterface's spawn API to clients"

### DIFF
--- a/include/llbuild/Basic/Subprocess.h
+++ b/include/llbuild/Basic/Subprocess.h
@@ -187,8 +187,7 @@ namespace llbuild {
       /// different status calls relating to the same process. It is only
       /// guaranteed to be unique from when it has been provided here to when it
       /// has been provided to the \see processFinished() call.
-      /// \param pid - The subprocess' identifier, can be -1 for failure reasons.
-      virtual void processStarted(ProcessContext* ctx, ProcessHandle handle, llbuild_pid_t pid) = 0;
+      virtual void processStarted(ProcessContext* ctx, ProcessHandle handle) = 0;
 
       /// Called to report an error in the management of a command process.
       ///

--- a/include/llbuild/Core/BuildEngine.h
+++ b/include/llbuild/Core/BuildEngine.h
@@ -187,8 +187,7 @@ public:
              ArrayRef<StringRef> commandLine,
              ArrayRef<std::pair<StringRef, StringRef>> environment,
              basic::ProcessAttributes attributes = {true},
-             llvm::Optional<basic::ProcessCompletionFn> completionFn = {llvm::None},
-             basic::ProcessDelegate* delegate = nullptr);
+             llvm::Optional<basic::ProcessCompletionFn> completionFn = {llvm::None});
 
   basic::ProcessStatus spawn(basic::QueueJobContext* context,
                              ArrayRef<StringRef> commandLine);

--- a/lib/Basic/Subprocess.cpp
+++ b/lib/Basic/Subprocess.cpp
@@ -650,11 +650,8 @@ void llbuild::basic::spawnProcess(
     ProcessReleaseFn&& releaseFn,
     ProcessCompletionFn&& completionFn
 ) {
-  llbuild_pid_t pid = (llbuild_pid_t)-1;
-  
 #if !defined(_WIN32) && !defined(HAVE_POSIX_SPAWN)
   auto result = ProcessResult::makeFailed();
-  delegate.processStarted(ctx, handle, pid);
   delegate.processHadError(ctx, handle, Twine("process spawning is unavailable"));
   delegate.processFinished(ctx, handle, result);
   completionFn(result);
@@ -670,9 +667,10 @@ void llbuild::basic::spawnProcess(
   attr.controlEnabled = false;
 #endif
 
+  delegate.processStarted(ctx, handle);
+
   if (commandLine.size() == 0) {
     auto result = ProcessResult::makeFailed();
-    delegate.processStarted(ctx, handle, pid);
     delegate.processHadError(ctx, handle, Twine("no arguments for command"));
     delegate.processFinished(ctx, handle, result);
     completionFn(result);
@@ -813,6 +811,7 @@ void llbuild::basic::spawnProcess(
   }
 
   // Spawn the command.
+  llbuild_pid_t pid = (llbuild_pid_t)-1;
   bool wasCancelled;
   do {
       // We need to hold the spawn processes lock when we spawn, to ensure that
@@ -836,7 +835,6 @@ void llbuild::basic::spawnProcess(
         posix_spawn_file_actions_destroy(&fileActions);
         posix_spawnattr_destroy(&attributes);
 #endif
-        delegate.processStarted(ctx, handle, pid);
         delegate.processHadError(ctx, handle,
             Twine("unable to open " + whatPipe + " (") + strerror(errorPair.second) + ")");
         delegate.processFinished(ctx, handle, ProcessResult::makeFailed());
@@ -901,8 +899,6 @@ void llbuild::basic::spawnProcess(
                         const_cast<char* const*>(environment.getEnvp()));
 #endif
       }
-    
-      delegate.processStarted(ctx, handle, pid);
 
       if (result != 0) {
         auto processResult = ProcessResult::makeFailed();

--- a/lib/BuildSystem/BuildSystemExtensionManager.cpp
+++ b/lib/BuildSystem/BuildSystemExtensionManager.cpp
@@ -54,8 +54,7 @@ BuildSystemExtensionManager::lookupByCommandPath(StringRef path) {
     SmallString<1024> output;
     bool success;
     
-    virtual void processStarted(ProcessContext* ctx, ProcessHandle handle,
-                                llbuild_pid_t pid) {}
+    virtual void processStarted(ProcessContext* ctx, ProcessHandle handle) {}
 
     virtual void processHadError(ProcessContext* ctx, ProcessHandle handle,
                                  const Twine& message) {};

--- a/lib/BuildSystem/BuildSystemFrontend.cpp
+++ b/lib/BuildSystem/BuildSystemFrontend.cpp
@@ -251,8 +251,7 @@ public:
   }
 
   virtual void processStarted(ProcessContext* command,
-                              ProcessHandle handle,
-                              llbuild_pid_t pid) override {
+                              ProcessHandle handle) override {
     static_cast<BuildSystemFrontendDelegate*>(&getSystem().getDelegate())->
       commandProcessStarted(
           reinterpret_cast<Command*>(command),

--- a/lib/Commands/BuildEngineCommand.cpp
+++ b/lib/Commands/BuildEngineCommand.cpp
@@ -231,7 +231,7 @@ static int runAckermannBuild(int m, int n, int recomputeCount,
       assert(0 && ("error:" + message.str()).c_str());
     }
 
-    void processStarted(basic::ProcessContext*, basic::ProcessHandle, llbuild_pid_t) override { }
+    void processStarted(basic::ProcessContext*, basic::ProcessHandle) override { }
     void processHadError(basic::ProcessContext*, basic::ProcessHandle, const Twine&) override { }
     void processHadOutput(basic::ProcessContext*, basic::ProcessHandle, StringRef) override { }
     void processFinished(basic::ProcessContext*, basic::ProcessHandle, const basic::ProcessResult&) override { }
@@ -336,7 +336,7 @@ static int runEvoAckermann(int m, int n, int recomputeCount,
       assert(0 && ("error:" + message.str()).c_str());
     }
 
-    void processStarted(basic::ProcessContext*, basic::ProcessHandle, llbuild_pid_t) override { }
+    void processStarted(basic::ProcessContext*, basic::ProcessHandle) override { }
     void processHadError(basic::ProcessContext*, basic::ProcessHandle, const Twine&) override { }
     void processHadOutput(basic::ProcessContext*, basic::ProcessHandle, StringRef) override { }
     void processFinished(basic::ProcessContext*, basic::ProcessHandle, const basic::ProcessResult&) override { }

--- a/lib/Commands/NinjaBuildCommand.cpp
+++ b/lib/Commands/NinjaBuildCommand.cpp
@@ -666,7 +666,7 @@ public:
 
   void queueJobStarted(JobDescriptor*) override {}
   void queueJobFinished(JobDescriptor*) override {}
-  void processStarted(ProcessContext* ctx, ProcessHandle handle, llbuild_pid_t pid) override {
+  void processStarted(ProcessContext* ctx, ProcessHandle handle) override {
     std::lock_guard<std::mutex> lock(outputBufferMutex);
     outputBuffers.emplace(handle.id, SmallString<1024>());
   }

--- a/lib/Core/BuildEngine.cpp
+++ b/lib/Core/BuildEngine.cpp
@@ -1830,10 +1830,10 @@ void TaskInterface::spawn(basic::QueueJobContext *context,
                           ArrayRef<StringRef> commandLine,
                           ArrayRef<std::pair<StringRef, StringRef> > environment,
                           basic::ProcessAttributes attributes,
-                          llvm::Optional<basic::ProcessCompletionFn> completionFn,
-                          basic::ProcessDelegate* delegate) {
+                          llvm::Optional<basic::ProcessCompletionFn> completionFn) {
+  // FIXME: handle environment
   static_cast<BuildEngineImpl*>(impl)->getExecutionQueue().executeProcess(
-    context, commandLine, environment, attributes, completionFn, delegate);
+    context, commandLine, environment, attributes, completionFn);
 }
 
 basic::ProcessStatus TaskInterface::spawn(basic::QueueJobContext *context,

--- a/lib/Evo/EvoEngine.cpp
+++ b/lib/Evo/EvoEngine.cpp
@@ -109,8 +109,7 @@ private:
     }
 
     void processStarted(basic::ProcessContext* ctx,
-                        basic::ProcessHandle handle,
-                        llbuild_pid_t pid) override { }
+                        basic::ProcessHandle handle) override { }
 
     void processHadError(basic::ProcessContext* ctx,
                          basic::ProcessHandle handle,

--- a/perftests/Xcode/PerfTests/BuildSystemPerfTests.mm
+++ b/perftests/Xcode/PerfTests/BuildSystemPerfTests.mm
@@ -74,7 +74,7 @@ static void ExecuteShellCommand(const char *String) {
 
 
 class PerfTestProcessDelegate : public ProcessDelegate {
-    void processStarted(ProcessContext*, ProcessHandle, llbuild_pid_t) {}
+    void processStarted(ProcessContext*, ProcessHandle) {}
     void processHadError(ProcessContext*, ProcessHandle, const Twine&) {}
     void processHadOutput(ProcessContext*, ProcessHandle, StringRef) {}
     void processFinished(ProcessContext*, ProcessHandle, const ProcessResult&) {}

--- a/perftests/Xcode/PerfTests/CorePerfTests.mm
+++ b/perftests/Xcode/PerfTests/CorePerfTests.mm
@@ -176,7 +176,7 @@ public:
       abort();
     }
 
-    void processStarted(basic::ProcessContext*, basic::ProcessHandle, llbuild_pid_t) override { }
+    void processStarted(basic::ProcessContext*, basic::ProcessHandle) override { }
     void processHadError(basic::ProcessContext*, basic::ProcessHandle, const Twine&) override { }
     void processHadOutput(basic::ProcessContext*, basic::ProcessHandle, StringRef) override { }
     void processFinished(basic::ProcessContext*, basic::ProcessHandle, const basic::ProcessResult&) override { }
@@ -267,7 +267,7 @@ static int64_t i64pow(int64_t Value, int64_t Exponent) {
       abort();
     }
 
-    void processStarted(basic::ProcessContext*, basic::ProcessHandle, llbuild_pid_t) override { }
+    void processStarted(basic::ProcessContext*, basic::ProcessHandle) override { }
     void processHadError(basic::ProcessContext*, basic::ProcessHandle, const Twine&) override { }
     void processHadOutput(basic::ProcessContext*, basic::ProcessHandle, StringRef) override { }
     void processFinished(basic::ProcessContext*, basic::ProcessHandle, const basic::ProcessResult&) override { }
@@ -361,7 +361,7 @@ static int64_t i64pow(int64_t Value, int64_t Exponent) {
       abort();
     }
 
-    void processStarted(basic::ProcessContext*, basic::ProcessHandle, llbuild_pid_t) override { }
+    void processStarted(basic::ProcessContext*, basic::ProcessHandle) override { }
     void processHadError(basic::ProcessContext*, basic::ProcessHandle, const Twine&) override { }
     void processHadOutput(basic::ProcessContext*, basic::ProcessHandle, StringRef) override { }
     void processFinished(basic::ProcessContext*, basic::ProcessHandle, const basic::ProcessResult&) override { }

--- a/products/libllbuild/Core-C-API.cpp
+++ b/products/libllbuild/Core-C-API.cpp
@@ -94,7 +94,7 @@ class CAPIBuildEngineDelegate : public BuildEngineDelegate, public basic::Execut
     cAPIDelegate.error(cAPIDelegate.context, message.str().c_str());
   }
 
-  void processStarted(basic::ProcessContext*, basic::ProcessHandle, llbuild_pid_t pid) override { }
+  void processStarted(basic::ProcessContext*, basic::ProcessHandle) override { }
   void processHadError(basic::ProcessContext*, basic::ProcessHandle, const Twine&) override { }
   void processHadOutput(basic::ProcessContext*, basic::ProcessHandle, StringRef) override { }
   void processFinished(basic::ProcessContext*, basic::ProcessHandle, const basic::ProcessResult&) override { }

--- a/products/libllbuild/include/llbuild/buildsystem.h
+++ b/products/libllbuild/include/llbuild/buildsystem.h
@@ -610,25 +610,6 @@ llb_buildsystem_tool_create(const llb_data_t* name,
 typedef struct llb_buildsystem_queue_job_context_t_
   llb_buildsystem_queue_job_context_t;
 
-/// Delegate for process spawning
-typedef struct llb_buildsystem_spawn_delegate_t_ {
-  /// User context pointer.
-  void* context;
-  
-  /// Called when the spawned process started
-  void (*process_started)(void* context, llbuild_pid_t pid);
-  
-  /// Called to report an error in the management of the process
-  void (*process_had_error)(void* context, const llb_data_t* error);
-  
-  /// Called to report command output (stdout and stderr)
-  void (*process_had_output)(void* context, const llb_data_t* data);
-  
-  /// Called when the process finished running
-  void (*process_finished)(void* context, const llb_buildsystem_command_extended_result_t *result);
-  
-} llb_buildsystem_spawn_delegate_t;
-
 /// Delegate structure for callbacks required by an external build command.
 typedef struct llb_buildsystem_external_command_delegate_t_ {
   /// User context pointer.
@@ -759,9 +740,6 @@ llb_buildsystem_command_interface_task_discovered_dependency(llb_task_interface_
 LLBUILD_EXPORT llb_build_value_file_info_t
 llb_buildsystem_command_interface_get_file_info(llb_buildsystem_interface_t* bi_p, const char* path);
 
-/// Spawns a process using the task interface and a job's context
-LLBUILD_EXPORT bool
-llb_buildsystem_command_interface_spawn(llb_task_interface_t ti, llb_buildsystem_queue_job_context_t *job_context, const char * const*args, int32_t arg_count, const char * const *env_keys, const char * const *env_values, int32_t env_count, llb_data_t *working_dir, llb_buildsystem_spawn_delegate_t *delegate);
 
 // MARK: Quality of Service
 

--- a/products/llbuildSwift/Internals.swift
+++ b/products/llbuildSwift/Internals.swift
@@ -63,22 +63,4 @@ extension Array where Element == String {
 
         return appendPointer(self.startIndex, to: &elements)
     }
-    
-    internal func withCArrayOfOptionalStrings<T>(_ body: @escaping (UnsafePointer<UnsafePointer<CChar>?>) -> T) -> T {
-        func appendPointer(_ index: Array.Index, to target: inout Array<UnsafePointer<CChar>?>) -> T {
-            if index == self.endIndex {
-                return body(&target)
-            } else {
-                return self[index].withCString { cStringPtr in
-                    target.append(cStringPtr)
-                    return appendPointer(self.index(after: index), to: &target)
-                }
-            }
-        }
-
-        var elements = Array<UnsafePointer<CChar>?>()
-        elements.reserveCapacity(self.count)
-
-        return appendPointer(self.startIndex, to: &elements)
-    }
 }

--- a/unittests/Basic/LaneBasedExecutionQueueTest.cpp
+++ b/unittests/Basic/LaneBasedExecutionQueueTest.cpp
@@ -37,7 +37,7 @@ namespace {
 
     virtual void queueJobStarted(JobDescriptor*) override {}
     virtual void queueJobFinished(JobDescriptor*) override {}
-    virtual void processStarted(ProcessContext*, ProcessHandle, llbuild_pid_t) override {}
+    virtual void processStarted(ProcessContext*, ProcessHandle) override {}
     virtual void processHadError(ProcessContext*, ProcessHandle,
                                  const Twine& message) override {}
     virtual void processHadOutput(ProcessContext*, ProcessHandle,

--- a/unittests/BuildSystem/MockBuildSystemDelegate.h
+++ b/unittests/BuildSystem/MockBuildSystemDelegate.h
@@ -43,8 +43,7 @@ private:
 
   virtual void queueJobFinished(JobDescriptor*) override {}
 
-  virtual void processStarted(ProcessContext*, ProcessHandle,
-                              llbuild_pid_t) override {}
+  virtual void processStarted(ProcessContext*, ProcessHandle handle) override {}
 
   virtual void processHadError(ProcessContext*, ProcessHandle handle,
                                const Twine& message) override {}

--- a/unittests/Core/BuildEngineCancellationTest.cpp
+++ b/unittests/Core/BuildEngineCancellationTest.cpp
@@ -50,7 +50,7 @@ private:
       abort();
   }
 
-  void processStarted(basic::ProcessContext*, basic::ProcessHandle, llbuild_pid_t) override { }
+  void processStarted(basic::ProcessContext*, basic::ProcessHandle) override { }
   void processHadError(basic::ProcessContext*, basic::ProcessHandle, const Twine&) override { }
   void processHadOutput(basic::ProcessContext*, basic::ProcessHandle, StringRef) override { }
   void processFinished(basic::ProcessContext*, basic::ProcessHandle, const basic::ProcessResult&) override { }

--- a/unittests/Core/BuildEngineTest.cpp
+++ b/unittests/Core/BuildEngineTest.cpp
@@ -69,7 +69,7 @@ private:
     }
   }
 
-  void processStarted(basic::ProcessContext*, basic::ProcessHandle, llbuild_pid_t) override { }
+  void processStarted(basic::ProcessContext*, basic::ProcessHandle) override { }
   void processHadError(basic::ProcessContext*, basic::ProcessHandle, const Twine&) override { }
   void processHadOutput(basic::ProcessContext*, basic::ProcessHandle, StringRef) override { }
   void processFinished(basic::ProcessContext*, basic::ProcessHandle, const basic::ProcessResult&) override { }

--- a/unittests/Core/DepsBuildEngineTest.cpp
+++ b/unittests/Core/DepsBuildEngineTest.cpp
@@ -50,7 +50,7 @@ class SimpleBuildEngineDelegate : public core::BuildEngineDelegate, public basic
     abort();
   }
 
-  void processStarted(basic::ProcessContext*, basic::ProcessHandle, llbuild_pid_t) override { }
+  void processStarted(basic::ProcessContext*, basic::ProcessHandle) override { }
   void processHadError(basic::ProcessContext*, basic::ProcessHandle, const Twine&) override { }
   void processHadOutput(basic::ProcessContext*, basic::ProcessHandle, StringRef) override { }
   void processFinished(basic::ProcessContext*, basic::ProcessHandle, const basic::ProcessResult&) override { }

--- a/unittests/Evo/EvoEngineTest.cpp
+++ b/unittests/Evo/EvoEngineTest.cpp
@@ -69,7 +69,7 @@ private:
     }
   }
 
-  void processStarted(basic::ProcessContext*, basic::ProcessHandle, llbuild_pid_t) override { }
+  void processStarted(basic::ProcessContext*, basic::ProcessHandle) override { }
   void processHadError(basic::ProcessContext*, basic::ProcessHandle, const Twine&) override { }
   void processHadOutput(basic::ProcessContext*, basic::ProcessHandle, StringRef) override { }
   void processFinished(basic::ProcessContext*, basic::ProcessHandle, const basic::ProcessResult&) override { }


### PR DESCRIPTION
Reverts apple/swift-llbuild#752

This regressed the Windows build: https://ci-external.swift.org/job/oss-swift-windows-toolchain-x86_64-vs2019/418/consoleText