### PR TITLE
rdar://105261237 (llbuild test failure in BuildDBBindingsTests.testCouldNotOpenDatabaseErrors)

### DIFF
--- a/unittests/Swift/BuildDBBindingsTests.swift
+++ b/unittests/Swift/BuildDBBindingsTests.swift
@@ -141,7 +141,7 @@ class BuildDBBindingsTests: XCTestCase {
     
     expectCouldNotOpenError(path: exampleBuildDBPath,
                             clientSchemaVersion: 8,
-                            expectedError: "Version mismatch. (database-schema: 15 requested schema: 15. database-client: \(exampleBuildDBClientSchemaVersion) requested client: 8)")
+                            expectedError: "Version mismatch. (database-schema: 16 requested schema: 16. database-client: \(exampleBuildDBClientSchemaVersion) requested client: 8)")
     XCTAssertNoThrow(try BuildDB(path: exampleBuildDBPath, clientSchemaVersion: exampleBuildDBClientSchemaVersion))
   }
   


### PR DESCRIPTION
Apparently we don't run tests for Swift bindings when we smoke test (smoke tests only run lit tests) and I forgot to run Swift binding tests before merging.