### PR TITLE
Add new Swift API for creating CustomTasks from byte arrays instead of strings

### DIFF
--- a/Xcode/Configs/Common.xcconfig
+++ b/Xcode/Configs/Common.xcconfig
@@ -34,6 +34,9 @@ USE_HEADERMAP = NO
 SWIFT_OBJC_INTERFACE_HEADER_NAME =
 SWIFT_INSTALL_OBJC_HEADER = NO
 
+// The major component of the user module version should be the date it was last changed (YYMMDD.N, where N is usually 0 but can be used if multiple API changes are made on the same day).
+SWIFT_USER_MODULE_VERSION = 230727.0
+
 // Enable InstallAPI.
 SUPPORTS_TEXT_BASED_API = YES
 TAPI_ENABLE_MODULES = YES

--- a/products/libllbuild/BuildKey-C-API.cpp
+++ b/products/libllbuild/BuildKey-C-API.cpp
@@ -140,6 +140,11 @@ llb_build_key_t *llb_build_key_make_custom_task(const char *name, const char *ta
   return (llb_build_key_t *)new CAPIBuildKey(BuildKey::makeCustomTask(StringRef(name), StringRef(taskData)));
 }
 
+llb_build_key_t *llb_build_key_make_custom_task_with_data(const char *name, llb_data_t data) {
+  return (llb_build_key_t *)new CAPIBuildKey(BuildKey::makeCustomTask(StringRef(name), StringRef((const char *)data.data, data.length)));
+}
+
+
 void llb_build_key_get_custom_task_name(llb_build_key_t *key, llb_data_t *out_name) {
   auto name = ((CAPIBuildKey *)key)->getInternalBuildKey().getCustomTaskName();
   out_name->length = name.size();
@@ -150,6 +155,12 @@ void llb_build_key_get_custom_task_data(llb_build_key_t *key, llb_data_t *out_ta
   auto data = ((CAPIBuildKey *)key)->getInternalBuildKey().getCustomTaskData();
   out_task_data->length = data.size();
   out_task_data->data = (const uint8_t*)strdup(data.str().c_str());
+}
+
+void llb_build_key_get_custom_task_data_no_copy(llb_build_key_t *key, llb_data_t *out_task_data) {
+  auto data = ((CAPIBuildKey *)key)->getInternalBuildKey().getCustomTaskData();
+  out_task_data->length = data.size();
+  out_task_data->data = (const uint8_t *)data.data();
 }
 
 llb_build_key_t *llb_build_key_make_directory_contents(const char *path) {

--- a/products/libllbuild/include/llbuild/buildkey.h
+++ b/products/libllbuild/include/llbuild/buildkey.h
@@ -81,8 +81,11 @@ LLBUILD_EXPORT void llb_build_key_get_command_name(llb_build_key_t *key, llb_dat
 
 // Custom Task
 LLBUILD_EXPORT llb_build_key_t *llb_build_key_make_custom_task(const char *name, const char *taskData);
+LLBUILD_EXPORT llb_build_key_t *llb_build_key_make_custom_task_with_data(const char *name, llb_data_t data);
 LLBUILD_EXPORT void llb_build_key_get_custom_task_name(llb_build_key_t *key, llb_data_t *out_name);
 LLBUILD_EXPORT void llb_build_key_get_custom_task_data(llb_build_key_t *key, llb_data_t *out_task_data);
+LLBUILD_EXPORT void llb_build_key_get_custom_task_data_no_copy(llb_build_key_t *key, llb_data_t *out_task_data);
+
 
 // Directory Contents
 LLBUILD_EXPORT llb_build_key_t *llb_build_key_make_directory_contents(const char *path);

--- a/products/libllbuild/include/llbuild/llbuild-defines.h
+++ b/products/libllbuild/include/llbuild/llbuild-defines.h
@@ -85,6 +85,8 @@
 ///
 /// Version History:
 ///
+/// 16: Added more efficient C API for working with custom tasks
+///
 /// 15: Added `determined_rule_needs_to_run` delegate method
 ///
 /// 14: Added configure API to CAPIExternalCommand
@@ -116,6 +118,6 @@
 /// 1: Added `environment` parameter to llb_buildsystem_invocation_t.
 ///
 /// 0: Pre-history
-#define LLBUILD_C_API_VERSION 15
+#define LLBUILD_C_API_VERSION 16
 
 #endif

--- a/products/llbuildSwift/BuildKey.swift
+++ b/products/llbuildSwift/BuildKey.swift
@@ -148,6 +148,12 @@ public class BuildKey: CustomStringConvertible, Equatable, Hashable {
             self.init(llb_build_key_make_custom_task(name, taskData))
         }
         
+        public convenience init(name: String, taskDataBytes: [UInt8]) {
+            self.init(taskDataBytes.withUnsafeBufferPointer { buf in
+                llb_build_key_make_custom_task_with_data(name, llb_data_t(length: UInt64(buf.count), data: buf.baseAddress))
+            })
+        }
+        
         /// The name of the task
         public var name: String {
             return formString {
@@ -160,6 +166,12 @@ public class BuildKey: CustomStringConvertible, Equatable, Hashable {
             return formString {
                 llb_build_key_get_custom_task_data(internalBuildKey, &$0)
             }
+        }
+        
+        public var taskDataBytes: [UInt8] {
+            var data = llb_data_t()
+            llb_build_key_get_custom_task_data_no_copy(internalBuildKey, &data)
+            return Array(UnsafeBufferPointer(start: data.data, count: Int(data.length)))
         }
         
         public override var description: String {


### PR DESCRIPTION
Custom task data is often unstructured, and won't be valid UTF-8. Exposing API that works with data instead of strings avoids the need for hacks like base-64 encoding when creating them using the Swift API, and makes it easier to avoid UTF8 encoding overhead.

Also, adopt the use of a Swift user module version in llbuild, allowing clients to more easily stage in use of new API

rdar://112936539