### PR TITLE
Reapply changes to use posix_spawn_file_actions_addchdir_np on macOS

### DIFF
--- a/lib/Basic/Subprocess.cpp
+++ b/lib/Basic/Subprocess.cpp
@@ -77,6 +77,7 @@ int pthread_fchdir_np(int fd)
 
 #ifndef HAVE_POSIX_SPAWN_CHDIR
 #if defined(__sun) || \
+  (defined(__MAC_OS_X_VERSION_MIN_REQUIRED) && __MAC_OS_X_VERSION_MIN_REQUIRED >= 101500) || \
   __GLIBC_PREREQ(2, 29)
 #define HAVE_POSIX_SPAWN_CHDIR 1
 #else
@@ -90,6 +91,12 @@ static int posix_spawn_file_actions_addchdir(posix_spawn_file_actions_t * __rest
 #if HAVE_POSIX_SPAWN_CHDIR
   return ::posix_spawn_file_actions_addchdir_np(file_actions, path);
 #else
+#ifdef __APPLE__
+  if (__builtin_available(macOS 10.15, *)) {
+    return ::posix_spawn_file_actions_addchdir_np(file_actions, path);
+  }
+#endif
+
   // Any other POSIX platform returns ENOSYS (Function not implemented),
   // to simplify the fallback logic around the call site.
   return ENOSYS;

--- a/lib/Basic/Subprocess.cpp
+++ b/lib/Basic/Subprocess.cpp
@@ -91,7 +91,7 @@ static int posix_spawn_file_actions_addchdir(posix_spawn_file_actions_t * __rest
 #if HAVE_POSIX_SPAWN_CHDIR
   return ::posix_spawn_file_actions_addchdir_np(file_actions, path);
 #else
-#ifdef __APPLE__
+#if defined(__APPLE__) && __MAC_OS_X_VERSION_MAX_ALLOWED >= 101500
   if (__builtin_available(macOS 10.15, *)) {
     return ::posix_spawn_file_actions_addchdir_np(file_actions, path);
   }

--- a/products/libllbuild/BuildSystem-C-API.cpp
+++ b/products/libllbuild/BuildSystem-C-API.cpp
@@ -727,7 +727,15 @@ class CAPIExternalCommand : public ExternalCommand {
                                                    QueueJobContext* context,
                                                    std::string depsPath) {
     // Read the dependencies file.
-    auto input = system.getFileSystem().getFileContents(depsPath);
+    std::unique_ptr<llvm::MemoryBuffer> input;
+    if (llvm::sys::path::is_absolute(depsPath)) {
+      input = system.getFileSystem().getFileContents(depsPath);
+    } else {
+      SmallString<PATH_MAX> absPath = StringRef(workingDirectory);
+      llvm::sys::path::append(absPath, depsPath);
+      llvm::sys::fs::make_absolute(absPath);
+      input = system.getFileSystem().getFileContents(StringRef(absPath));
+    }
     if (!input) {
       system.getDelegate().commandHadError(this, "unable to open dependencies file (" + depsPath + ")");
       return false;
@@ -778,7 +786,15 @@ class CAPIExternalCommand : public ExternalCommand {
                                              QueueJobContext* context,
                                              std::string depsPath) {
     // Read the dependencies file.
-    auto input = system.getFileSystem().getFileContents(depsPath);
+    std::unique_ptr<llvm::MemoryBuffer> input;
+    if (llvm::sys::path::is_absolute(depsPath)) {
+      input = system.getFileSystem().getFileContents(depsPath);
+    } else {
+      SmallString<PATH_MAX> absPath = StringRef(workingDirectory);
+      llvm::sys::path::append(absPath, depsPath);
+      llvm::sys::fs::make_absolute(absPath);
+      input = system.getFileSystem().getFileContents(StringRef(absPath));
+    }
     if (!input) {
       system.getDelegate().commandHadError(this, "unable to open dependencies file (" + depsPath + ")");
       return false;

--- a/tests/BuildSystem/Build/discovered-makefile-deps-relative.llbuild
+++ b/tests/BuildSystem/Build/discovered-makefile-deps-relative.llbuild
@@ -21,7 +21,7 @@
 
 # Check a build that modifies the header.
 #
-# RUN: echo "mod" >> %t.build/header-1
+# RUN: echo "mod" >> %t.build/wd/header-1
 # RUN: %{llbuild} buildsystem build --serial --chdir %t.build &> %t2.out
 # RUN: %{FileCheck} --check-prefix=CHECK-AFTER-MOD --input-file=%t2.out %s
 #


### PR DESCRIPTION
The deployment target issues which lead to the initial revert several years back are no longer a concern. Reapply these changes, so that when spawning tasks we're making less use of global state.