### PR TITLE
rdar://99877341 (Check contents instead of modTime to determine if rule needs rerun)

### DIFF
--- a/include/llbuild/Basic/FileInfo.h
+++ b/include/llbuild/Basic/FileInfo.h
@@ -30,6 +30,12 @@
 #include <cstdint>
 #include <string>
 
+#ifdef __APPLE__
+#include <CommonCrypto/CommonDigest.h>
+#else
+#include "llvm/Support/MD5.h"
+#endif
+
 namespace llbuild {
 namespace basic {
 
@@ -60,6 +66,20 @@ struct FileTimestamp {
   }
 };
 
+struct FileChecksum {
+  uint8_t bytes[32] = {0};
+
+  bool operator==(const FileChecksum& rhs) const {
+    return (memcmp(bytes, rhs.bytes, sizeof(bytes)) == 0);
+  }
+
+  bool operator!=(const FileChecksum& rhs) const {
+    return !(*this==rhs);
+  }
+
+  static FileChecksum getChecksumForPath(const std::string& path);
+};
+
 /// File information which is intended to be used as a proxy for when a file has
 /// changed.
 ///
@@ -75,6 +95,8 @@ struct FileInfo {
   uint64_t size;
   /// The modification time of the file.
   FileTimestamp modTime;
+  /// The checksum of the file.
+  FileChecksum checksum = {};
 
   /// Check if this is a FileInfo representing a missing file.
   bool isMissing() const {
@@ -86,13 +108,15 @@ struct FileInfo {
 
   /// Check if the FileInfo corresponds to a directory.
   bool isDirectory() const;
-  
+
   bool operator==(const FileInfo& rhs) const {
     return (device == rhs.device &&
             inode == rhs.inode &&
             size == rhs.size &&
-            modTime == rhs.modTime);
+            modTime == rhs.modTime &&
+            checksum == rhs.checksum);
   }
+
   bool operator!=(const FileInfo& rhs) const {
     return !(*this == rhs);
   }
@@ -121,6 +145,20 @@ struct BinaryCodingTraits<FileTimestamp> {
 };
 
 template<>
+struct BinaryCodingTraits<FileChecksum> {
+  static inline void encode(const FileChecksum& value, BinaryEncoder& coder) {
+    for(int i=0; i<32; i++) {
+      coder.write(value.bytes[i]);
+    }
+  }
+  static inline void decode(FileChecksum& value, BinaryDecoder& coder) {
+    for(int i=0; i<32; i++) {
+      coder.read(value.bytes[i]);
+    }
+  }
+};
+
+template<>
 struct BinaryCodingTraits<FileInfo> {
   static inline void encode(const FileInfo& value, BinaryEncoder& coder) {
     coder.write(value.device);
@@ -128,6 +166,7 @@ struct BinaryCodingTraits<FileInfo> {
     coder.write(value.mode);
     coder.write(value.size);
     coder.write(value.modTime);
+    coder.write(value.checksum);
   }
   static inline void decode(FileInfo& value, BinaryDecoder& coder) {
     coder.read(value.device);
@@ -135,8 +174,105 @@ struct BinaryCodingTraits<FileInfo> {
     coder.read(value.mode);
     coder.read(value.size);
     coder.read(value.modTime);
+    coder.read(value.checksum);
   }
 };
+
+class FileChecksumHasher {
+public:
+  FileChecksumHasher(const std::string& path): path(path) { }
+
+  virtual void copy(uint8_t *outputBuffer) = 0;
+
+  bool readAndDigest() {
+    this->file = std::fopen(path.c_str(), "rb");
+
+    uint8_t buffer[4*4096];
+    size_t bytesRead = 0;
+
+    if (file != NULL) {
+      while ((bytesRead = fread(buffer, 1, sizeof(buffer), file)) > 0) {
+        update(buffer, bytesRead);
+      }
+      fclose(file);
+      finalize();
+      return true;
+    } else {
+      return false;
+    }
+  }
+
+  virtual void readPathStringAndDigest(FileChecksum& result) {
+    update(reinterpret_cast<const uint8_t*>(&path[0]), path.size());
+    finalize();
+    copy(result.bytes);
+  }
+
+  virtual void finalize() = 0;
+
+  virtual void update(const uint8_t *buffer, size_t bytesRead) = 0;
+
+  virtual ~FileChecksumHasher() = default;
+
+private:
+  FILE *file = NULL;
+  const std::string& path;
+};
+
+#ifndef __APPLE__
+class FileChecksumHasherMD5: public FileChecksumHasher {
+public:
+  FileChecksumHasherMD5(const std::string& path): FileChecksumHasher(path) {
+  }
+
+  void copy(uint8_t *outputBuffer) override {
+    std::copy(output.Bytes.begin(), output.Bytes.end(), outputBuffer);
+  }
+
+  void finalize() override {
+    llvm::MD5::MD5Result output;
+    hasher.final(output);
+  }
+
+  void update(const uint8_t *buffer, size_t bytesRead) override {
+    const char* buffer2 = (char*) buffer;
+    hasher.update(StringRef(buffer2, bytesRead));
+  }
+
+private:
+  llvm::MD5 hasher;
+  llvm::MD5::MD5Result output;
+};
+
+typedef FileChecksumHasherMD5 PlatformSpecificHasher;
+
+#else
+
+class FileChecksumHasherSHA256: public FileChecksumHasher {
+public:
+  FileChecksumHasherSHA256(const std::string& path): FileChecksumHasher(path) {
+    CC_SHA256_Init(&ctx);
+  }
+
+  void copy(uint8_t *outputBuffer) override {
+    std::copy(temp_digest, temp_digest+CC_SHA256_DIGEST_LENGTH, outputBuffer);
+  }
+
+  void finalize() override {
+    CC_SHA256_Final(temp_digest, &ctx);
+  }
+
+  void update(const uint8_t *buffer, size_t bytesRead) override {
+    CC_SHA256_Update(&ctx, buffer, bytesRead);
+  }
+
+private:
+  CC_SHA256_CTX ctx = {};
+  unsigned char temp_digest[CC_SHA256_DIGEST_LENGTH] = { 42 };
+};
+
+typedef FileChecksumHasherSHA256 PlatformSpecificHasher;
+#endif
 
 }
 }

--- a/lib/Basic/FileSystem.cpp
+++ b/lib/Basic/FileSystem.cpp
@@ -137,6 +137,11 @@ std::unique_ptr<llvm::MemoryBuffer>
 DeviceAgnosticFileSystem::getFileContents(const std::string& path) {
   return impl->getFileContents(path);
 }
+
+std::unique_ptr<llvm::MemoryBuffer>
+ChecksumOnlyFileSystem::getFileContents(const std::string& path) {
+  return impl->getFileContents(path);
+}
 namespace {
 
 class LocalFileSystem : public FileSystem {
@@ -210,7 +215,11 @@ public:
 
     return false;
   }
-  
+
+  virtual FileChecksum getFileChecksum(const std::string& path) override {
+    return FileChecksum::getChecksumForPath(path);
+  }
+
   virtual FileInfo getFileInfo(const std::string& path) override {
     return FileInfo::getInfoForPath(path);
   }
@@ -234,4 +243,9 @@ std::unique_ptr<FileSystem> basic::createLocalFileSystem() {
 std::unique_ptr<FileSystem>
 basic::DeviceAgnosticFileSystem::from(std::unique_ptr<FileSystem> fs) {
   return llvm::make_unique<DeviceAgnosticFileSystem>(std::move(fs));
+}
+
+std::unique_ptr<FileSystem>
+basic::ChecksumOnlyFileSystem::from(std::unique_ptr<FileSystem> fs) {
+  return llvm::make_unique<ChecksumOnlyFileSystem>(std::move(fs));
 }

--- a/lib/Commands/NinjaBuildCommand.cpp
+++ b/lib/Commands/NinjaBuildCommand.cpp
@@ -188,7 +188,7 @@ private:
   union {
     /// The file info for the rule output, for existing inputs and successful
     /// commands with a single output.
-    FileInfo asOutputInfo;
+    FileInfo asOutputInfo { };
 
     /// The file info for successful commands with multiple outputs.
     FileInfo* asOutputInfos;

--- a/lib/Core/SQLiteBuildDB.cpp
+++ b/lib/Core/SQLiteBuildDB.cpp
@@ -66,6 +66,7 @@ namespace {
 
 class SQLiteBuildDB : public BuildDB {
   /// Version History:
+  /// * 16: Add checksum field to FileInfo.
   /// * 15: Add barriers in dependency list.
   /// * 14: Filtered directory tree structure nodes, related build key changes
   /// * 13: Tagging dependencies with single-use flag.
@@ -78,7 +79,7 @@ class SQLiteBuildDB : public BuildDB {
   /// * 6: Added `ordinal` field for dependencies.
   /// * 5: Switched to using `WITHOUT ROWID` for dependencies.
   /// * 4: Pre-history
-  static const int currentSchemaVersion = 15;
+  static const int currentSchemaVersion = 16;
 
   std::string path;
   uint32_t clientSchemaVersion;

--- a/products/libllbuild/BuildSystem-C-API.cpp
+++ b/products/libllbuild/BuildSystem-C-API.cpp
@@ -101,6 +101,10 @@ public:
     return cAPIDelegate.fs_remove(cAPIDelegate.context, path.c_str());
   }
 
+  virtual basic::FileChecksum getFileChecksum(const std::string& path) override {
+    return localFileSystem->getFileChecksum(path);
+  }
+
   virtual basic::FileInfo getFileInfo(const std::string& path) override {
     if (!cAPIDelegate.fs_get_file_info) {
       return localFileSystem->getFileInfo(path);

--- a/tests/BuildSystem/Build/file-system-checksum-only-symlinks.llbuild
+++ b/tests/BuildSystem/Build/file-system-checksum-only-symlinks.llbuild
@@ -1,0 +1,74 @@
+# Check basic building functionality with the checksum-only file system when symlinks are involved
+# Note: result of scanning a checksum node will still be valid even
+# if the content of the path that it links to changes.
+#
+# RUN: rm -rf %t.build
+# RUN: mkdir -p %t.build
+# RUN: echo magic1 string > "%t.build/raw1.txt"
+# RUN: echo magic2 string > "%t.build/raw2.txt"
+# RUN: ln -s "%t.build/raw1.txt" "%t.build/raw.txt"
+# RUN: cat %s > "%t.build/build.llbuild"
+# RUN: %{llbuild} buildsystem build --serial --chdir %t.build --trace %t.trace > %t.out
+# RUN: %{FileCheck} --input-file=%t.out %s
+#
+# CHECK: Create magic.txt from raw.txt
+# CHECK: Extract first word
+# CHECK: Capitalize first word
+# CHECK: MAGIC1
+
+# Check the engine trace.
+#
+# RUN: %{FileCheck} --input-file=%t.trace %s --check-prefix CHECK-TRACE
+#
+# CHECK-TRACE: "build-started"
+# CHECK-TRACE: "new-rule", "R1", "Tbasic"
+# CHECK-TRACE: "new-rule", "R2", "Nfinal.txt"
+# CHECK-TRACE: "new-rule", "R3", "Ccapitalize-first-word"
+# CHECK-TRACE: "new-rule", "R4", "Nfirst-word.txt"
+# CHECK-TRACE: "new-rule", "R5", "Cextract-first-word"
+# CHECK-TRACE: "new-rule", "R6", "Nmagic.txt"
+# CHECK-TRACE: "new-rule", "R7", "Cread-magic-file"
+# CHECK-TRACE: "new-rule", "R8", "Nraw.txt"
+# CHECK-TRACE: "build-ended"
+
+# Check that a null build does nothing.
+#
+# RUN: %{llbuild} buildsystem build --serial --chdir %t.build --trace %t.trace > %t2.out
+# RUN: echo "PREVENT-EMPTY-FILE" >> %t2.out
+# RUN: %{FileCheck} --input-file=%t2.out %s --check-prefix=CHECK-REBUILD
+#
+# CHECK-REBUILD-NOT: Create magic.txt from raw.txt
+# CHECK-REBUILD-NOT: Extract first word
+# CHECK-REBUILD-NOT: Capitalize first word
+
+client:
+  name: basic
+  file-system: checksum-only
+
+targets:
+  basic: ["final.txt"]
+
+# define the default target to execute when this manifest is loaded.
+default: basic
+
+commands:
+  read-magic-file:
+    tool: shell
+    inputs: ["raw.txt"]
+    outputs: ["magic.txt"]
+    description: "Create magic.txt from raw.txt"
+    args: "cat raw.txt > magic.txt"
+
+  extract-first-word:
+    tool: shell
+    inputs: ["magic.txt"]
+    outputs: ["first-word.txt"]
+    description: "Extract first word"
+    args: "cat magic.txt | awk '{print $1;}' > first-word.txt"
+
+  capitalize-first-word:
+    tool: shell
+    inputs: ["first-word.txt"]
+    outputs: ["final.txt"]
+    description: "Capitalize first word"
+    args: "cat first-word.txt | tr a-z A-Z > final.txt; cat final.txt"

--- a/tests/BuildSystem/Build/file-system-checksum-only.llbuild
+++ b/tests/BuildSystem/Build/file-system-checksum-only.llbuild
@@ -1,0 +1,91 @@
+# Check basic building functionality with the checksum-only file system.
+#
+# RUN: rm -rf %t.build
+# RUN: mkdir -p %t.build
+# RUN: echo magic string > "%t.build/raw.txt"
+# RUN: cat %s > "%t.build/build.llbuild"
+# RUN: %{llbuild} buildsystem build --serial --chdir %t.build --trace %t.trace > %t.out
+# RUN: %{FileCheck} --input-file=%t.out %s
+#
+# CHECK: Create magic.txt from raw.txt
+# CHECK: Extract first word
+# CHECK: Capitalize first word
+# CHECK: MAGIC
+
+# Check the engine trace.
+#
+# RUN: %{FileCheck} --input-file=%t.trace %s --check-prefix CHECK-TRACE
+#
+# CHECK-TRACE: "build-started"
+# CHECK-TRACE: "new-rule", "R1", "Tbasic"
+# CHECK-TRACE: "new-rule", "R2", "Nfinal.txt"
+# CHECK-TRACE: "new-rule", "R3", "Ccapitalize-first-word"
+# CHECK-TRACE: "new-rule", "R4", "Nfirst-word.txt"
+# CHECK-TRACE: "new-rule", "R5", "Cextract-first-word"
+# CHECK-TRACE: "new-rule", "R6", "Nmagic.txt"
+# CHECK-TRACE: "new-rule", "R7", "Cread-magic-file"
+# CHECK-TRACE: "new-rule", "R8", "Nraw.txt"
+# CHECK-TRACE: "build-ended"
+
+# Check that a null build does nothing.
+#
+# RUN: %{llbuild} buildsystem build --serial --chdir %t.build --trace %t.trace > %t2.out
+# RUN: echo "PREVENT-EMPTY-FILE" >> %t2.out
+# RUN: %{FileCheck} --input-file=%t2.out %s --check-prefix=CHECK-REBUILD
+#
+# CHECK-REBUILD-NOT: Create magic.txt from raw.txt
+# CHECK-REBUILD-NOT: Extract first word
+# CHECK-REBUILD-NOT: Capitalize first word
+
+# Check that "Capitalize first word" is not executed when string is modified but the first word is unchanged.
+#
+# RUN: echo magic updated string > "%t.build/raw.txt"
+# RUN: %{llbuild} buildsystem build --serial --chdir %t.build > %t3.out
+# RUN: %{FileCheck} --input-file=%t3.out %s --check-prefix=CHECK-REBUILD-MODIFIED
+#
+# CHECK-REBUILD-MODIFIED: Create magic.txt from raw.txt
+# CHECK-REBUILD-MODIFIED: Extract first word
+# CHECK-REBUILD-MODIFIED-NOT: Capitalize first word
+
+# Check that "Capitalize first word" is executed when the first word is changed.
+#
+# RUN: echo supermagic string > "%t.build/raw.txt"
+# RUN: %{llbuild} buildsystem build --serial --chdir %t.build > %t4.out
+# RUN: %{FileCheck} --input-file=%t4.out %s --check-prefix=CHECK-REBUILD-MODIFIED-MODIFIED
+#
+# CHECK-REBUILD-MODIFIED-MODIFIED: Create magic.txt from raw.txt
+# CHECK-REBUILD-MODIFIED-MODIFIED: Extract first word
+# CHECK-REBUILD-MODIFIED-MODIFIED: Capitalize first word
+# CHECK-REBUILD-MODIFIED-MODIFIED: SUPERMAGIC
+
+client:
+  name: basic
+  file-system: checksum-only
+
+targets:
+  basic: ["final.txt"]
+
+# define the default target to execute when this manifest is loaded.
+default: basic
+
+commands:
+  read-magic-file:
+    tool: shell
+    inputs: ["raw.txt"]
+    outputs: ["magic.txt"]
+    description: "Create magic.txt from raw.txt"
+    args: "cat raw.txt > magic.txt"
+
+  extract-first-word:
+    tool: shell
+    inputs: ["magic.txt"]
+    outputs: ["first-word.txt"]
+    description: "Extract first word"
+    args: "cat magic.txt | awk '{print $1;}' > first-word.txt"
+
+  capitalize-first-word:
+    tool: shell
+    inputs: ["first-word.txt"]
+    outputs: ["final.txt"]
+    description: "Capitalize first word"
+    args: "cat first-word.txt | tr a-z A-Z > final.txt; cat final.txt"

--- a/unittests/Basic/FileSystemTest.cpp
+++ b/unittests/Basic/FileSystemTest.cpp
@@ -183,7 +183,41 @@ TEST(DeviceAgnosticFileSystemTest, basic) {
 
   auto ourFileContents = fs->getFileContents(tempPath.str());
   EXPECT_EQ(ourFileContents->getBuffer().str(), "Hello, world!");
-  // Remote the temporary file.
+  // Remove the temporary file.
+  auto ec = llvm::sys::fs::remove(tempPath.str());
+  EXPECT_FALSE(ec);
+}
+
+TEST(ChecksumOnlyFileSystem, basic) {
+  // Check basic sanity of the local filesystem object.
+  auto fs = ChecksumOnlyFileSystem::from(createLocalFileSystem());
+
+  // Write a temp file.
+  SmallString<256> tempPath;
+  llvm::sys::fs::createTemporaryFile("FileSystemTests", "txt", tempPath);
+  {
+    std::error_code ec;
+    llvm::raw_fd_ostream os(tempPath.str(), ec, llvm::sys::fs::F_Text);
+    EXPECT_FALSE(ec);
+    os << "Hello, world!";
+    os.close();
+  }
+
+  auto missingFileInfo = fs->getFileInfo("/does/not/exists");
+  EXPECT_TRUE(missingFileInfo.isMissing());
+
+  auto ourFileInfo = fs->getFileInfo(tempPath.str());
+  EXPECT_FALSE(ourFileInfo.isMissing());
+
+  EXPECT_EQ(ourFileInfo.device, 0ull);
+  EXPECT_EQ(ourFileInfo.inode, 0ull);
+
+  auto missingFileContents = fs->getFileContents("/does/not/exist");
+  EXPECT_EQ(missingFileContents.get(), nullptr);
+
+  auto ourFileContents = fs->getFileContents(tempPath.str());
+  EXPECT_EQ(ourFileContents->getBuffer().str(), "Hello, world!");
+  // Remove the temporary file.
   auto ec = llvm::sys::fs::remove(tempPath.str());
   EXPECT_FALSE(ec);
 }

--- a/unittests/BuildSystem/BuildSystemTaskTests.cpp
+++ b/unittests/BuildSystem/BuildSystemTaskTests.cpp
@@ -87,6 +87,16 @@ public:
     return realFS->getLinkInfo(path);
   }
 
+  virtual FileChecksum getFileChecksum(const std::string& path) override {
+    FileInfo info = realFS->getFileInfo(path);
+    if (info.isMissing()) {
+      std::unique_lock<std::mutex> lock(missingPathsMutex);
+      missingPaths.push_back(path);
+    }
+    FileChecksum checksum = realFS->getFileChecksum(path);
+    return checksum;
+  }
+
   virtual bool createSymlink(const std::string& src, const std::string& target) override {
     return realFS->createSymlink(src, target);
   }
@@ -111,6 +121,10 @@ public:
 
   virtual bool remove(const std::string& path) override {
     return realFS.remove(path);
+  }
+
+  virtual FileChecksum getFileChecksum(const std::string& path) override {
+    return realFS.getFileChecksum(path);
   }
 
   virtual FileInfo getFileInfo(const std::string& path) override {


### PR DESCRIPTION
This PR lands an opt-in support for content checksum comparison in FileInfo.

Normally a rule is marked for `NeedsToRun` if the timestamp of its input is different from the result from previous build.

In contrast to how llbuild currently works, using `ChecksumOnlyFileSystem` should cause llbuild to not mark a rule as `NeedsToRun` when modification time of input is different but checksum of the contents of the path that FileInfo is referring to matches the checksum from previous build.