### PR TITLE
Fixup use of invalid implicit cast of strongly-typed enum to underlying type.

### DIFF
--- a/include/llbuild/Basic/Tracing.h
+++ b/include/llbuild/Basic/Tracing.h
@@ -161,7 +161,7 @@ private:
 };
 
 // Engine Queue Processing
-enum class EngineQueueItemKind {
+enum class EngineQueueItemKind : int {
   RuleToScan = 0,
   InputRequest,
   FinishedInputRequest,
@@ -171,12 +171,14 @@ enum class EngineQueueItemKind {
   FindingCycle,
   BreakingCycle,
 };
+typedef std::underlying_type<EngineQueueItemKind>::type EngineQueueItemKindTy;
 
 struct TracingEngineQueueItemEvent {
   TracingEngineQueueItemEvent(EngineQueueItemKind kind, char const *key)
       : key(key) {
     if (!TracingEnabled) return;
-    LLBUILD_TRACE_INTERVAL_BEGIN("engine_queue_item_event", "key:%s;kind:%d", key, kind);
+    LLBUILD_TRACE_INTERVAL_BEGIN("engine_queue_item_event", "key:%s;kind:%d",
+                                 key, static_cast<EngineQueueItemKindTy>(kind));
   }
   
   ~TracingEngineQueueItemEvent() {


### PR DESCRIPTION
This code being previously allowed was a bug in Clang addressed in https://github.com/llvm/llvm-project/issues/38717.

Resolves rdar://111400323