### PR TITLE
Introduce the concept of "detached" external commands for the C/Swift API

### DIFF
--- a/examples/c-api/buildsystem/main.c
+++ b/examples/c-api/buildsystem/main.c
@@ -96,6 +96,8 @@ fancy_tool_create_command(void *context, const llb_data_t* name) {
   delegate.provide_value = fancy_command_provide_value;
   delegate.execute_command = fancy_command_execute_command;
   delegate.execute_command_ex = NULL;
+  delegate.execute_command_detached = NULL;
+  delegate.cancel_detached_command = NULL;
   delegate.is_result_valid = NULL;
   return llb_buildsystem_external_command_create(name, delegate);
 }

--- a/include/llbuild/BuildSystem/BuildSystem.h
+++ b/include/llbuild/BuildSystem/BuildSystem.h
@@ -300,6 +300,14 @@ public:
   /// Cancel the current build.
   void cancel();
 
+  /// Add cancellation delegate. If the same delegate object was added before
+  /// then the call is a noop.
+  void addCancellationDelegate(core::CancellationDelegate* del);
+
+  /// Remove cancellation delegate. If the delegate was not added or was
+  /// previously removed the call is a noop.
+  void removeCancellationDelegate(core::CancellationDelegate* del);
+
   static uint32_t getSchemaVersion();
   /// @}
 

--- a/include/llbuild/BuildSystem/Command.h
+++ b/include/llbuild/BuildSystem/Command.h
@@ -154,6 +154,9 @@ public:
 
   virtual bool isExternalCommand() const { return false; }
 
+  /// The command should execute outside the execution lanes.
+  virtual bool isDetached() const { return false; }
+
   virtual void addOutput(BuildNode* node) final {
     outputs.push_back(node);
     node->getProducers().push_back(this);

--- a/include/llbuild/Core/BuildEngine.h
+++ b/include/llbuild/Core/BuildEngine.h
@@ -423,6 +423,14 @@ public:
 
 };
 
+/// Delegate interface for build cancellation notifications.
+class CancellationDelegate {
+public:
+  virtual ~CancellationDelegate();
+
+  virtual void buildCancelled() = 0;
+};
+
 /// A build engine supports fast, incremental, persistent, and parallel
 /// execution of computational graphs.
 ///
@@ -500,7 +508,10 @@ public:
 
   void resetForBuild();
   bool isCancelled();
-  
+
+  void addCancellationDelegate(CancellationDelegate* del);
+  void removeCancellationDelegate(CancellationDelegate* del);
+
   /// Attach a database for persisting build state.
   ///
   /// A database should only be attached immediately after creating the engine,

--- a/products/libllbuild/include/llbuild/buildsystem.h
+++ b/products/libllbuild/include/llbuild/buildsystem.h
@@ -727,9 +727,10 @@ typedef struct llb_buildsystem_external_command_delegate_t_ {
   /// execution queue, so long as it arranges to only notify the system of
   /// completion once all that work is complete.
   ///
-  /// If defined, the build value returning `execute_command_ex` variant is
-  /// called first. If an 'invalid' buile value is returned, the bindings will
-  /// then try calling the legacy `execute_command` variant if it is defined.
+  /// If defined, the `execute_command_detached` variant is called first.
+  /// The build value returning `execute_command_ex` variant has priority next.
+  /// If an 'invalid' buile value is returned, the bindings will then try
+  /// calling the legacy `execute_command` variant if it is defined.
   ///
   /// The C API takes ownership of the value returned by `execute_command_ex`.
   llb_buildsystem_command_result_t (*execute_command)(void* context,
@@ -743,6 +744,21 @@ typedef struct llb_buildsystem_external_command_delegate_t_ {
                                          llb_buildsystem_interface_t* bi,
                                          llb_task_interface_t ti,
                                          llb_buildsystem_queue_job_context_t* job_context);
+
+  /// Called for the external command to do its work without blocking an
+  /// execution lane. When done the external command should call `result_fn`
+  /// passing a result and optionally a `llb_build_value`.
+  void (*execute_command_detached)(void* context,
+                                llb_buildsystem_command_t* command,
+                                llb_buildsystem_interface_t* bi,
+                                llb_task_interface_t ti,
+                                llb_buildsystem_queue_job_context_t* job_context,
+                                void* result_ctx,
+                                void (*result_fn)(void* result_ctx, llb_buildsystem_command_result_t, llb_build_value*));
+
+  /// If non-NULL and command is 'detached', the build system will call it to
+  /// request the command to cancel when the build is cancelled.
+  void (*cancel_detached_command)(void* context, llb_buildsystem_command_t* command);
 
   /// Called by the build system to determine if the current build result
   /// remains valid.

--- a/unittests/CAPI/BuildSystem-C-API.cpp
+++ b/unittests/CAPI/BuildSystem-C-API.cpp
@@ -147,6 +147,8 @@ depinfo_tester_tool_create_command(void *context, const llb_data_t* name) {
   delegate.provide_value = depinfo_tester_command_provide_value;
   delegate.execute_command = depinfo_tester_command_execute_command;
   delegate.execute_command_ex = NULL;
+  delegate.execute_command_detached = NULL;
+  delegate.cancel_detached_command = NULL;
   delegate.is_result_valid = NULL;
   return llb_buildsystem_external_command_create(name, delegate);
 }


### PR DESCRIPTION
These are commands that run without blocking the execution lanes or being constrained by them (the number of execution lanes does not restrict how many 'detached' commands can run in parallel).

It is up to the client to decide whether a 'detached' command is appropriate for its purposes, but a good use case for executing commands outside the execution lanes is when the work involves the network; in such case it is beneficial to avoid blocking execution lanes while waiting for network queries, while also being able to initiate more parallel network queries than the number of CPU cores.