### PR TITLE
Add an API to notify the BuildEngine/BuildSystem delegate when it is determined that a rule needs to run

### DIFF
--- a/include/llbuild/BuildSystem/BuildSystem.h
+++ b/include/llbuild/BuildSystem/BuildSystem.h
@@ -16,6 +16,7 @@
 #include "llbuild/Basic/Compiler.h"
 #include "llbuild/Basic/LLVM.h"
 #include "llbuild/Basic/Subprocess.h"
+#include "llbuild/Core/BuildEngine.h"
 
 #include "llvm/ADT/Optional.h"
 #include "llvm/ADT/StringRef.h"
@@ -225,6 +226,15 @@ public:
   /// because multiple commands are producing it.
   virtual void cannotBuildNodeDueToMultipleProducers(Node* output,
                std::vector<Command*>) = 0;
+  
+  /// Called when it's been determined that a rule needs to run.
+  ///
+  ///  \param ruleNeedingToRun - The rule that needs to run.
+  ///
+  ///  \param reason - Describes why the rule needs to run. For example, because it has never run or because an input was rebuilt.
+  ///
+  ///  \param inputRule - If `reason` is `InputRebuilt`, the rule for the rebuilt input, else  `nullptr`.
+  virtual void determinedRuleNeedsToRun(core::Rule* ruleNeedingToRun, core::Rule::RunReason reason, core::Rule* inputRule) = 0;
 };
 
 /// The BuildSystem class is used to perform builds using the native build

--- a/include/llbuild/BuildSystem/BuildSystemFrontend.h
+++ b/include/llbuild/BuildSystem/BuildSystemFrontend.h
@@ -288,6 +288,15 @@ public:
   virtual void commandProcessFinished(Command*, ProcessHandle handle,
                                       const basic::ProcessResult& result);
 
+  /// Called when it's been determined that a rule needs to run.
+  ///
+  ///  \param ruleNeedingToRun - The rule that needs to run.
+  ///
+  ///  \param reason - Describes why the rule needs to run. For example, because it has never run or because an input was rebuilt.
+  ///
+  ///  \param inputRule - If `reason` is `InputRebuilt`, the rule for the rebuilt input, else  `nullptr`.
+  virtual void determinedRuleNeedsToRun(core::Rule* ruleNeedingToRun, core::Rule::RunReason reason, core::Rule* inputRule) override;
+
   /// Called when a cycle is detected by the build engine and it cannot make
   /// forward progress.
   ///

--- a/include/llbuild/Core/BuildEngine.h
+++ b/include/llbuild/Core/BuildEngine.h
@@ -315,6 +315,23 @@ public:
     SupplyPriorValue = 1
   };
 
+  enum class RunReason {
+    /// The rule has not built before.
+    NeverBuilt = 0,
+  
+    /// The rule's signature changed.
+    SignatureChanged = 1,
+  
+    /// The rule has an invalid value.
+    InvalidValue = 2,
+  
+    /// An input of the rule was rebuilt.
+    InputRebuilt = 3,
+  
+    /// The rule was forced, e.g. during cycle breaking.
+    Forced = 4
+  };
+
 public:
   /// The key computed by the rule.
   const KeyType key;
@@ -363,6 +380,15 @@ public:
   /// requested Key cannot be supplied, the delegate should provide a dummy rule
   /// that the client can translate into an error.
   virtual std::unique_ptr<Rule> lookupRule(const KeyType& key) = 0;
+
+  /// Called when it's been determined that a rule needs to run.
+  ///
+  ///  \param ruleNeedingToRun - The rule that needs to run.
+  ///
+  ///  \param reason - Describes why the rule needs to run. For example, because it has never run or because an input was rebuilt.
+  ///
+  ///  \param inputRule - If `reason` is `InputRebuilt`, the rule for the rebuilt input, else  `nullptr`.
+  virtual void determinedRuleNeedsToRun(Rule* ruleNeedingToRun, Rule::RunReason reason, Rule* inputRule);
 
   /// Called when a cycle is detected by the build engine to check if it should
   /// attempt to resolve the cycle and continue

