### PR TITLE
Fix a few comment typos in the codebase

### DIFF
--- a/include/llbuild/Basic/Subprocess.h
+++ b/include/llbuild/Basic/Subprocess.h
@@ -213,7 +213,7 @@ namespace llbuild {
       /// \param ctx - Opaque context passed on to the delegate
       /// \param handle - The handle used to identify the process. This handle
       ///  will become invalid as soon as the client returns from this API call.
-      /// \param result - Whether the process suceeded, failed or was cancelled.
+      /// \param result - Whether the process succeded, failed or was cancelled.
       //
       // FIXME: Need to include additional information on the status here, e.g., the
       // signal status, and the process output (if buffering).

--- a/include/llbuild/Basic/Subprocess.h
+++ b/include/llbuild/Basic/Subprocess.h
@@ -213,7 +213,7 @@ namespace llbuild {
       /// \param ctx - Opaque context passed on to the delegate
       /// \param handle - The handle used to identify the process. This handle
       ///  will become invalid as soon as the client returns from this API call.
-      /// \param result - Whether the process succeded, failed or was cancelled.
+      /// \param result - Whether the process succeeded, failed or was cancelled.
       //
       // FIXME: Need to include additional information on the status here, e.g., the
       // signal status, and the process output (if buffering).

--- a/include/llbuild/BuildSystem/BuildSystemFrontend.h
+++ b/include/llbuild/BuildSystem/BuildSystemFrontend.h
@@ -281,7 +281,7 @@ public:
   /// \param handle - The handle used to identify the process. This handle will
   /// become invalid as soon as the client returns from this API call.
   ///
-  /// \param result - Whether the process suceeded, failed or was cancelled.
+  /// \param result - Whether the process succeeded, failed or was cancelled.
   //
   // FIXME: Need to include additional information on the status here, e.g., the
   // signal status, and the process output (if buffering).

--- a/products/libllbuild/include/llbuild/buildsystem.h
+++ b/products/libllbuild/include/llbuild/buildsystem.h
@@ -494,7 +494,7 @@ typedef struct llb_buildsystem_delegate_t_ {
   /// Xparam process The handle used to identify the process. This handle
   /// will become invalid as soon as the client returns from this API call.
   ///
-  /// Xparam result Whether the process suceeded, failed or was cancelled.
+  /// Xparam result Whether the process succeeded, failed or was cancelled.
   /// Xparam exitStatus The raw exit status of the process.
   void (*command_process_finished)(void* context,
                                    llb_buildsystem_command_t* command,

--- a/products/llbuildSwift/BuildSystemBindings.swift
+++ b/products/llbuildSwift/BuildSystemBindings.swift
@@ -52,7 +52,7 @@ public protocol ProcessDelegate {
     
     /// Called when a command's job has finished executing an external process.
     ///
-    /// - result: Whether the process suceeded, failed or was cancelled.
+    /// - result: Whether the process succeeded, failed or was cancelled.
     func processFinished(result: CommandExtendedResult)
 }
 
@@ -910,7 +910,7 @@ public protocol BuildSystemDelegate {
     /// handle will become invalid as soon as the client returns from this API
     /// call.
     ///
-    /// - parameter result: Whether the process suceeded, failed or was cancelled.
+    /// - parameter result: Whether the process succeeded, failed or was cancelled.
     /// - parameter exitStatus: The raw exit status of the process.
     func commandProcessFinished(_ command: Command, process: ProcessHandle, result: CommandExtendedResult)
 


### PR DESCRIPTION
`suceeded` -> `succeeded`