### PR TITLE
build: support using llbuild in larger projects

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -101,7 +101,7 @@ find_package(PythonInterp)
 
 # Find includes in the source directory.
 include_directories(BEFORE
-  ${CMAKE_SOURCE_DIR}/include)
+  ${PROJECT_SOURCE_DIR}/include)
 
 # Xcode: Use libc++ and c++14 using proper build settings.
 if (XCODE)


### PR DESCRIPTION
This enables the use of swift-llbuild with CMake in a larger project with CMake. In particular, this enables the use of swift-llbuild with FetchContent to enable integration with other projects for vendoring.