--- a/lib/BuildSystem/BuildSystem.cpp
+++ b/lib/BuildSystem/BuildSystem.cpp
@@ -144,6 +144,7 @@ class BuildSystemEngineDelegate : public BuildEngineDelegate {
   const BuildDescription& getBuildDescription() const;
 
   virtual std::unique_ptr<Rule> lookupRule(const KeyType& keyData) override;
+  virtual void determinedRuleNeedsToRun(Rule* ruleNeedingToRun, Rule::RunReason reason, Rule* inputRule) override;
   virtual bool shouldResolveCycle(const std::vector<Rule*>& items,
                                   Rule* candidateRule,
                                   Rule::CycleAction action) override;
@@ -1821,6 +1822,10 @@ std::unique_ptr<Rule> BuildSystemEngineDelegate::lookupRule(const KeyType& keyDa
 
   assert(0 && "invalid key type");
   abort();
+}
+
+void BuildSystemEngineDelegate::determinedRuleNeedsToRun(Rule* ruleNeedingToRun, Rule::RunReason reason, Rule* inputRule) {
+  return getBuildSystem().getDelegate().determinedRuleNeedsToRun(ruleNeedingToRun, reason, inputRule);
 }
 
 bool BuildSystemEngineDelegate::shouldResolveCycle(const std::vector<Rule*>& cycle,

--- a/lib/BuildSystem/BuildSystemFrontend.cpp
+++ b/lib/BuildSystem/BuildSystemFrontend.cpp
@@ -741,6 +741,8 @@ void BuildSystemFrontendDelegate::commandProcessStarted(Command*,
                                                         ProcessHandle) {
 }
 
+void BuildSystemFrontendDelegate::determinedRuleNeedsToRun(core::Rule* ruleNeedingToRun, core::Rule::RunReason reason, core::Rule* inputRule) {}
+
 bool BuildSystemFrontendDelegate::
 shouldResolveCycle(const std::vector<core::Rule*>& items,
                    core::Rule* candidateRule,

--- a/lib/Core/BuildEngine.cpp
+++ b/lib/Core/BuildEngine.cpp
@@ -47,6 +47,8 @@ void Rule::updateStatus(BuildEngine&, StatusKind) {}
 
 BuildEngineDelegate::~BuildEngineDelegate() {}
 
+void BuildEngineDelegate::determinedRuleNeedsToRun(Rule* ruleNeedingToRun, Rule::RunReason, Rule* inputRule) {}
+
 bool BuildEngineDelegate::shouldResolveCycle(const std::vector<Rule*>& items,
                                              Rule* candidateRule,
                                              Rule::CycleAction action) {
@@ -460,6 +462,7 @@ private:
       if (trace)
         trace->ruleNeedsToRunBecauseNeverBuilt(ruleInfo.rule.get());
       ruleInfo.state = RuleInfo::StateKind::NeedsToRun;
+      delegate.determinedRuleNeedsToRun(ruleInfo.rule.get(), Rule::RunReason::NeverBuilt, nullptr);
       return true;
     }
 
@@ -467,6 +470,7 @@ private:
       if (trace)
         trace->ruleNeedsToRunBecauseSignatureChanged(ruleInfo.rule.get());
       ruleInfo.state = RuleInfo::StateKind::NeedsToRun;
+      delegate.determinedRuleNeedsToRun(ruleInfo.rule.get(), Rule::RunReason::SignatureChanged, nullptr);
       return true;
     }
 
@@ -479,6 +483,7 @@ private:
       if (trace)
         trace->ruleNeedsToRunBecauseInvalidValue(ruleInfo.rule.get());
       ruleInfo.state = RuleInfo::StateKind::NeedsToRun;
+      delegate.determinedRuleNeedsToRun(ruleInfo.rule.get(), Rule::RunReason::InvalidValue, nullptr);
       return true;
     }
 
@@ -658,6 +663,7 @@ private:
             trace->ruleNeedsToRunBecauseInputRebuilt(
               ruleInfo.rule.get(), inputRuleInfo.rule.get());
           finishScanRequest(ruleInfo, RuleInfo::StateKind::NeedsToRun);
+          delegate.determinedRuleNeedsToRun(ruleInfo.rule.get(), Rule::RunReason::InputRebuilt, inputRuleInfo.rule.get());
           return;
         }
       }
