### PR TITLE
Various set of SPM based build updates for Windows

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -221,7 +221,11 @@ do {
     ]
 
     package.targets.filter({ llvmTargets.contains($0.name) }).forEach { target in
-        target.cxxSettings = [ .define("LLVM_ON_WIN32", .when(platforms: [.windows])) ]
+        target.cxxSettings = [
+            .define("LLVM_ON_WIN32", .when(platforms: [.windows])),
+            .define("_CRT_SECURE_NO_WARNINGS", .when(platforms: [.windows])),
+            .define("_CRT_NONSTDC_NO_WARNINGS", .when(platforms: [.windows])),
+        ]
     }
 }
 

--- a/Package.swift
+++ b/Package.swift
@@ -200,6 +200,8 @@ let package = Package(
 
 do {
     let llvmTargets: Set<String> = [
+        "libllbuild",
+
         "llvmDemangle",
         "llvmSupport",
 
@@ -220,14 +222,6 @@ do {
         target.cxxSettings = [ .define("LLVM_ON_WIN32", .when(platforms: [.windows])) ]
     }
 }
-
-package.targets.first { $0.name == "libllbuild" }?.cxxSettings = [
-    .define("LLVM_ON_WIN32", .when(platforms: [.windows])),
-    // FIXME: we need to define `libllbuild_EXPORTS` to ensure that the
-    // symbols are exported from the DLL that is being built here until
-    // static linking is supported on Windows.
-    .define("libllbuild_EXPORTS", .when(platforms: [.windows])),
-]
 
 package.targets.first { $0.name == "llbuildBasic" }?.linkerSettings = [
     .linkedLibrary("ShLwApi", .when(platforms: [.windows]))

--- a/Package.swift
+++ b/Package.swift
@@ -221,7 +221,7 @@ do {
     ]
 
     package.targets.filter({ llvmTargets.contains($0.name) }).forEach { target in
-        target.cxxSettings = [
+        target.cxxSettings = (target.cxxSettings ?? []) + [
             .define("LLVM_ON_WIN32", .when(platforms: [.windows])),
             .define("_CRT_SECURE_NO_WARNINGS", .when(platforms: [.windows])),
             .define("_CRT_NONSTDC_NO_WARNINGS", .when(platforms: [.windows])),

--- a/Package.swift
+++ b/Package.swift
@@ -201,6 +201,7 @@ let package = Package(
 do {
     let llvmTargets: Set<String> = [
         "libllbuild",
+        "llbuildCore",
 
         "llvmDemangle",
         "llvmSupport",
@@ -214,6 +215,7 @@ do {
         "llbuildBasicTests",
         "llbuildBuildSystemTests",
         "llbuildCoreTests",
+        "llbuildNinjaTests",
 
         "swift-build-tool",
     ]


### PR DESCRIPTION
Update the build for Windows to get SPM based builds working better.  This should make it easier to work with llbuild and SPM when developing with SPM.