### PR TITLE
Add API to return CommandResult for ExternalCommands

### DIFF
--- a/examples/c-api/buildsystem/main.c
+++ b/examples/c-api/buildsystem/main.c
@@ -72,14 +72,14 @@ static void fancy_command_provide_value(void* context,
                                         const llb_build_value* value,
                                         uintptr_t inputID) {}
 
-static bool
+static llb_buildsystem_command_result_t
 fancy_command_execute_command(void *context, llb_buildsystem_command_t* command,
                               llb_buildsystem_interface_t* bi,
                               llb_task_interface_t ti,
                               llb_buildsystem_queue_job_context_t* job) {
   printf("%s\n", __FUNCTION__);
   fflush(stdout);
-  return true;
+  return llb_buildsystem_command_result_succeeded;
 }
 
 // "Fancy" Tool Implementation

--- a/products/libllbuild/include/llbuild/buildsystem.h
+++ b/products/libllbuild/include/llbuild/buildsystem.h
@@ -675,7 +675,7 @@ typedef struct llb_buildsystem_external_command_delegate_t_ {
   /// then try calling the legacy `execute_command` variant if it is defined.
   ///
   /// The C API takes ownership of the value returned by `execute_command_ex`.
-  bool (*execute_command)(void* context,
+  llb_buildsystem_command_result_t (*execute_command)(void* context,
                           llb_buildsystem_command_t* command,
                           llb_buildsystem_interface_t* bi,
                           llb_task_interface_t ti,

--- a/unittests/CAPI/BuildSystem-C-API.cpp
+++ b/unittests/CAPI/BuildSystem-C-API.cpp
@@ -68,7 +68,7 @@ static void depinfo_tester_command_provide_value(void* context,
                                                  const llb_build_value* value,
                                                  uintptr_t inputID) {}
   
-static bool
+static llb_buildsystem_command_result_t
 depinfo_tester_command_execute_command(void *context,
                                        llb_buildsystem_command_t* command,
                                        llb_buildsystem_interface_t* bi,
@@ -103,13 +103,13 @@ depinfo_tester_command_execute_command(void *context,
   // Read the absolute path of the indirect input from the direct input.
   std::string indirectInputPath = readFileContents(directInputPath);
   if (indirectInputPath.empty()) {
-    return false;
+    return llb_buildsystem_command_result_failed;
   }
   
   // Read the contents of the indirect input.
   std::string indirectContents = readFileContents(indirectInputPath);
   if (indirectContents.empty()) {
-    return false;
+    return llb_buildsystem_command_result_failed;
   }
   
   // Write the contents of the indirect input to the output.
@@ -134,7 +134,7 @@ depinfo_tester_command_execute_command(void *context,
 
   // Clean up.
   llb_free(desc);
-  return true;
+  return llb_buildsystem_command_result_succeeded;
 }
 
 static llb_buildsystem_command_t*


### PR DESCRIPTION
ExternalCommands mimic a process that runs in-process but could express their result only as a bool before.
With this change, an ExternalCommand can also set itself as cancelled or skipped on their own logic.
That allows clients to cancel commands if their dependencies exit with an unwanted BuildValue.

rdar://87451647