### PR TITLE
Add option to mark dependencies as single use

### DIFF
--- a/include/llbuild/Core/BuildEngine.h
+++ b/include/llbuild/Core/BuildEngine.h
@@ -18,7 +18,7 @@
 #include "llbuild/Basic/ExecutionQueue.h"
 #include "llbuild/Basic/Hashing.h"
 
-#include "llbuild/Core/AttributedKeyIDs.h"
+#include "llbuild/Core/DependencyKeyIDs.h"
 #include "llbuild/Core/KeyID.h"
 
 #include "llvm/ADT/StringRef.h"
@@ -89,7 +89,7 @@ struct Result {
   Epoch builtAt = 0;
 
   /// The explicit dependencies required by the generation.
-  AttributedKeyIDs dependencies;
+  DependencyKeyIDs dependencies;
   
   /// The start of the command as a timestamp since a reference time
   basic::Clock::Timestamp start;
@@ -138,6 +138,13 @@ public:
   /// by the engine.
   void request(const KeyType& key, uintptr_t inputID);
 
+  /// Request a task as a dependency just for the current build iteration. Once
+  /// the requesting task finishes, the dependency will be removed so that
+  /// incremental builds won't consider it for invalidating the task.
+  ///
+  /// NOTE: This method behaves like `request` for the current build.
+  void requestSingleUse(const KeyType& key, uintptr_t inputID);
+  
   /// Specify that the task must be built subsequent to the
   /// computation of \arg Key.
   ///

--- a/llbuild.xcodeproj/project.pbxproj
+++ b/llbuild.xcodeproj/project.pbxproj
@@ -1028,7 +1028,7 @@
 		406A05022162A20800EBA895 /* check-all */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.script.sh; path = "check-all"; sourceTree = "<group>"; };
 		406A05032162A5A200EBA895 /* build-and-test */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.script.sh; path = "build-and-test"; sourceTree = "<group>"; };
 		40942C05237F6A8900A9B341 /* KeyID.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = KeyID.h; sourceTree = "<group>"; };
-		40942C06237F6A8900A9B341 /* AttributedKeyIDs.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AttributedKeyIDs.h; sourceTree = "<group>"; };
+		40942C06237F6A8900A9B341 /* DependencyKeyIDs.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = DependencyKeyIDs.h; sourceTree = "<group>"; };
 		40B3C8FF20D3AEBC007C5847 /* CMakeLists.txt */ = {isa = PBXFileReference; lastKnownFileType = text; path = CMakeLists.txt; sourceTree = "<group>"; };
 		40B3C91A20D3AEC9007C5847 /* CAPITests */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = CAPITests; sourceTree = BUILT_PRODUCTS_DIR; };
 		40B3C91B20D3AF9B007C5847 /* C-API.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "C-API.cpp"; sourceTree = "<group>"; };
@@ -2350,7 +2350,7 @@
 		E1A2245719F997FE0059043E /* Headers */ = {
 			isa = PBXGroup;
 			children = (
-				40942C06237F6A8900A9B341 /* AttributedKeyIDs.h */,
+				40942C06237F6A8900A9B341 /* DependencyKeyIDs.h */,
 				40942C05237F6A8900A9B341 /* KeyID.h */,
 				E1E221041A0067EF00957481 /* BuildDB.h */,
 				E1A2245819F997FE0059043E /* BuildEngine.h */,

--- a/products/libllbuild/BuildSystem-C-API.cpp
+++ b/products/libllbuild/BuildSystem-C-API.cpp
@@ -1163,6 +1163,11 @@ void llb_buildsystem_command_interface_task_needs_input(llb_task_interface_t ti,
   coreti->request(((CAPIBuildKey *)key)->getInternalBuildKey().toData(), inputID);
 }
 
+void llb_buildsystem_command_interface_task_needs_single_use_input(llb_task_interface_t ti, llb_build_key_t* key, uintptr_t inputID) {
+  auto coreti = reinterpret_cast<core::TaskInterface*>(&ti);
+  coreti->requestSingleUse(((CAPIBuildKey *)key)->getInternalBuildKey().toData(), inputID);
+}
+
 llb_build_value_file_info_t llb_buildsystem_command_interface_get_file_info(llb_buildsystem_interface_t* bi_p, const char* path) {
   auto bi = (BuildSystem*)bi_p;
   return llbuild::capi::convertFileInfo(bi->getFileSystem().getFileInfo(path));

--- a/products/libllbuild/include/llbuild/buildsystem.h
+++ b/products/libllbuild/include/llbuild/buildsystem.h
@@ -781,6 +781,15 @@ llb_buildsystem_command_get_verbose_description(
 LLBUILD_EXPORT void
 llb_buildsystem_command_interface_task_needs_input(llb_task_interface_t ti, llb_build_key_t* key, uintptr_t inputID);
 
+/// Request a task as a dependency just for the current build iteration.
+/// Once the requesting task finishes, the dependency will be removed so
+/// that incremental builds won't consider it for invalidating the task.
+///
+/// NOTE: This method behaves like `llb_buildsystem_command_interface_task_needs_input`
+/// for the current build.
+LLBUILD_EXPORT void
+llb_buildsystem_command_interface_task_needs_single_use_input(llb_task_interface_t ti, llb_build_key_t* key, uintptr_t inputID);
+
 /// Marks a key as a discovered dependency for the task.
 LLBUILD_EXPORT void
 llb_buildsystem_command_interface_task_discovered_dependency(llb_task_interface_t ti, llb_build_key_t* key);

--- a/products/llbuildSwift/BuildSystemBindings.swift
+++ b/products/llbuildSwift/BuildSystemBindings.swift
@@ -89,6 +89,15 @@ public struct BuildSystemCommandInterface {
     public func commandNeedsInput(key: BuildKey, inputID: UInt) {
         llb_buildsystem_command_interface_task_needs_input(_taskInterface, key.internalBuildKey, inputID)
     }
+    
+    /// Request an input as a dependency just for the current build iteration.
+    /// Once the requesting command finishes, the dependency will be removed so that
+    /// incremental builds won't consider it for invalidation.
+    ///
+    /// NOTE: This method behaves like `request` for the current build.
+    public func commandsNeedsSingleUseInput(key: BuildKey, inputID: UInt) {
+        llb_buildsystem_command_interface_task_needs_single_use_input(_taskInterface, key.internalBuildKey, inputID)
+    }
 
     /// Marks a build key as a runtime found dependency for the command.
     public func commandDiscoveredDependency(key: BuildKey) {


### PR DESCRIPTION
A dependency marked as singleUse will only be added to the dependencies of the requesting task for the current build iteration.
This allows tasks to request other tasks for running once and not get invalidated for following incremental builds.

rdar://91494744