@@ -1242,6 +1248,7 @@ private:
 
         // mark this rule as needs to run (forced)
         finishScanRequest(ruleInfo, RuleInfo::StateKind::NeedsToRun);
+        delegate.determinedRuleNeedsToRun(ruleInfo.rule.get(), Rule::RunReason::Forced, nullptr);
         ruleInfo.wasForced = true;
 
         return true;

--- a/products/libllbuild/include/llbuild/buildsystem.h
+++ b/products/libllbuild/include/llbuild/buildsystem.h
@@ -203,6 +203,24 @@ typedef enum LLBUILD_ENUM_ATTRIBUTES {
     llb_quality_of_service_unspecified = 4
 } llb_quality_of_service_t LLBUILD_SWIFT_NAME(QualityOfService);
 
+/// Rule run reasons.
+typedef enum LLBUILD_ENUM_ATTRIBUTES {
+    /// The rule has never been built.
+    llb_rule_run_reason_never_built LLBUILD_SWIFT_NAME(neverBuilt) = 0,
+
+    /// The rule's signature has changed.
+    llb_rule_run_reason_signature_changed LLBUILD_SWIFT_NAME(signatureChanged) = 1,
+
+    /// The rule has an invalid value.
+    llb_rule_run_reason_invalid_value LLBUILD_SWIFT_NAME(invalidValue) = 2,
+
+    /// An input of the rule has been rebuilt.
+    llb_rule_run_reason_input_rebuilt LLBUILD_SWIFT_NAME(inputRebuilt) = 3,
+
+    /// The rule has never been built.
+    llb_rule_run_reason_forced LLBUILD_SWIFT_NAME(forced) = 4,
+} llb_rule_run_reason_t LLBUILD_SWIFT_NAME(RuleRunReason);
+
 /// Invocation parameters for a build system.
 typedef struct llb_buildsystem_invocation_t_ llb_buildsystem_invocation_t;
 struct llb_buildsystem_invocation_t_ {
@@ -479,6 +497,15 @@ typedef struct llb_buildsystem_delegate_t_ {
                                    llb_buildsystem_command_t* command,
                                    llb_buildsystem_process_t* process,
                                    const llb_buildsystem_command_extended_result_t* result);
+
+  /// Called when it's been determined that a rule needs to run.
+  ///
+  ///  Xparam rule_needing_to_run The rule that needs to run.
+  ///
+  ///  Xparam reason Describes why the rule needs to run. For example, because it has never run or because an input was rebuilt.
+  ///
+  ///  Xparam input_rule If `reason` is `InputRebuilt`, the rule for the rebuilt input, else  `nullptr`.
+  void (*determined_rule_needs_to_run)(void* context, llb_build_key_t* rule_needing_to_run, llb_rule_run_reason_t reason, llb_build_key_t* input_rule);
 
   /// Called when a cycle is detected by the build engine and it cannot make
   /// forward progress.

--- a/products/libllbuild/include/llbuild/llbuild-defines.h
+++ b/products/libllbuild/include/llbuild/llbuild-defines.h
@@ -85,6 +85,8 @@
 ///
 /// Version History:
 ///
+/// 15: Added `determined_rule_needs_to_run` delegate method
+///
 /// 14: Added configure API to CAPIExternalCommand
 ///
 /// 13: Update command status for custom tasks as well
@@ -114,6 +116,6 @@
 /// 1: Added `environment` parameter to llb_buildsystem_invocation_t.
 ///
 /// 0: Pre-history
-#define LLBUILD_C_API_VERSION 14
+#define LLBUILD_C_API_VERSION 15
 
 #endif

--- a/unittests/BuildSystem/MockBuildSystemDelegate.h
+++ b/unittests/BuildSystem/MockBuildSystemDelegate.h
@@ -201,6 +201,8 @@ public:
       messages.push_back(message);
     }
   }
+  
+  virtual void determinedRuleNeedsToRun(core::Rule* ruleNeedingToRun, core::Rule::RunReason reason, core::Rule* inputRule) { }
 };
 
 }


### PR DESCRIPTION
…, and why

For example, because it has never been built, or because one of its inputs was rebuilt

rdar://95208406