### PR TITLE
Report when a task has a missing dynamically-requested input

### DIFF
--- a/include/llbuild/BuildSystem/ExternalCommand.h
+++ b/include/llbuild/BuildSystem/ExternalCommand.h
@@ -70,6 +70,9 @@ class ExternalCommand : public Command {
   /// (this implies ShouldSkip is true).
   SmallPtrSet<Node*, 1> missingInputNodes;
 
+  /// If true, the command had missing dynamic inputs.
+  bool hasMissingDynamicInputs = false;
+
   /// If true, the command can legally be updated if the output state allows it.
   bool canUpdateIfNewer = true;
 

--- a/products/libllbuild/BuildSystem-C-API.cpp
+++ b/products/libllbuild/BuildSystem-C-API.cpp
@@ -309,8 +309,11 @@ public:
   virtual void commandCannotBuildOutputDueToMissingInputs(Command* command,
                Node* outputNode, SmallPtrSet<Node*, 1> inputNodes) override {
     if (cAPIDelegate.command_cannot_build_output_due_to_missing_inputs) {
-      auto str = outputNode->getName().str();
-      auto output = new CAPIBuildKey(BuildKey::makeNode(str));
+      CAPIBuildKey *output = nullptr;
+      if (outputNode) {
+        auto str = outputNode->getName().str();
+        output = new CAPIBuildKey(BuildKey::makeNode(str));
+      }
 
       CAPINodesVector inputs(inputNodes);
 


### PR DESCRIPTION
Currently, we don't have the necessary information to report which input is missing, but higher-level build systems can use other delegate callbacks to reconstruct that information. If no missing input is reported at all, we can easily end up in a situation where tasks are unexpectedly and silently cancelled, making debugging these sorts of issues difficult.

rdar://58130864