### PR TITLE
Run ShellCommand dependency parsing at high priority

### DIFF
--- a/lib/BuildSystem/BuildSystem.cpp
+++ b/lib/BuildSystem/BuildSystem.cpp
@@ -2169,8 +2169,6 @@ public:
 
       // Otherwise, collect the discovered dependencies, if used.
       if (!depsPath.empty()) {
-        // FIXME: Really want this job to go into a high priority fifo queue
-        // so as to not hold up downstream tasks.
         ti.spawn({ this, [this, ti, completionFn, result](QueueJobContext* context) mutable {
           if (!processDiscoveredDependencies(ti, context)) {
             // If we were unable to process the dependencies output, report a
@@ -2181,7 +2179,7 @@ public:
           }
           if (completionFn.hasValue())
             completionFn.getValue()(result);
-        }});
+        }}, QueueJobPriority::High);
         return;
       }
 

--- a/lib/BuildSystem/ShellCommand.cpp
+++ b/lib/BuildSystem/ShellCommand.cpp
@@ -346,8 +346,6 @@ void ShellCommand::executeExternalCommand(
 
     // Collect the discovered dependencies, if used.
     if (!depsPaths.empty()) {
-      // FIXME: Really want this job to go into a high priority fifo queue
-      // so as to not hold up downstream tasks.
       ti.spawn(QueueJob{ this, [this, &system, ti, completionFn, result](QueueJobContext* context) mutable {
             if (!processDiscoveredDependencies(system, ti, context)) {
               // If we were unable to process the dependencies output, report a
@@ -358,7 +356,7 @@ void ShellCommand::executeExternalCommand(
             }
             if (completionFn.hasValue())
               completionFn.getValue()(result);
-          }});
+          }}, QueueJobPriority::High);
       return;
     }
 


### PR DESCRIPTION
This ensures dependency file parsing runs as soon as possible after a task finishes, in FIFO order when using the LaneBasedExecutionQueue. Previously, it could run significantly later when many tasks were enqueued, delaying "task finished" callbacks despite the fact that very little work remained to be done.

rdar://96151636