### PR TITLE
Fix test for Apple Silicon bot

### DIFF
--- a/tests/SwiftBuildTool/swift-compiler-whole-module-optimization.swift-build
+++ b/tests/SwiftBuildTool/swift-compiler-whole-module-optimization.swift-build
@@ -12,7 +12,7 @@
 #
 # CHECK: Compiling Swift Module 'Foo'
 # CHECK-VERBOSE: swiftc -module-name Bar -incremental -emit-dependencies -emit-module -emit-module-path Bar.swiftmodule -output-file-map bar.build/output-file-map.json -parse-as-library -whole-module-optimization -num-threads 1 -c s1.swift -I importB
-# CHECK-VERBOSE-NEXT: swiftc -module-name Foo -incremental -emit-dependencies -emit-module -emit-module-path Foo.swiftmodule -output-file-map foo.build/output-file-map.json -parse-as-library -whole-module-optimization -num-threads 0 -c s1.swift s2.swift -I importA -I importB -Onone -I somePath
+# CHECK-VERBOSE: swiftc -module-name Foo -incremental -emit-dependencies -emit-module -emit-module-path Foo.swiftmodule -output-file-map foo.build/output-file-map.json -parse-as-library -whole-module-optimization -num-threads 0 -c s1.swift s2.swift -I importA -I importB -Onone -I somePath
 
 # # Sanity check the output file map.
 #


### PR DESCRIPTION
The Apple Silicon bot appears to use a newer version of Python, so outputs a deprecation warning for `pipes.quote`. For now, update the `CHECK` line to handle this. rdar://109671403 is tracking the replacement of `pipes.quote` with `shlex.quote`.

rdar://109833753