### PR TITLE
Fix recent build regression on Android

### DIFF
--- a/include/llvm/Config/config.h
+++ b/include/llvm/Config/config.h
@@ -18,7 +18,7 @@
 #define ENABLE_CRASH_OVERRIDES 1
 
 /* Define to 1 if you have the `backtrace' function. */
-#if __has_include(<execinfo.h>)
+#if __has_include(<execinfo.h>) && !(defined(__ANDROID__) && __ANDROID_API__ < 33)
 #define HAVE_BACKTRACE TRUE
 #endif
 


### PR DESCRIPTION
Bionic added execinfo.h last year, but [only made the backtrace APIs available
for Android API 33 or later](https://android.googlesource.com/platform/bionic/+/refs/heads/main/libc/include/execinfo.h#48).


@3405691582, #881 also removed your OpenBSD check, but I see that OpenBSD recently added this header, mesonbuild/meson#11151, so the header check should suffice there?

@al45tair, you suggested this change, please review.

[Here is the error message showing this failing on my Android CI](https://github.com/finagolfin/swift-android-sdk/actions/runs/5484702470/jobs/9992614257#step:6:5839), and the subsequent pull adding this change to my Android CI that fixed it, finagolfin/swift-android-sdk#112.