### PR TITLE
rdar://104245531 (ProducedDirectory outputs in llbuild and opt-in ownership analysis)

### DIFF
--- a/include/llbuild/BuildSystem/BuildFile.h
+++ b/include/llbuild/BuildSystem/BuildFile.h
@@ -13,6 +13,7 @@
 #ifndef LLBUILD_BUILDSYSTEM_BUILDFILE_H
 #define LLBUILD_BUILDSYSTEM_BUILDFILE_H
 
+#include "llbuild/BuildSystem/BuildSystem.h"
 #include "llbuild/Basic/Compiler.h"
 #include "llbuild/Basic/LLVM.h"
 
@@ -95,7 +96,12 @@ public:
   virtual void error(StringRef filename,
                      const BuildFileToken& at,
                      const Twine& message) = 0;
-  
+
+  /// Called by the build file loader when ownership analysis determines
+  /// multiple producers exist for node.
+  virtual void cannotLoadDueToMultipleProducers(Node *output,
+                                                std::vector<Command*> commands) = 0;
+
   /// Called by the build file loader after the 'client' file section has been
   /// loaded.
   ///
@@ -150,7 +156,7 @@ public:
                      BuildFileDelegate& delegate);
   ~BuildFile();
 
-  /// Return the delegate the engine was configured with.
+  /// Return the file delegate the engine was configured with.
   BuildFileDelegate* getDelegate();
 
   /// Load the build file from the provided filename.

--- a/include/llbuild/BuildSystem/BuildNode.h
+++ b/include/llbuild/BuildSystem/BuildNode.h
@@ -84,6 +84,12 @@ public:
     return exclusionPatterns;
   }
 
+  std::vector<StringRef> mustScanAfterPaths;
+
+  const std::vector<StringRef>& getMustScanAfterPaths() const {
+    return mustScanAfterPaths;
+  }
+
   virtual bool configureAttribute(const ConfigureContext& ctx, StringRef name,
                                   StringRef value) override;
   virtual bool configureAttribute(const ConfigureContext& ctx, StringRef name,

--- a/include/llbuild/BuildSystem/Command.h
+++ b/include/llbuild/BuildSystem/Command.h
@@ -147,6 +147,8 @@ public:
                             uintptr_t inputID, const BuildValue& value) = 0;
 
 
+  virtual bool isExternalCommand() const { return false; }
+
   typedef std::function<void (BuildValue&&)> ResultFn;
 
   /// Execute the command, and return the value.

--- a/include/llbuild/BuildSystem/Command.h
+++ b/include/llbuild/BuildSystem/Command.h
@@ -10,6 +10,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "llbuild/BuildSystem/BuildNode.h"
+
 #ifndef LLBUILD_BUILDSYSTEM_COMMAND_H
 #define LLBUILD_BUILDSYSTEM_COMMAND_H
 
