### PR TITLE
Fix leak in CAPIBuildSystemFrontendDelegate::determinedRuleNeedsToRun

### DIFF
--- a/products/libllbuild/BuildSystem-C-API.cpp
+++ b/products/libllbuild/BuildSystem-C-API.cpp
@@ -509,6 +509,9 @@ public:
       }
       cAPIDelegate.determined_rule_needs_to_run(cAPIDelegate.context, needsToRun, convertRunReason(reason), input);
       llb_build_key_destroy(needsToRun);
+      if (input) {
+        llb_build_key_destroy(input);
+      }
     }
   }
 


### PR DESCRIPTION
Fix a memory leak in this delegate method of one of the build key wrappers