### PR TITLE
Remove deprecated protocol requirements from Tool

### DIFF
--- a/products/llbuildSwift/BuildSystemBindings.swift
+++ b/products/llbuildSwift/BuildSystemBindings.swift
@@ -145,9 +145,6 @@ public struct JobContext {
 }
 
 public protocol Tool: AnyObject {
-    @available(*, deprecated, message: "Use the overload that returns an Optional")
-    func createCommand(_ name: String) -> ExternalCommand
-
     /// Called to create a specific command instance of this tool.
     func createCommand(_ name: String) -> ExternalCommand?
 
@@ -156,11 +153,6 @@ public protocol Tool: AnyObject {
 }
 
 public extension Tool {
-    @available(*, deprecated, message: "Use the overload that returns an Optional")
-    func createCommand(_ name: String) -> ExternalCommand? {
-        return createCommand(name) as ExternalCommand
-    }
-
     // Default implementation to allow clients to avoid declaring this method if not required.
     func createCustomCommand(_ buildKey: BuildKey.CustomTask) -> ExternalCommand? {
         return nil

--- a/unittests/Swift/BuildSystemEngineTests.swift
+++ b/unittests/Swift/BuildSystemEngineTests.swift
@@ -102,11 +102,6 @@ final class TestTool: Tool {
         self.expectedCommands = expectedCommands
     }
 
-    @available(*, deprecated, message: "Use the overload that returns an Optional")
-    func createCommand(_ name: String) -> ExternalCommand {
-        return (createCommand(name) as ExternalCommand?)!
-    }
-
     func createCommand(_ name: String) -> ExternalCommand? {
         guard let command = expectedCommands[name] else {
             XCTFail("Command \(name) not expected.")


### PR DESCRIPTION
We don't need these anymore.

rdar://99288001