### PR TITLE
A1 rdar://105156287 ([ownership-analysis] Restrict mustScanAfterPaths to user scripts)

### DIFF
--- a/include/llbuild/BuildSystem/Command.h
+++ b/include/llbuild/BuildSystem/Command.h
@@ -55,7 +55,7 @@ public:
 
   std::vector<BuildNode*> inputs;
   std::vector<BuildNode*> outputs;
-  bool excludeFromOwnershipAnalysis = false;
+  bool repairViaOwnershipAnalysis = false;
 
   StringRef getName() const { return name; }
 

--- a/lib/BuildSystem/BuildNode.cpp
+++ b/lib/BuildSystem/BuildNode.cpp
@@ -104,9 +104,6 @@ bool BuildNode::configureAttribute(const ConfigureContext& ctx, StringRef name,
   } else if (name == "content-exclusion-patterns") {
     exclusionPatterns = basic::StringList(value);
     return true;
-  } else if (name == "must-scan-after-paths") {
-    mustScanAfterPaths = basic::StringList(value).getValues();
-    return true;
   }
     
   // We don't support any other custom attributes.

--- a/lib/BuildSystem/BuildSystem.cpp
+++ b/lib/BuildSystem/BuildSystem.cpp
@@ -3094,28 +3094,14 @@ public:
 };
 
 class MkdirTool : public Tool {
-  bool excludeFromOwnershipAnalysis = false;
 
 public:
   using Tool::Tool;
 
   virtual bool configureAttribute(const ConfigureContext& ctx, StringRef name,
                                   StringRef value) override {
-    if (name == "exclude-from-ownership-analysis") {
-      if (value == "true") {
-        excludeFromOwnershipAnalysis = true;
-        return true;
-      } else if (value == "false") {
-        excludeFromOwnershipAnalysis = false;
-        return true;
-      } else {
-        ctx.error("invalid value for attribute: '" + name + "'");
-        return false;
-      }
-    } else {
-      ctx.error("unexpected attribute: '" + name + "'");
-      return false;
-    }
+    ctx.error("unexpected attribute: '" + name + "'");
+    return false;
   }
 
   virtual bool configureAttribute(const ConfigureContext& ctx, StringRef name,
@@ -3134,7 +3120,6 @@ public:
 
   virtual std::unique_ptr<Command> createCommand(StringRef name) override {
     auto res = llvm::make_unique<MkdirCommand>(name);
-    res->excludeFromOwnershipAnalysis = excludeFromOwnershipAnalysis;
     return res;
   }
 };
@@ -3226,12 +3211,12 @@ class SymlinkCommand : public Command {
     } else if (name == "link-output-path") {
       linkOutputPath = value;
       return true;
-    } else if (name == "exclude-from-ownership-analysis") {
+    } else if (name == "repair-via-ownership-analysis") {
       if (value == "true") {
-        excludeFromOwnershipAnalysis = true;
+        repairViaOwnershipAnalysis = true;
         return true;
       } else if (value == "false") {
-        excludeFromOwnershipAnalysis = false;
+        repairViaOwnershipAnalysis = false;
         return true;
       } else {
         ctx.error("invalid value for attribute: '" + name + "'");
@@ -3378,18 +3363,18 @@ public:
 };
 
 class SymlinkTool : public Tool {
-  bool excludeFromOwnershipAnalysis = false;
+  bool repairViaOwnershipAnalysis = false;
 public:
   using Tool::Tool;
 
   virtual bool configureAttribute(const ConfigureContext& ctx, StringRef name,
                                   StringRef value) override {
-    if (name == "exclude-from-ownership-analysis") {
+    if (name == "repair-via-ownership-analysis") {
       if (value == "true") {
-        excludeFromOwnershipAnalysis = true;
+        repairViaOwnershipAnalysis = true;
         return true;
       } else if(value == "false") {
-        excludeFromOwnershipAnalysis = false;
+        repairViaOwnershipAnalysis = false;
         return true;
       } else {
         ctx.error("invalid value for attribute: '" + name + "'");
@@ -3417,7 +3402,7 @@ public:
 
   virtual std::unique_ptr<Command> createCommand(StringRef name) override {
     auto res = llvm::make_unique<SymlinkCommand>(name);
-    res->excludeFromOwnershipAnalysis = excludeFromOwnershipAnalysis;
+    res->repairViaOwnershipAnalysis = repairViaOwnershipAnalysis;
     return res;
   }
 };

--- a/lib/BuildSystem/ExternalCommand.cpp
+++ b/lib/BuildSystem/ExternalCommand.cpp
@@ -97,12 +97,12 @@ configureAttribute(const ConfigureContext& ctx, StringRef name,
     alwaysOutOfDate = value == "true";
     return true;
     
-  } else if (name == "exclude-from-ownership-analysis") {
+  } else if (name == "repair-via-ownership-analysis") {
     if (value == "true") {
-      excludeFromOwnershipAnalysis = true;
+      repairViaOwnershipAnalysis = true;
       return true;
     } else if (value == "false") {
-      excludeFromOwnershipAnalysis = false;
+      repairViaOwnershipAnalysis = false;
       return true;
     } else {
       ctx.error("invalid value for attribute: '" + name + "'");

--- a/products/libllbuild/BuildSystem-C-API.cpp
+++ b/products/libllbuild/BuildSystem-C-API.cpp
@@ -848,12 +848,12 @@ class CAPIExternalCommand : public ExternalCommand {
       } else {
         return false;
       }
-    } else if (name == "exclude-from-ownership-analysis") {
+    } else if (name == "repair-via-ownership-analysis") {
       if (value == "true") {
-        excludeFromOwnershipAnalysis = true;
+        repairViaOwnershipAnalysis = true;
         return true;
       } else if (value == "false") {
-        excludeFromOwnershipAnalysis = false;
+        repairViaOwnershipAnalysis = false;
         return true;
       } else {
         return false;

--- a/tests/BuildSystem/Build/directory-input-and-output.llbuild
+++ b/tests/BuildSystem/Build/directory-input-and-output.llbuild
@@ -7,8 +7,8 @@
 #
 # raw/
 #  |   libX.fake-h <-- written on disk (initial state)
-#  |   libX.fake-h <-- written on disk (initial state)
 #  |   libY.fake-h <-- written on disk (initial state)
+#  |   libZ.fake-h <-- written on disk (initial state)
 #  v
 # [TaskA] (verbatim copy; mixed case)
 #  |
@@ -115,6 +115,7 @@ commands:
           cat $outputFile
       done
       '
+    repair-via-ownership-analysis: true
 
   taskA:
     tool: shell
@@ -136,3 +137,4 @@ commands:
       ls .
       cat *
       '
+    repair-via-ownership-analysis: true

--- a/tests/BuildSystem/Build/directory-input-must-scan-after-paths-error.llbuild
+++ b/tests/BuildSystem/Build/directory-input-must-scan-after-paths-error.llbuild
@@ -32,6 +32,7 @@ commands:
     outputs: ["out/a.txt"]
     description: "TaskA"
     args: "cat raw.txt > out/a.txt; cat out/a.txt; false"
+    repair-via-ownership-analysis: true
 
   taskB:
     tool: shell
@@ -39,6 +40,7 @@ commands:
     outputs: ["out/b.txt"]
     description: "TaskB"
     args: "echo 'Output from TaskB for b.txt' > out/b.txt; cat out/b.txt"
+    repair-via-ownership-analysis: true
 
   taskC:
     tool: shell
@@ -46,3 +48,4 @@ commands:
     outputs: ["final.txt"]
     description: "TaskC"
     args: "cat out/* | tr a-z A-Z > final.txt; cat final.txt"
+    repair-via-ownership-analysis: true

--- a/tests/BuildSystem/Build/directory-input-must-scan-after-paths.llbuild
+++ b/tests/BuildSystem/Build/directory-input-must-scan-after-paths.llbuild
@@ -64,6 +64,7 @@ commands:
     outputs: ["out/a.txt"]
     description: "TaskA"
     args: "cat raw.txt > out/a.txt; cat out/a.txt"
+    repair-via-ownership-analysis: true
 
   taskB:
     tool: shell
@@ -71,6 +72,7 @@ commands:
     outputs: ["out/b.txt"]
     description: "TaskB"
     args: "echo 'Output from TaskB for b.txt' > out/b.txt; cat out/b.txt"
+    repair-via-ownership-analysis: true
 
   taskC:
     tool: shell
@@ -78,3 +80,4 @@ commands:
     outputs: ["final.txt"]
     description: "TaskC"
     args: "cat out/* | tr a-z A-Z > final.txt; cat final.txt"
+    repair-via-ownership-analysis: true


### PR DESCRIPTION
Minor refinement to the inclusion/exclusion mechanism. We need this before we can land a downstream PR.