### PR TITLE
[5.10] Revert 'Add missing dependencies (#888)'

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -66,7 +66,7 @@ let package = Package(
         /// The public llbuild Swift API.
         .target(
             name: "llbuildSwift",
-            dependencies: ["libllbuild", "llbuild"],
+            dependencies: ["libllbuild"],
             path: "products/llbuildSwift",
             exclude: []
         ),
@@ -109,7 +109,7 @@ let package = Package(
         
         .target(
             name: "llbuildAnalysis",
-            dependencies: ["llbuildSwift", "llbuild"],
+            dependencies: ["llbuildSwift"],
             path: "lib/Analysis"
         ),
         


### PR DESCRIPTION
Cherrypick of #891

__Explanation:__ The llbuild executable is not a dependency of these two libraries.

__Scope:__ Only affects SwiftPM build of this repo

__Issue:__ None

__Risk:__ low, as less code is built after this

__Testing:__ Passed all CI on trunk

__Reviewer:__ @neonichu