### PR TITLE
build: correct indicator that we are building in shared mode

### DIFF
--- a/products/libllbuild/CMakeLists.txt
+++ b/products/libllbuild/CMakeLists.txt
@@ -11,6 +11,8 @@ add_llbuild_library(libllbuild
   ${SOURCES}
   SHARED
   OUTPUT_NAME llbuild)
+target_compile_definitions(libllbuild PRIVATE
+  _WINDLL)
 
 set_property(TARGET libllbuild PROPERTY MACOSX_RPATH ON)
 


### PR DESCRIPTION
We currently do not build `libllbuild` statically (though we could). Indicate that we are building it dynamically on Windows via `_WINDLL`.