### PR TITLE
[EXPERIMENTAL] Add support for `vcpkg`

### DIFF
--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,0 +1,5 @@
+{
+  "name": "llbuild",
+  "version-string": "0.1.0",
+  "dependencies": ["sqlite3"]
+}


### PR DESCRIPTION
Windows developers have a relatively difficult experience for pulling in dependencies. This patch adds support for [`vcpkg`](https://github.com/microsoft/vcpkg)'s manifest mode, which can seamlessly integrate with CMake.