### PR TITLE
Remove -incremental when using -whole-module-optimization

### DIFF
--- a/lib/BuildSystem/BuildSystem.cpp
+++ b/lib/BuildSystem/BuildSystem.cpp
@@ -2583,8 +2583,7 @@ class SwiftCompilerShellCommand : public ExternalCommand {
       result.push_back("-module-alias");
       result.push_back(nameAndAlias);
     }
-    
-    result.push_back("-incremental");
+
     result.push_back("-emit-dependencies");
     if (!moduleOutputPath.empty()) {
       result.push_back("-emit-module");
@@ -2600,6 +2599,8 @@ class SwiftCompilerShellCommand : public ExternalCommand {
       result.push_back("-whole-module-optimization");
       result.push_back("-num-threads");
       result.push_back(numThreads);
+    } else {
+      result.push_back("-incremental");
     }
     result.push_back("-c");
     for (const auto& source: sourcesList) {

--- a/tests/SwiftBuildTool/swift-compiler-whole-module-optimization.swift-build
+++ b/tests/SwiftBuildTool/swift-compiler-whole-module-optimization.swift-build
@@ -11,8 +11,8 @@
 # RUN: %{FileCheck} --check-prefix=CHECK-VERBOSE --input-file=%t-verbose.out %s
 #
 # CHECK: Compiling Swift Module 'Foo'
-# CHECK-VERBOSE: swiftc -module-name Bar -incremental -emit-dependencies -emit-module -emit-module-path Bar.swiftmodule -output-file-map bar.build/output-file-map.json -parse-as-library -whole-module-optimization -num-threads 1 -c s1.swift -I importB
-# CHECK-VERBOSE: swiftc -module-name Foo -incremental -emit-dependencies -emit-module -emit-module-path Foo.swiftmodule -output-file-map foo.build/output-file-map.json -parse-as-library -whole-module-optimization -num-threads 0 -c s1.swift s2.swift -I importA -I importB -Onone -I somePath
+# CHECK-VERBOSE: swiftc -module-name Bar -emit-dependencies -emit-module -emit-module-path Bar.swiftmodule -output-file-map bar.build/output-file-map.json -parse-as-library -whole-module-optimization -num-threads 1 -c s1.swift -I importB
+# CHECK-VERBOSE: swiftc -module-name Foo -emit-dependencies -emit-module -emit-module-path Foo.swiftmodule -output-file-map foo.build/output-file-map.json -parse-as-library -whole-module-optimization -num-threads 0 -c s1.swift s2.swift -I importA -I importB -Onone -I somePath
 
 # # Sanity check the output file map.
 #

--- a/tests/SwiftBuildTool/swift-compiler.swift-build
+++ b/tests/SwiftBuildTool/swift-compiler.swift-build
@@ -12,7 +12,7 @@
 #
 # CHECK: Compiling Swift Module 'Foo'
 # FIXME: This should quote output paths.
-# CHECK-VERBOSE: swiftc -module-name Foo -incremental -emit-dependencies -emit-module -emit-module-path Foo.swiftmodule -output-file-map temps/output-file-map.json -parse-as-library -c "s 1.swift" "s 2.swift" -I "import A" -I "import B" -Onone -I "path with spaces"
+# CHECK-VERBOSE: swiftc -module-name Foo -emit-dependencies -emit-module -emit-module-path Foo.swiftmodule -output-file-map temps/output-file-map.json -parse-as-library -incremental -c "s 1.swift" "s 2.swift" -I "import A" -I "import B" -Onone -I "path with spaces"
 
 # Sanity check the output file map.
 #


### PR DESCRIPTION
Passing both results in noisy remarks when building from the command line like:

```
remark: Incremental compilation has been disabled: it is not compatible with whole module optimization
```

https://forums.swift.org/t/incremental-compilation-has-been-disabled-it-is-not-compatible-with-whole-module-optimization/66092