### PR TITLE
llbuild: add missing parenthesis to macros

### DIFF
--- a/include/llbuild/Basic/Stat.h
+++ b/include/llbuild/Basic/Stat.h
@@ -35,15 +35,15 @@ namespace sys {
 #endif
 
 #if !defined(S_ISREG)
-#define S_ISREG(mode) ((mode) & _S_IFMT) == S_IFREG
+#define S_ISREG(mode) (((mode) & _S_IFMT) == S_IFREG)
 #endif
 
 #if !defined(S_ISDIR)
-#define S_ISDIR(mode) ((mode) & _S_IFMT) == S_IFDIR
+#define S_ISDIR(mode) (((mode) & _S_IFMT) == S_IFDIR)
 #endif
 
 #if !defined(S_ISBLK)
-#define S_ISBLK(mode) ((mode) & _S_IFMT) == S_IFBLK
+#define S_ISBLK(mode) (((mode) & _S_IFMT) == S_IFBLK)
 #endif
 
 #if !defined(S_ISCHR)


### PR DESCRIPTION
The value itself is the result of the macro, which was not parenthesized which made the usage of it incorrect in a few places where the negation was being checked and that bound more tightly than the equality check.