### PR TITLE
Add user-defined SKIP_INSTALL_CLI_TOOLS setting to the Xcode build

### DIFF
--- a/Xcode/Configs/Common.xcconfig
+++ b/Xcode/Configs/Common.xcconfig
@@ -66,6 +66,9 @@ OTHER_CPLUSPLUSFLAGS = $(OTHER_CFLAGS) -Wimplicit-fallthrough -Wsign-compare -Wa
 // Clients can override this to the empty string to avoid installing anything.
 COMMANDLINETOOLS_FRAMEWORK_INSTALL_PATH = $(DSTROOT)/Library/Developer/CommandLineTools/usr/lib/swift/pm/llbuild/llbuild.framework
 
+// Flag to easily enable SKIP_INSTALL for llbuild's CLI tools
+SKIP_INSTALL_CLI_TOOLS = NO
+
 // MARK: Signing Support
 
 // Enable code signing, if appropriate.

--- a/llbuild.xcodeproj/project.pbxproj
+++ b/llbuild.xcodeproj/project.pbxproj
@@ -5192,7 +5192,7 @@
 				DEVELOPMENT_TEAM = "";
 				INSTALL_PATH = "$(DT_TOOLCHAIN_INSTALL_DIR:standardizepath)/usr/bin";
 				PROVISIONING_PROFILE_SPECIFIER = "";
-				SKIP_INSTALL = NO;
+				SKIP_INSTALL = "$(SKIP_INSTALL_CLI_TOOLS)";
 			};
 			name = Debug;
 		};
@@ -5203,7 +5203,7 @@
 				DEVELOPMENT_TEAM = "";
 				INSTALL_PATH = "$(DT_TOOLCHAIN_INSTALL_DIR:standardizepath)/usr/bin";
 				PROVISIONING_PROFILE_SPECIFIER = "";
-				SKIP_INSTALL = NO;
+				SKIP_INSTALL = "$(SKIP_INSTALL_CLI_TOOLS)";
 			};
 			name = Release;
 		};
@@ -5424,7 +5424,7 @@
 				INSTALL_PATH = "$(DT_TOOLCHAIN_INSTALL_DIR:standardizepath)/usr/local/bin";
 				PRODUCT_NAME = llbuild;
 				PROVISIONING_PROFILE_SPECIFIER = "";
-				SKIP_INSTALL = NO;
+				SKIP_INSTALL = "$(SKIP_INSTALL_CLI_TOOLS)";
 			};
 			name = Debug;
 		};
@@ -5436,7 +5436,7 @@
 				INSTALL_PATH = "$(DT_TOOLCHAIN_INSTALL_DIR:standardizepath)/usr/local/bin";
 				PRODUCT_NAME = llbuild;
 				PROVISIONING_PROFILE_SPECIFIER = "";
-				SKIP_INSTALL = NO;
+				SKIP_INSTALL = "$(SKIP_INSTALL_CLI_TOOLS)";
 			};
 			name = Release;
 		};


### PR DESCRIPTION
Add a convenient override point to skip building the CLI tools in some contexts.