### PR TITLE
[Windows Build] Change processStarted(pid:) to use llbuild_pid_t?

### DIFF
--- a/products/llbuildSwift/BuildSystemBindings.swift
+++ b/products/llbuildSwift/BuildSystemBindings.swift
@@ -104,7 +104,7 @@ public struct BuildSystemCommandInterface {
     /// - commandLine: All command line arguments
     /// - environment: The environment the process will be executed in
     /// - workingDirectory: The path to the directory the process will use
-    /// - processDelegate: An instace that handles delegate callbacks about the execution of the process
+    /// - processDelegate: An instance that handles delegate callbacks about the execution of the process
     public func spawn(_ jobContext: JobContext, commandLine: [String], environment: [String: String], workingDirectory: String, processDelegate: ProcessDelegate) -> Bool {
         let keys = Array(environment.keys)
         let values = Array(environment.values)        

--- a/products/llbuildSwift/BuildSystemBindings.swift
+++ b/products/llbuildSwift/BuildSystemBindings.swift
@@ -36,7 +36,7 @@ public protocol ProcessDelegate {
     /// Called when the external process has started executing.
     ///
     /// - pid: The subprocess' identifier, can be -1 for failure reasons.
-    func processStarted(pid: llbuild_pid_t)
+    func processStarted(pid: llbuild_pid_t?)
     
     /// Called to report an error in the management of a command process.
     ///


### PR DESCRIPTION
This is needed because Windows models llbuild_pid_t as a HANDLE, which is an implicitly unwrapped pointer, so the value can be nil, INVALID_HANDLE_VALUE, or a valid HANDLE value.