### PR TITLE
Fix parallelism check failures with few cores

### DIFF
--- a/unittests/BuildSystem/BuildSystemFrontendTest.cpp
+++ b/unittests/BuildSystem/BuildSystemFrontendTest.cpp
@@ -401,7 +401,7 @@ commands:
     BuildSystemFrontend frontend(delegate, invocation, createLocalFileSystem());
     ASSERT_TRUE(frontend.build("<all>"));
 
-    ASSERT_EQ(delegate.maxTaskParallism(), 3);
+    ASSERT_EQ(delegate.maxTaskParallism(), std::min(3, (int)std::thread::hardware_concurrency()));
   }
 
   // Test an 'incremental' build where we have an existing build database
@@ -413,7 +413,7 @@ commands:
     // FIXME: This build graph triggers degenerate build behavior. Due to the
     // way we scan tasks, we end up waiting for the first task to resolve before
     // we unlock the other two branches to run in parallel.
-    ASSERT_EQ(delegate.maxTaskParallism(), 2);
+    ASSERT_EQ(delegate.maxTaskParallism(), std::min(2, (int)std::thread::hardware_concurrency()));
   }
 }
 


### PR DESCRIPTION
The number of paralell jobs can be lower than 2 if the host hardware has a lower number of cores.

The ci job running on a machine with 2 cores is failing due to these assertions (the job recently started testing llbuild)
```
/home/buildbot/jenkins/workspace/oss-swift-RA-linux-ubuntu-20.04-webassembly/llbuild/unittests/BuildSystem/BuildSystemFrontendTest.cpp:404: Failure
Expected equality of these values:
  delegate.maxTaskParallism()
    Which is: 2
  3

/home/buildbot/jenkins/workspace/oss-swift-RA-linux-ubuntu-20.04-webassembly/llbuild/unittests/BuildSystem/BuildSystemFrontendTest.cpp:404
Expected equality of these values:
  delegate.maxTaskParallism()
    Which is: 2
  3
```
https://ci-external.swift.org/job/oss-swift-RA-linux-ubuntu-20.04-webassembly/1641/console