### PR TITLE
Tie lifetimes of Swift wrappers to c++ command and tool objects

### DIFF
--- a/examples/c-api/buildsystem/main.c
+++ b/examples/c-api/buildsystem/main.c
@@ -90,6 +90,7 @@ static llb_buildsystem_command_t*
 fancy_tool_create_command(void *context, const llb_data_t* name) {
   llb_buildsystem_external_command_delegate_t delegate;
   delegate.context = NULL;
+  delegate.destroy_context = NULL;
   delegate.get_signature = NULL;
   delegate.configure = NULL;
   delegate.start = fancy_command_start;

--- a/products/libllbuild/BuildSystem-C-API.cpp
+++ b/products/libllbuild/BuildSystem-C-API.cpp
@@ -704,6 +704,12 @@ public:
     return std::unique_ptr<Command>(
         (Command*) cAPIDelegate.create_custom_command(cAPIDelegate.context, key_p));
   }
+  
+  ~CAPITool() {
+    if (cAPIDelegate.destroy_context) {
+      cAPIDelegate.destroy_context(cAPIDelegate.context);
+    }
+  }
 };
 
 class CAPIExternalCommand : public ExternalCommand {
@@ -1197,6 +1203,12 @@ public:
       llb_data_destroy(&data);
     }
     return sig;
+  }
+  
+  ~CAPIExternalCommand() {
+    if (cAPIDelegate.destroy_context) {
+      cAPIDelegate.destroy_context(cAPIDelegate.context);
+    }
   }
 };
 

--- a/products/libllbuild/include/llbuild/buildsystem.h
+++ b/products/libllbuild/include/llbuild/buildsystem.h
@@ -630,6 +630,10 @@ typedef struct llb_buildsystem_tool_delegate_t_ {
 
   llb_buildsystem_command_t* (*create_custom_command)(void* context,
                                                       const llb_build_key_t* key);
+  
+  /// Callback a client may use to tear down data structures associated with the context
+  /// pointer.
+  void (*destroy_context)(void* context);
 
   // FIXME: Support dynamic tool commands.
 } llb_buildsystem_tool_delegate_t;
@@ -771,6 +775,10 @@ typedef struct llb_buildsystem_external_command_delegate_t_ {
   bool (*is_result_valid)(void* context,
                           llb_buildsystem_command_t* command,
                           const llb_build_value* value);
+  
+  /// Callback a client may use to tear down data structures associated with the context
+  /// pointer.
+  void (*destroy_context)(void* context);
 
 } llb_buildsystem_external_command_delegate_t;
 

--- a/unittests/CAPI/BuildSystem-C-API.cpp
+++ b/unittests/CAPI/BuildSystem-C-API.cpp
@@ -141,6 +141,7 @@ static llb_buildsystem_command_t*
 depinfo_tester_tool_create_command(void *context, const llb_data_t* name) {
   llb_buildsystem_external_command_delegate_t delegate;
   delegate.context = NULL;
+  delegate.destroy_context = NULL;
   delegate.get_signature = NULL;
   delegate.configure = NULL;
   delegate.start = depinfo_tester_command_start;


### PR DESCRIPTION
Previously, these were kept alive in large arrays tied to the lifetime of the BuildSystem object. Instead, tie their lifetime to the CAPITools and CAPIExternalCommands which delegate to them. This makes ownership significantly easier to reason about and allows clients to tear them down more eagerly in context where the build system is reused for multiple build operations.