### PR TITLE
Revert 'Add missing dependencies (#888)'

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -66,7 +66,7 @@ let package = Package(
         /// The public llbuild Swift API.
         .target(
             name: "llbuildSwift",
-            dependencies: ["libllbuild", "llbuild"],
+            dependencies: ["libllbuild"],
             path: "products/llbuildSwift",
             exclude: []
         ),
@@ -109,7 +109,7 @@ let package = Package(
         
         .target(
             name: "llbuildAnalysis",
-            dependencies: ["llbuildSwift", "llbuild"],
+            dependencies: ["llbuildSwift"],
             path: "lib/Analysis"
         ),
         


### PR DESCRIPTION
The llbuild executable is not a dependency of these two libraries.

Note that apple/swift-package-manager#6909 will have to be merged first, else reverting this will break the SwiftPM build.