### PR TITLE
[CMake] Don't install libllbuild in the Swift toolchain now that it's statically linked

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,6 +51,9 @@ else()
   endif()
 endif()
 
+if(CMAKE_SYSTEM_NAME STREQUAL Android)
+  set(CMAKE_HAVE_LIBC_PTHREAD TRUE)
+endif()
 set(THREADS_PREFER_PTHREAD_FLAG FALSE)
 find_package(Threads REQUIRED)
 

--- a/products/libllbuild/CMakeLists.txt
+++ b/products/libllbuild/CMakeLists.txt
@@ -57,14 +57,6 @@ install(TARGETS libllbuild
   RUNTIME DESTINATION bin
   COMPONENT libllbuild)
 
-if(Swift IN_LIST LLBUILD_SUPPORT_BINDINGS)
-  if(NOT CMAKE_SYSTEM_NAME STREQUAL Windows)
-    install(TARGETS libllbuild
-      DESTINATION lib/swift/pm/llbuild
-      COMPONENT libllbuildSwift)
-  endif()
-endif()
-
 add_custom_target(install-libllbuild
                   DEPENDS libllbuild
                   COMMENT "Installing libllbuild..."

--- a/products/llbuildSwift/CMakeLists.txt
+++ b/products/llbuildSwift/CMakeLists.txt
@@ -65,7 +65,7 @@ else()
   if(NOT CMAKE_SYSTEM_NAME STREQUAL Windows)
     target_link_options(llbuildSwift PRIVATE "SHELL:-no-toolchain-stdlib-rpath")
     set_target_properties(llbuildSwift PROPERTIES
-      INSTALL_RPATH "$ORIGIN:$ORIGIN/../../$<LOWER_CASE:${CMAKE_SYSTEM_NAME}>")
+      INSTALL_RPATH "$ORIGIN/../../$<LOWER_CASE:${CMAKE_SYSTEM_NAME}>")
   endif()
 endif()
 set_target_properties(llbuildSwift PROPERTIES


### PR DESCRIPTION
Now that `libllbuildSwift` is statically linked against `libllbuild` with #852, remove the runpath and don't install it. Also, the Android build started failing, so set the appropriate flag for it to work again.

Previously, we installed `libllbuild.so` in the Swift toolchain alongside `libllbuildSwift.so` and set the ELF runpath so it knew it was in the same directory:
```
> ls swift-5.7.3-RELEASE-ubuntu20.04/usr/lib/swift/pm/llbuild/
libllbuild.so  libllbuildSwift.so
> readelf -d swift-5.7.3-RELEASE-ubuntu20.04/usr/lib/swift/pm/llbuild/libllbuildSwift.so |ag runpath
 0x000000000000001d (RUNPATH)            Library runpath: [$ORIGIN:$ORIGIN/../../linux]
```
Now that @compnerd made it link statically, we're wrongly shipping the static libllbuild and still have the now unneeded runpath:
```
> ls swift-DEVELOPMENT-SNAPSHOT-2023-03-01-a-ubuntu20.04/usr/lib/swift/pm/llbuild/
libllbuild.a  libllbuildSwift.so
> readelf -d swift-DEVELOPMENT-SNAPSHOT-2023-03-01-a-ubuntu20.04/usr/lib/swift/pm/llbuild/libllbuildSwift.so | ag runpath
 0x000000000000001d (RUNPATH)            Library runpath: [$ORIGIN:$ORIGIN/../../linux]
```
Also, I started seeing [cross-compilation failures on my daily Android CI](https://github.com/buttaface/swift-android-sdk/actions/runs/4250967892/jobs/7392741185) with this move to static linking, which this Android change now fixes, buttaface/swift-android-sdk#94.