### PR TITLE
Escape = characters in interpolated variables in sed expressions since = is used as the delimiter character

### DIFF
--- a/utils/Xcode/create-lit-site-cfg.sh
+++ b/utils/Xcode/create-lit-site-cfg.sh
@@ -30,19 +30,19 @@ mkdir -p "${BUILT_PRODUCTS_DIR}/tests/Unit"
 
 sed < "${SRCROOT}/tests/lit.site.cfg.in" \
       > "${BUILT_PRODUCTS_DIR}/tests/lit.site.cfg" \
-    -e "s=@LLBUILD_SRC_DIR@=${SRCROOT}=g" \
-    -e "s=@LLBUILD_OBJ_DIR@=${BUILT_PRODUCTS_DIR}=g" \
-    -e "s=@LLBUILD_OUTPUT_DIR@=${BUILT_PRODUCTS_DIR}=g" \
-    -e "s=@LLBUILD_TOOLS_DIR@=${BUILT_PRODUCTS_DIR}=g" \
-    -e "s=@LLBUILD_LIBS_DIR@=${BUILT_PRODUCTS_DIR}=g" \
-    -e "s=@FILECHECK_EXECUTABLE@=${FILECHECK}=g"
+    -e "s=@LLBUILD_SRC_DIR@=${SRCROOT//=/\\=}=g" \
+    -e "s=@LLBUILD_OBJ_DIR@=${BUILT_PRODUCTS_DIR//=/\\=}=g" \
+    -e "s=@LLBUILD_OUTPUT_DIR@=${BUILT_PRODUCTS_DIR//=/\\=}=g" \
+    -e "s=@LLBUILD_TOOLS_DIR@=${BUILT_PRODUCTS_DIR//=/\\=}=g" \
+    -e "s=@LLBUILD_LIBS_DIR@=${BUILT_PRODUCTS_DIR//=/\\=}=g" \
+    -e "s=@FILECHECK_EXECUTABLE@=${FILECHECK//=/\\=}=g"
 
 sed < "${SRCROOT}/tests/Unit/lit.site.cfg.in" \
       > "${BUILT_PRODUCTS_DIR}/tests/Unit/lit.site.cfg" \
-    -e "s=@LLBUILD_SRC_DIR@=${SRCROOT}=g" \
-    -e "s=@LLBUILD_OBJ_DIR@=${BUILT_PRODUCTS_DIR}=g" \
-    -e "s=@LLBUILD_OUTPUT_DIR@=${BUILT_PRODUCTS_DIR}=g" \
-    -e "s=@LLBUILD_TOOLS_DIR@=${BUILT_PRODUCTS_DIR}=g" \
-    -e "s=@LLBUILD_LIBS_DIR@=${BUILT_PRODUCTS_DIR}=g" \
+    -e "s=@LLBUILD_SRC_DIR@=${SRCROOT//=/\\=}=g" \
+    -e "s=@LLBUILD_OBJ_DIR@=${BUILT_PRODUCTS_DIR//=/\\=}=g" \
+    -e "s=@LLBUILD_OUTPUT_DIR@=${BUILT_PRODUCTS_DIR//=/\\=}=g" \
+    -e "s=@LLBUILD_TOOLS_DIR@=${BUILT_PRODUCTS_DIR//=/\\=}=g" \
+    -e "s=@LLBUILD_LIBS_DIR@=${BUILT_PRODUCTS_DIR//=/\\=}=g" \
     -e "s=@LLBUILD_BUILD_MODE@=.=g" \
-    -e "s=@FILECHECK_EXECUTABLE@=${FILECHECK}=g"
+    -e "s=@FILECHECK_EXECUTABLE@=${FILECHECK//=/\\=}=g"


### PR DESCRIPTION
This prevents the script from failing when any of these paths contain an = character.