### PR TITLE
libllbuild: correct the macro usage for DLL builds

### DIFF
--- a/products/libllbuild/include/llbuild/llbuild-defines.h
+++ b/products/libllbuild/include/llbuild/llbuild-defines.h
@@ -31,7 +31,7 @@
 #define LLBUILD_EXPORT LLBUILD_EXTERN __attribute__((__visibility__("default")))
 #else
 // asume PE/COFF
-#if defined(_DLL)
+#if defined(_WINDLL)
 #if defined(libllbuild_EXPORTS)
 #define LLBUILD_EXPORT LLBUILD_EXTERN __declspec(dllexport)
 #else


### PR DESCRIPTION
`_DLL` indicates that the MSVCRT version is the shared form rather than static.  This corresponds to `/MD` (and the lack to `/MT`).  `_WINDLL` is used to indicate that we are building statically or dynamically. This change is required to experiment with static builds of libllbuild with CMake.