### PR TITLE
Various build fixes to get llbuild to build with SPM on Windows

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -176,6 +176,10 @@ let package = Package(
                 "gtest-test-part.cc",
                 "gtest-typed-test.cc",
                 "gtest.cc",
+            ],
+            cxxSettings: [
+                .headerSearchPath(".."),
+                .headerSearchPath("../include"),
             ]),
         
         // MARK: Ingested LLVM code.

--- a/Package.swift
+++ b/Package.swift
@@ -117,29 +117,45 @@ let package = Package(
 
         .target(
             name: "llbuildBasicTests",
-            dependencies: ["llbuildBasic", "gtestlib"],
+            dependencies: ["llbuildBasic", "gmocklib"],
             path: "unittests/Basic",
+            cxxSettings: [
+                .headerSearchPath("../../utils/unittest/googlemock/include"),
+                .headerSearchPath("../../utils/unittest/googletest/include"),
+            ],
             linkerSettings: [
                 .linkedLibrary("dl", .when(platforms: [.linux])),
                 .linkedLibrary("pthread", .when(platforms: [.linux]))]),
         .target(
             name: "llbuildCoreTests",
-            dependencies: ["llbuildCore", "gtestlib"],
+            dependencies: ["llbuildCore", "gmocklib"],
             path: "unittests/Core",
+            cxxSettings: [
+                .headerSearchPath("../../utils/unittest/googlemock/include"),
+                .headerSearchPath("../../utils/unittest/googletest/include"),
+            ],
             linkerSettings: [
                 .linkedLibrary("dl", .when(platforms: [.linux])),
                 .linkedLibrary("pthread", .when(platforms: [.linux]))]),
         .target(
             name: "llbuildBuildSystemTests",
-            dependencies: ["llbuildBuildSystem", "gtestlib"],
+            dependencies: ["llbuildBuildSystem", "gmocklib"],
             path: "unittests/BuildSystem",
+            cxxSettings: [
+                .headerSearchPath("../../utils/unittest/googlemock/include"),
+                .headerSearchPath("../../utils/unittest/googletest/include"),
+            ],
             linkerSettings: [
                 .linkedLibrary("dl", .when(platforms: [.linux])),
                 .linkedLibrary("pthread", .when(platforms: [.linux]))]),
         .target(
             name: "llbuildNinjaTests",
-            dependencies: ["llbuildNinja", "gtestlib"],
+            dependencies: ["llbuildNinja", "gmocklib"],
             path: "unittests/Ninja",
+            cxxSettings: [
+                .headerSearchPath("../../utils/unittest/googlemock/include"),
+                .headerSearchPath("../../utils/unittest/googletest/include"),
+            ],
             linkerSettings: [
                 .linkedLibrary("dl", .when(platforms: [.linux])),
                 .linkedLibrary("pthread", .when(platforms: [.linux]))]),

--- a/Package.swift
+++ b/Package.swift
@@ -170,6 +170,7 @@ let package = Package(
             exclude: [
                 "gtest-death-test.cc",
                 "gtest-filepath.cc",
+                "gtest-matchers.cc",
                 "gtest-port.cc",
                 "gtest-printers.cc",
                 "gtest-test-part.cc",

--- a/Package.swift
+++ b/Package.swift
@@ -181,7 +181,24 @@ let package = Package(
                 .headerSearchPath(".."),
                 .headerSearchPath("../include"),
             ]),
-        
+
+        .target(
+            name: "gmocklib",
+            dependencies: ["gtestlib"],
+            path: "utils/unittest/googlemock/src",
+            exclude: [
+                "gmock-cardinalities.cc",
+                "gmock-internal-utils.cc",
+                "gmock-matchers.cc",
+                "gmock-spec-builders.cc",
+                "gmock.cc",
+            ],
+            cxxSettings: [
+                .headerSearchPath(".."),
+                .headerSearchPath("../include"),
+                .headerSearchPath("../../googletest/include"),
+            ]),
+
         // MARK: Ingested LLVM code.
         .target(
           name: "llvmDemangle",


### PR DESCRIPTION
This should be rebased upon #873.  It simultaneously requires apple/swift-package-manager#6345 to get the fix for the `..` header search path handling corrected.  Update the build rules for GTest to avoid duplicate definitions, add build rules for GMock, update the tests to use GMock as a dependency.  This set of updates enables building llbuild with SPM on Windows (with some minor hand holding for SQLite and overlinking of swiftrt.obj).