### PR TITLE
Add support for Musl libc

### DIFF
--- a/include/llbuild/Basic/CrossPlatformCompatibility.h
+++ b/include/llbuild/Basic/CrossPlatformCompatibility.h
@@ -23,7 +23,9 @@
 #include <windows.h>
 #else
 #include <inttypes.h>
+#if __has_include(<sys/cdefs.h>)
 #include <sys/cdefs.h>
+#endif
 #include <sys/resource.h>
 #include <unistd.h>
 #if defined(__linux__) || defined(__GNU__)

--- a/include/llvm/Config/config.h
+++ b/include/llvm/Config/config.h
@@ -18,7 +18,7 @@
 #define ENABLE_CRASH_OVERRIDES 1
 
 /* Define to 1 if you have the `backtrace' function. */
-#if !defined(__ANDROID__) && !defined(__OpenBSD__) && defined(__GLIBC_PREREQ)
+#if __has_include(<execinfo.h>)
 #define HAVE_BACKTRACE TRUE
 #endif
 

--- a/include/llvm/Config/config.h
+++ b/include/llvm/Config/config.h
@@ -18,7 +18,7 @@
 #define ENABLE_CRASH_OVERRIDES 1
 
 /* Define to 1 if you have the `backtrace' function. */
-#if !defined(__ANDROID__) && !defined(__OpenBSD__)
+#if !defined(__ANDROID__) && !defined(__OpenBSD__) && defined(__GLIBC_PREREQ)
 #define HAVE_BACKTRACE TRUE
 #endif
 

--- a/products/llbuildSwift/BuildDBBindings.swift
+++ b/products/llbuildSwift/BuildDBBindings.swift
@@ -15,6 +15,8 @@ import ucrt
 import WinSDK
 #elseif canImport(Glibc)
 import Glibc
+#elseif canImport(Musl)
+import Musl
 #else
 #error("Missing libc or equivalent")
 #endif

--- a/products/llbuildSwift/BuildKey.swift
+++ b/products/llbuildSwift/BuildKey.swift
@@ -15,6 +15,8 @@ import ucrt
 import WinSDK
 #elseif canImport(Glibc)
 import Glibc
+#elseif canImport(Musl)
+import Musl
 #else
 #error("Missing libc or equivalent")
 #endif

--- a/products/llbuildSwift/BuildSystemBindings.swift
+++ b/products/llbuildSwift/BuildSystemBindings.swift
@@ -15,6 +15,8 @@ import ucrt
 import WinSDK
 #elseif canImport(Glibc)
 import Glibc
+#elseif canImport(Musl)
+import Musl
 #else
 #error("Missing libc or equivalent")
 #endif
@@ -1172,7 +1174,7 @@ public final class BuildSystem {
         #elseif os(Windows)
         info.pointee.mod_time.seconds = UInt64(s.st_mtime)
         info.pointee.mod_time.nanoseconds = 0
-        #elseif canImport(Glibc)
+        #elseif canImport(Glibc) || canImport(Musl)
         info.pointee.mod_time.seconds = UInt64(s.st_mtim.tv_sec)
         info.pointee.mod_time.nanoseconds = UInt64(s.st_mtim.tv_nsec)
         #else

--- a/products/llbuildSwift/BuildValue.swift
+++ b/products/llbuildSwift/BuildValue.swift
@@ -15,6 +15,8 @@ import ucrt
 import WinSDK
 #elseif canImport(Glibc)
 import Glibc
+#elseif canImport(Musl)
+import Musl
 #else
 #error("Missing libc or equivalent")
 #endif

--- a/products/llbuildSwift/Internals.swift
+++ b/products/llbuildSwift/Internals.swift
@@ -15,6 +15,8 @@ import ucrt
 import WinSDK
 #elseif canImport(Glibc)
 import Glibc
+#elseif canImport(Musl)
+import Musl
 #else
 #error("Missing libc or equivalent")
 #endif


### PR DESCRIPTION
Since Musl is sufficiently different from Glibc (see https://wiki.musl-libc.org/functional-differences-from-glibc.html), it requires a different import, which now should be applied to files that have `import Glibc` in them.