@@ -47,10 +49,13 @@ class Command : public basic::JobDescriptor {
   Command &operator=(Command&& rhs) LLBUILD_DELETED_FUNCTION;
     
   std::string name;
-
 public:
   explicit Command(StringRef name) : name(name) {}
   virtual ~Command();
+
+  std::vector<BuildNode*> inputs;
+  std::vector<BuildNode*> outputs;
+  bool excludeFromOwnershipAnalysis = false;
 
   StringRef getName() const { return name; }
 
@@ -148,6 +153,19 @@ public:
 
 
   virtual bool isExternalCommand() const { return false; }
+
+  virtual void addOutput(BuildNode* node) final {
+    outputs.push_back(node);
+    node->getProducers().push_back(this);
+  }
+
+  virtual const std::vector<BuildNode*>& getInputs() const final {
+    return inputs;
+  }
+  
+  virtual const std::vector<BuildNode*>& getOutputs() const final {
+    return outputs;
+  }
 
   typedef std::function<void (BuildValue&&)> ResultFn;
 

--- a/include/llbuild/BuildSystem/ExternalCommand.h
+++ b/include/llbuild/BuildSystem/ExternalCommand.h
@@ -44,8 +44,6 @@ class ExternalCommandHandler;
 /// build system and interact using files. It defines common base behaviors
 /// which make sense for all such tools.
 class ExternalCommand : public Command {
-  std::vector<BuildNode*> inputs;
-  std::vector<BuildNode*> outputs;
   std::string description;
 
   /// Whether to allow missing inputs.
@@ -111,10 +109,6 @@ public:
 
   bool isExternalCommand() const override { return true; }
 
-  const std::vector<BuildNode*>& getInputs() const { return inputs; }
-  
-  const std::vector<BuildNode*>& getOutputs() const { return outputs; }
-
   virtual void configureDescription(const ConfigureContext&,
                                     StringRef value) override;
   
@@ -123,8 +117,6 @@ public:
 
   virtual void configureOutputs(const ConfigureContext&,
                                 const std::vector<Node*>& value) override;
-
-  virtual void addOutput(BuildNode* output);
 
   virtual bool configureAttribute(const ConfigureContext& ctx, StringRef name,
                                   StringRef value) override;

--- a/include/llbuild/BuildSystem/ExternalCommand.h
+++ b/include/llbuild/BuildSystem/ExternalCommand.h
@@ -81,10 +81,6 @@ class ExternalCommand : public Command {
   bool canUpdateIfNewerWithResult(const BuildValue& result);
 
 protected:
-  const std::vector<BuildNode*>& getInputs() const { return inputs; }
-  
-  const std::vector<BuildNode*>& getOutputs() const { return outputs; }
-  
   StringRef getDescription() const { return description; }
 
   /// This function must be overriden by subclasses for any additional keys.
@@ -113,6 +109,12 @@ protected:
 public:
   using Command::Command;
 
+  bool isExternalCommand() const override { return true; }
+
+  const std::vector<BuildNode*>& getInputs() const { return inputs; }
+  
+  const std::vector<BuildNode*>& getOutputs() const { return outputs; }
+
   virtual void configureDescription(const ConfigureContext&,
                                     StringRef value) override;
   
@@ -121,6 +123,8 @@ public:
 
   virtual void configureOutputs(const ConfigureContext&,
                                 const std::vector<Node*>& value) override;
+
+  virtual void addOutput(BuildNode* output);
 
   virtual bool configureAttribute(const ConfigureContext& ctx, StringRef name,
                                   StringRef value) override;

--- a/lib/BuildSystem/BuildNode.cpp
+++ b/lib/BuildSystem/BuildNode.cpp
@@ -104,6 +104,9 @@ bool BuildNode::configureAttribute(const ConfigureContext& ctx, StringRef name,
   } else if (name == "content-exclusion-patterns") {
     exclusionPatterns = basic::StringList(value);
     return true;
+  } else if (name == "must-scan-after-paths") {
+    mustScanAfterPaths = basic::StringList(value).getValues();
+    return true;
   }
     
   // We don't support any other custom attributes.
@@ -115,6 +118,9 @@ bool BuildNode::configureAttribute(const ConfigureContext& ctx, StringRef name,
                                    ArrayRef<StringRef> values) {
   if (name == "content-exclusion-patterns") {
     exclusionPatterns = basic::StringList(values);
+    return true;
+  } else if (name == "must-scan-after-paths") {
+    mustScanAfterPaths = basic::StringList(values).getValues();
     return true;
   }
 
@@ -133,7 +139,15 @@ bool BuildNode::configureAttribute(
 
 FileInfo BuildNode::getFileInfo(basic::FileSystem& fileSystem) const {
   assert(!isVirtual());
-  return fileSystem.getFileInfo(getName());
+
+  // Drop the trailing slash
+  // otherwise non-directory paths that end with "/" will be reported as missing
+  StringRef path = getName();
+  if (path.endswith("/") && path != "/") {
+    path = path.substr(0, path.size() - 1);
+  }
+
+  return fileSystem.getFileInfo(path);
 }
 
 FileInfo BuildNode::getLinkInfo(basic::FileSystem& fileSystem) const {

--- a/lib/BuildSystem/BuildSystem.cpp
+++ b/lib/BuildSystem/BuildSystem.cpp
@@ -108,6 +108,9 @@ public:
                      const BuildFileToken& at,
                      const Twine& message) override;
 
+  virtual void cannotLoadDueToMultipleProducers(Node *output,
+                                                std::vector<Command*> commands) override;
+
   virtual bool configureClient(const ConfigureContext&, StringRef name,
                                uint32_t version,
                                const property_list_type& properties) override;
@@ -573,7 +576,10 @@ class DirectoryInputNodeTask : public Task {
 
   core::ValueType directorySignature;
 
-  virtual void start(TaskInterface ti) override {
+  int totalBlockingDeps = 0;
+  int finishedBlockingDeps = 0;
+
+  void performUnblockedRequest(TaskInterface ti) {
     // Remove any trailing slash from the node name.
     StringRef path =  node.getName();
     if (path.endswith("/") && path != "/") {
@@ -585,13 +591,38 @@ class DirectoryInputNodeTask : public Task {
                /*inputID=*/0);
   }
 
+  virtual void start(TaskInterface ti) override {
+    // We reserve inputID=0 for the blocked DirectoryTreeSignature request.
+    // inputID=1, 2, ... are used for mustScanAfterPaths
+    for (auto mustScanAfterPath: node.getMustScanAfterPaths()) {
+      ++totalBlockingDeps;
+      ti.request(BuildKey::makeNode(mustScanAfterPath).toData(), totalBlockingDeps);
+    }
+
+    // If mustScanAfterPaths is empty, simply request DirectoryTreeSignature in start
+    if (totalBlockingDeps == 0) {
+      performUnblockedRequest(ti);
+    }
+  }
+
   virtual void providePriorValue(TaskInterface,
                                  const ValueType& value) override {
   }
 
-  virtual void provideValue(TaskInterface, uintptr_t inputID,
-                            const ValueType& value) override {
-    directorySignature = value;
+  virtual void provideValue(TaskInterface ti, uintptr_t inputID,
+                            const ValueType& valueData) override {
+    if (inputID == 0) {
+      directorySignature = valueData;
+    } else {
+      auto value = BuildValue::fromData(valueData);
+
+      ++finishedBlockingDeps;
+      if (finishedBlockingDeps == totalBlockingDeps) {
+        // All paths within mustScanAfterPaths are scanned..
+        // DirectoryTreeSignature is unblocked
+        performUnblockedRequest(ti);
+      }
+    }
   }
 
   virtual void inputsAvailable(TaskInterface ti) override {
@@ -764,6 +795,110 @@ public:
       return false;
 
     // The produced node result itself doesn't need any synchronization.
+    return true;
+  }
+};
+
+class ProducedDirectoryNodeTask : public Task {
+  Node& node;
+
+  BuildValue nodeResult;
+  core::ValueType directorySignature;
+
+  Command* producingCommand = nullptr;
+
+  // Whether this is a node we are unable to produce.
+  bool isInvalid = false;
+
+  virtual void start(TaskInterface ti) override {
+    // Request the producer command.
+    auto getCommand = [&]()->Command* {
+      if (node.getProducers().size() == 1) {
+        return node.getProducers()[0];
+      }
+      // Give the delegate a chance to resolve to a single command.
+      return getBuildSystem(ti).getDelegate().
+          chooseCommandFromMultipleProducers(&node, node.getProducers());
+    };
+
+    if (Command* foundCommand = getCommand()) {
+      producingCommand = foundCommand;
+      ti.request(BuildKey::makeCommand(producingCommand->getName()).toData(),
+                 /*InputID=*/0);
+      return;
+    }
+
+    // Notify that we could not resolve to a single producer.
+    getBuildSystem(ti).getDelegate().
+        cannotBuildNodeDueToMultipleProducers(&node, node.getProducers());
+    isInvalid = true;
+  }
+
+  virtual void providePriorValue(TaskInterface,
+                                 const ValueType& value) override {
+  }
+
+  virtual void provideValue(TaskInterface ti, uintptr_t inputID,
+                            const ValueType& valueData) override {
+    if (inputID == 0) {
+      auto value = BuildValue::fromData(valueData);
+
+      // Extract the node result from the command.
+      assert(producingCommand);
+
+      // NOTE: nodeResult only contains stat info of the directory, not its signature.
+      nodeResult = producingCommand->getResultForOutput(&node, value);
+
+      if (nodeResult.isExistingInput()) {
+        // The external command must have produced the directory node.
+        // Request for its signature and store it
+
+        StringRef path =  node.getName();
+        if (path.endswith("/") && path != "/") {
+          path = path.substr(0, path.size() - 1);
+        }
+        ti.request(BuildKey::makeDirectoryTreeSignature(path,basic::StringList()).toData(), /*inputID=*/1);
+      } else {
+        // ExternalCommand failed..
+        isInvalid = true;
+      }
+    } else if (inputID == 1) {
+      directorySignature = valueData;
+    }
+  }
+
+  virtual void inputsAvailable(TaskInterface ti) override {
+    if (isInvalid) {
+      getBuildSystem(ti).getDelegate().hadCommandFailure();
+      ti.complete(BuildValue::makeFailedInput().toData());
+      return;
+    }
+
+    assert(!nodeResult.isInvalid());
+
+    // Complete the task immediately.
+    ti.complete(ValueType(directorySignature));
+  }
+
+public:
+  ProducedDirectoryNodeTask(Node& node)
+      : node(node), nodeResult(BuildValue::makeInvalid()) {}
+
+  static bool isResultValid(BuildEngine& engine, Node& node,
+                            const BuildValue& value) {
+    // If the result was failure, we always need to rebuild (it may produce an
+    // error).
+    if (value.isFailedInput())
+      return false;
+
+    // If the result was previously a missing input, it may have been because
+    // we did not previously know how to produce this node. We do now, so
+    // attempt to build it now.
+    if (value.isMissingInput())
+      return false;
+
+    // The produced node result itself doesn't need any synchronization.
+    // If the directory signature is changed, it will be reflected in value of this node.
     return true;
   }
 };
@@ -1732,6 +1867,7 @@ std::unique_ptr<Rule> BuildSystemEngineDelegate::lookupRule(const KeyType& keyDa
         ));
       }
 
+      // DirectoryInputNodeTask
       if (node->isDirectory()) {
         return std::unique_ptr<Rule>(new BuildSystemRule(
           keyData,
@@ -1758,6 +1894,7 @@ std::unique_ptr<Rule> BuildSystemEngineDelegate::lookupRule(const KeyType& keyDa
         ));
       }
       
+      // FileInputNodeTask
       return std::unique_ptr<Rule>(new BuildSystemRule(
         keyData,
         node->getSignature(),
@@ -1773,6 +1910,23 @@ std::unique_ptr<Rule> BuildSystemEngineDelegate::lookupRule(const KeyType& keyDa
     }
 
     // Otherwise, create a task for a produced node.
+    // ProducedDirectoryNodeTask
+    if (node->isDirectory()) {
+      return std::unique_ptr<Rule>(new BuildSystemRule(
+        keyData,
+        node->getSignature(),
+        /*Action=*/ [node](BuildEngine& engine) -> Task* {
+          return new ProducedDirectoryNodeTask(*node);
+        },
+        /*IsValid=*/ [node](BuildEngine& engine, const Rule& rule,
+                            const ValueType& value) -> bool {
+          return ProducedDirectoryNodeTask::isResultValid(
+              engine, *node, BuildValue::fromData(value));
+        }
+      ));
+    }
+
+    // ProducedNodeTask
     return std::unique_ptr<Rule>(new BuildSystemRule(
       keyData,
       node->getSignature(),
@@ -3788,6 +3942,12 @@ void BuildSystemFileDelegate::error(StringRef filename,
   // Delegate to the system delegate.
   auto atSystemToken = BuildSystemDelegate::Token{at.start, at.length};
   system.error(filename, atSystemToken, message);
+}
+
+void
+BuildSystemFileDelegate::cannotLoadDueToMultipleProducers(Node *output,
+                                                          std::vector<Command*> commands) {
+  getSystemDelegate().cannotBuildNodeDueToMultipleProducers(output, commands);
 }
 
 bool

--- a/lib/BuildSystem/ExternalCommand.cpp
+++ b/lib/BuildSystem/ExternalCommand.cpp
@@ -69,6 +69,11 @@ configureOutputs(const ConfigureContext&, const std::vector<Node*>& value) {
   }
 }
 
+void ExternalCommand::addOutput(BuildNode* node) {
+  outputs.emplace_back(node);
+  node->getProducers().push_back(this);
+}
+
 bool ExternalCommand::
 configureAttribute(const ConfigureContext& ctx, StringRef name,
                    StringRef value) {
@@ -398,6 +403,9 @@ void ExternalCommand::execute(BuildSystem& system,
       //
       // FIXME: Need to use the filesystem interfaces.
       auto parent = llvm::sys::path::parent_path(node->getName());
+      if (node->getName().endswith("/")) {
+        parent = llvm::sys::path::parent_path(parent);
+      }
       if (!parent.empty()) {
         (void) system.getFileSystem().createDirectories(parent);
       }

--- a/lib/BuildSystem/ExternalCommand.cpp
+++ b/lib/BuildSystem/ExternalCommand.cpp
@@ -69,11 +69,6 @@ configureOutputs(const ConfigureContext&, const std::vector<Node*>& value) {
   }
 }
 
-void ExternalCommand::addOutput(BuildNode* node) {
-  outputs.emplace_back(node);
-  node->getProducers().push_back(this);
-}
-
 bool ExternalCommand::
 configureAttribute(const ConfigureContext& ctx, StringRef name,
                    StringRef value) {
@@ -101,6 +96,18 @@ configureAttribute(const ConfigureContext& ctx, StringRef name,
     }
     alwaysOutOfDate = value == "true";
     return true;
+    
+  } else if (name == "exclude-from-ownership-analysis") {
+    if (value == "true") {
+      excludeFromOwnershipAnalysis = true;
+      return true;
+    } else if (value == "false") {
+      excludeFromOwnershipAnalysis = false;
+      return true;
+    } else {
+      ctx.error("invalid value for attribute: '" + name + "'");
+      return false;
+    }
   } else {
     ctx.error("unexpected attribute: '" + name + "'");
     return false;

--- a/lib/Commands/BuildSystemCommand.cpp
+++ b/lib/Commands/BuildSystemCommand.cpp
@@ -78,6 +78,9 @@ public:
                      const BuildFileToken& at,
                      const Twine& message) override;
 
+  virtual void cannotLoadDueToMultipleProducers(Node *output,
+                                                std::vector<Command*> commands) override;
+
   virtual bool configureClient(const ConfigureContext&, StringRef name,
                                uint32_t version,
                                const property_list_type& properties) override;
@@ -305,6 +308,14 @@ void ParseBuildFileDelegate::error(StringRef filename,
     fprintf(stderr, "%s: error: %s\n", filename.str().c_str(),
             message.str().c_str());
   }
+}
+
+void
+ParseBuildFileDelegate::cannotLoadDueToMultipleProducers(Node *output,
+                                                         std::vector<Command*> commands) {
+  std::string message = "cannot build '" + output->getName().str() + "' node is produced "
+  "by multiple commands; e.g. '" + (*commands.begin())->getName().str() + "'";
+  error("", {}, message);
 }
 
 bool

--- a/products/libllbuild/BuildSystem-C-API.cpp
+++ b/products/libllbuild/BuildSystem-C-API.cpp
@@ -841,6 +841,16 @@ class CAPIExternalCommand : public ExternalCommand {
       } else {
         return false;
       }
+    } else if (name == "exclude-from-ownership-analysis") {
+      if (value == "true") {
+        excludeFromOwnershipAnalysis = true;
+        return true;
+      } else if (value == "false") {
+        excludeFromOwnershipAnalysis = false;
+        return true;
+      } else {
+        return false;
+      }
     } else if (name == "working-directory") {
       // Ensure the working directory is absolute. This will make sure any
       // relative directories are interpreted as relative to the CWD at the time

--- a/tests/BuildSystem/Build/directory-input-and-output.llbuild
+++ b/tests/BuildSystem/Build/directory-input-and-output.llbuild
@@ -1,0 +1,137 @@
+# Some files are written to /tmp/raw/
+# TaskA reads /tmp/raw/ and produces /tmp/headers/
+# TaskB reads /tmp/headers/ and produces /tmp/headers-copy/
+# TaskC reads /tmp/headers-copy/libX.fake-h and produces /tmp/libX-from-TaskC.fake-h
+#
+# This test check many things at once and is intended for overall sanity check of all pieces.
+#
+# raw/
+#  |   libX.fake-h <-- written on disk (initial state)
+#  |   libX.fake-h <-- written on disk (initial state)
+#  |   libY.fake-h <-- written on disk (initial state)
+#  v
+# [TaskA] (verbatim copy; mixed case)
+#  |
+#  v
+# headers/
+#  |   libX.fake-h
+#  |   libY.fake-h
+#  |   libZ.fake-h
+#  v
+# [TaskB] (modified copy; ALL CAPS)
+#  |
+#  v
+# headers-copy/
+#      libX.fake-h
+#  ,-- libY.fake-h (will be automatically amended to outputs of TaskB)
+#  |   libZ.fake-h
+#  v
+# [TaskC] (modified copy; all lower case)
+#  |
+#  v
+# libY-from-TaskC.fake-h
+#
+# RUN: rm -rf "%t.build"
+# RUN: mkdir -p "%t.build/raw"
+# RUN: echo "Contents of libX.fake-h" > "%t.build/raw/libX.fake-h"
+# RUN: echo "Contents of libY.fake-h" > "%t.build/raw/libY.fake-h"
+# RUN: echo "Contents of libZ.fake-h" > "%t.build/raw/libZ.fake-h"
+# RUN: cat %s > "%t.build/build.llbuild"
+# RUN: %{llbuild} buildsystem build --serial --chdir %t.build --trace %t.trace > %t.out
+# RUN: %{FileCheck} --input-file=%t.out %s
+#
+# CHECK: TaskA
+# CHECK: Contents of libX.fake-h
+# CHECK: Contents of libY.fake-h
+# CHECK: Contents of libZ.fake-h
+# CHECK: TaskB
+# CHECK: CONTENTS OF LIBX.FAKE-H
+# CHECK: CONTENTS OF LIBY.FAKE-H
+# CHECK: CONTENTS OF LIBZ.FAKE-H
+# CHECK: TaskC
+# CHECK: contents of liby.fake-h
+#
+# Check that a null build does nothing.
+#
+# RUN: %{llbuild} buildsystem build --serial --chdir %t.build --trace %t.trace > %t2.out
+# RUN: echo "PREVENT-EMPTY-FILE" >> %t2.out
+# RUN: %{FileCheck} --input-file=%t2.out %s --check-prefix=CHECK-NULL
+# CHECK-NULL-NOT: TaskA
+# CHECK-NULL-NOT: TaskB
+# CHECK-NULL-NOT: TaskC
+#
+# Check modifying libY.fake-h rebuilds TaskC
+#
+# RUN: echo "Updated contents of libY.fake-h" > "%t.build/raw/libY.fake-h"
+# RUN: %{llbuild} buildsystem build --serial --chdir %t.build --trace %t.trace > %t3.out
+# RUN: %{FileCheck} --input-file=%t3.out %s --check-prefix=CHECK-UPDATE-Y
+# CHECK-UPDATE-Y: TaskA
+# CHECK-UPDATE-Y: Updated contents of libY.fake-h
+# CHECK-UPDATE-Y: TaskB
+# CHECK-UPDATE-Y: UPDATED CONTENTS OF LIBY.FAKE-H
+# CHECK-UPDATE-Y: TaskC
+# CHECK-UPDATE-Y: updated contents of liby.fake-h
+
+client:
+  name: basic
+  file-system: default
+
+targets:
+  basic: ["libY-from-TaskC.fake-h/"]
+
+# define the default target to execute when this manifest is loaded.
+default: basic
+
+commands:
+  taskC:
+    tool: shell
+    inputs: ["headers-processed/libY.fake-h/"]
+    outputs: ["libY-from-TaskC.fake-h/"]
+    description: "TaskC"
+    args: '
+      set -o errexit
+      set -o nounset
+
+      [ -f "headers-processed/libY.fake-h" ]
+      cat "headers-processed/libY.fake-h" | tr A-Z a-z > libY-from-TaskC.fake-h
+      cat libY-from-TaskC.fake-h
+      '
+
+  taskB:
+    tool: shell
+    inputs: ["headers/"]
+    outputs: ["headers-processed/"]
+    description: "TaskB"
+    args: '
+      set -o errexit
+      set -o nounset
+
+      mkdir -p "headers-processed/"
+      for headerFile in headers/*.fake-h
+      do
+          outputFile=headers-processed/$(basename "$headerFile")
+          cat "$headerFile" | tr a-z A-Z > "$outputFile"
+          cat $outputFile
+      done
+      '
+
+  taskA:
+    tool: shell
+    inputs: ["raw/"]
+    outputs: ["headers/"]
+    description: "TaskA"
+    args: '
+      set -o errexit
+      set -o nounset
+
+      mkdir -p headers/
+      cd headers/
+
+      for headerFile in ../raw/*.fake-h
+      do
+          cp "$headerFile" .
+      done
+
+      ls .
+      cat *
+      '

--- a/tests/BuildSystem/Build/directory-input-and-output.llbuild
+++ b/tests/BuildSystem/Build/directory-input-and-output.llbuild
@@ -75,6 +75,7 @@
 client:
   name: basic
   file-system: default
+  perform-ownership-analysis: yes
 
 targets:
   basic: ["libY-from-TaskC.fake-h/"]

--- a/tests/BuildSystem/Build/directory-input-basic.llbuild
+++ b/tests/BuildSystem/Build/directory-input-basic.llbuild
@@ -38,6 +38,7 @@
 client:
   name: basic
   file-system: default
+  perform-ownership-analysis: yes
 
 targets:
   basic: ["final.txt"]

--- a/tests/BuildSystem/Build/directory-input-basic.llbuild
+++ b/tests/BuildSystem/Build/directory-input-basic.llbuild
@@ -1,0 +1,54 @@
+# raw/
+#  |  raw.txt <-- written on disk (initial state)
+#  v
+# [TaskA]
+#  |
+#  v
+# checksum1.txt
+#
+# RUN: rm -rf "%t.build"
+# RUN: mkdir -p "%t.build/raw"
+# RUN: echo "Hello World!" > "%t.build/raw/raw.txt"
+# RUN: cat %s > "%t.build/build.llbuild"
+# RUN: %{llbuild} buildsystem build --serial --chdir %t.build --trace %t.trace > %t.out
+# RUN: %{FileCheck} --input-file=%t.out %s
+#
+# CHECK: TaskA
+# CHECK: Hello World!
+# CHECK: HELLO WORLD!
+#
+# Check that a null build does nothing.
+#
+# RUN: %{llbuild} buildsystem build --serial --chdir %t.build --trace %t.trace > %t2.out
+# RUN: echo "PREVENT-EMPTY-FILE" >> %t2.out
+# RUN: %{FileCheck} --input-file=%t2.out %s --check-prefix=CHECK-NULL
+# CHECK-NULL-NOT: TaskA
+# CHECK-NULL-NOT: Hello World!
+# CHECK-NULL-NOT: HELLO WORLD!
+#
+# Check modifying raw.txt rebuilds TaskA
+#
+# RUN: echo "Hola Amigos!" > "%t.build/raw/raw.txt"
+# RUN: %{llbuild} buildsystem build --serial --chdir %t.build --trace %t.trace > %t3.out
+# RUN: %{FileCheck} --input-file=%t3.out %s --check-prefix=CHECK-MOD
+# CHECK-MOD: TaskA
+# CHECK-MOD: Hola Amigos!
+# CHECK-MOD: HOLA AMIGOS!
+
+client:
+  name: basic
+  file-system: default
+
+targets:
+  basic: ["final.txt"]
+
+# define the default target to execute when this manifest is loaded.
+default: basic
+
+commands:
+  taskA:
+    tool: shell
+    inputs: ["raw/"]
+    outputs: ["final.txt"]
+    description: "TaskA"
+    args: "cat raw/raw.txt; cat raw/raw.txt | tr a-z A-Z > final.txt; cat final.txt"

--- a/tests/BuildSystem/Build/directory-input-must-scan-after-paths-error.llbuild
+++ b/tests/BuildSystem/Build/directory-input-must-scan-after-paths-error.llbuild
@@ -17,6 +17,7 @@
 client:
   name: basic
   file-system: default
+  perform-ownership-analysis: yes
 
 targets:
   basic: ["final.txt"]

--- a/tests/BuildSystem/Build/directory-input-must-scan-after-paths-error.llbuild
+++ b/tests/BuildSystem/Build/directory-input-must-scan-after-paths-error.llbuild
@@ -1,0 +1,47 @@
+# RUN: rm -rf %t.build
+# RUN: mkdir -p %t.build
+# RUN: echo "Output from TaskA for a.txt" > "%t.build/raw.txt"
+# RUN: cat %s > "%t.build/build.llbuild"
+# RUN: %{llbuild} buildsystem build --serial --chdir %t.build --trace %t.trace &> %t.out || true
+# RUN: %{FileCheck} --input-file=%t.out %s
+#
+# CHECK: TaskB
+# CHECK: Output from TaskB for b.txt
+# CHECK: TaskA
+# CHECK: Output from TaskA for a.txt
+# CHECK-NOT: TaskC
+# CHECK-NOT: OUTPUT FROM TASKA FOR A.TXT
+# CHECK-NOT: OUTPUT FROM TASKB FOR B.TXT
+# CHECK: build had 1 command failure
+
+client:
+  name: basic
+  file-system: default
+
+targets:
+  basic: ["final.txt"]
+
+# define the default target to execute when this manifest is loaded.
+default: basic
+
+commands:
+  taskA:
+    tool: shell
+    inputs: ["raw.txt"]
+    outputs: ["out/a.txt"]
+    description: "TaskA"
+    args: "cat raw.txt > out/a.txt; cat out/a.txt; false"
+
+  taskB:
+    tool: shell
+    inputs: []
+    outputs: ["out/b.txt"]
+    description: "TaskB"
+    args: "echo 'Output from TaskB for b.txt' > out/b.txt; cat out/b.txt"
+
+  taskC:
+    tool: shell
+    inputs: ["out/"]
+    outputs: ["final.txt"]
+    description: "TaskC"
+    args: "cat out/* | tr a-z A-Z > final.txt; cat final.txt"

--- a/tests/BuildSystem/Build/directory-input-must-scan-after-paths.llbuild
+++ b/tests/BuildSystem/Build/directory-input-must-scan-after-paths.llbuild
@@ -49,6 +49,7 @@
 client:
   name: basic
   file-system: default
+  perform-ownership-analysis: yes
 
 targets:
   basic: ["final.txt"]

--- a/tests/BuildSystem/Build/directory-input-must-scan-after-paths.llbuild
+++ b/tests/BuildSystem/Build/directory-input-must-scan-after-paths.llbuild
@@ -1,0 +1,79 @@
+# TaskA produces "out/a.txt"
+# TaskB produces "out/b.txt"
+# TaskC lists "out/" as input dependency
+# We manually set "must-scan-after-paths" for "out/" to ["out/a.txt", "out/b.txt"]
+# so we can defer scanning "out/" until its subpaths are produced.
+#
+# RUN: rm -rf %t.build
+# RUN: mkdir -p %t.build
+# RUN: echo "Output from TaskA for a.txt" > "%t.build/raw.txt"
+# RUN: cat %s > "%t.build/build.llbuild"
+# RUN: %{llbuild} buildsystem build --serial --chdir %t.build --trace %t.trace > %t.out
+# RUN: %{FileCheck} --input-file=%t.out %s
+#
+# CHECK: TaskB
+# CHECK: Output from TaskB for b.txt
+# CHECK: TaskA
+# CHECK: Output from TaskA for a.txt
+# CHECK: TaskC
+# CHECK: OUTPUT FROM TASKA FOR A.TXT
+# CHECK: OUTPUT FROM TASKB FOR B.TXT
+#
+# Check that a null build does nothing.
+#
+# RUN: %{llbuild} buildsystem build --serial --chdir %t.build --trace %t.trace > %t2.out
+# RUN: echo "PREVENT-EMPTY-FILE" >> %t2.out
+# RUN: %{FileCheck} --input-file=%t2.out %s --check-prefix=CHECK-REBUILD
+# CHECK-REBUILD-NOT: TaskB
+# CHECK-REBUILD-NOT: Output from TaskB for b.txt
+# CHECK-REBUILD-NOT: TaskA
+# CHECK-REBUILD-NOT: Output from TaskA for a.txt
+# CHECK-REBUILD-NOT: TaskC
+# CHECK-REBUILD-NOT: OUTPUT FROM TASKA FOR A.TXT
+# CHECK-REBUILD-NOT: OUTPUT FROM TASKB FOR B.TXT
+#
+# Check modifying a.txt rebuilds TaskA and TaskC
+#
+# RUN: echo "Updated output from TaskA for a.txt" > "%t.build/raw.txt"
+# RUN: %{llbuild} buildsystem build --serial --chdir %t.build --trace %t.trace > %t3.out
+# RUN: echo "PREVENT-EMPTY-FILE" >> %t3.out
+# RUN: %{FileCheck} --input-file=%t3.out %s --check-prefix=CHECK-MOD-A
+# CHECK-MOD-A-NOT: TaskB
+# CHECK-MOD-A-NOT: Output from TaskB for b.txt
+# CHECK-MOD-A: TaskA
+# CHECK-MOD-A: Updated output from TaskA for a.txt
+# CHECK-MOD-A: TaskC
+# CHECK-MOD-A: UPDATED OUTPUT FROM TASKA FOR A.TXT
+# CHECK-MOD-A: OUTPUT FROM TASKB FOR B.TXT
+
+client:
+  name: basic
+  file-system: default
+
+targets:
+  basic: ["final.txt"]
+
+# define the default target to execute when this manifest is loaded.
+default: basic
+
+commands:
+  taskA:
+    tool: shell
+    inputs: ["raw.txt"]
+    outputs: ["out/a.txt"]
+    description: "TaskA"
+    args: "cat raw.txt > out/a.txt; cat out/a.txt"
+
+  taskB:
+    tool: shell
+    inputs: []
+    outputs: ["out/b.txt"]
+    description: "TaskB"
+    args: "echo 'Output from TaskB for b.txt' > out/b.txt; cat out/b.txt"
+
+  taskC:
+    tool: shell
+    inputs: ["out/"]
+    outputs: ["final.txt"]
+    description: "TaskC"
+    args: "cat out/* | tr a-z A-Z > final.txt; cat final.txt"


### PR DESCRIPTION
Follow up to `[1]` which was reverted in `[2]` because it broke downstream.

This PR
* turns ownership analysis off-by-default to avoid various bootstrapping issues
* implements a mechanism to opt-out certain tasks from ownership analysis
* broadens the scope of analysis so we can have ownership information for mkdir, symlink and custom commands (not just external command)

`[1]`: https://github.com/apple/swift-llbuild/pull/849
`[2]`: https://github.com/apple/swift-llbuild/pull/854