### PR TITLE
Include the name of the unfound tool in the error.

### DIFF
--- a/lib/BuildSystem/BuildFile.cpp
+++ b/lib/BuildSystem/BuildFile.cpp
@@ -352,7 +352,7 @@ class BuildFileImpl {
     // Otherwise, ask the delegate to create the tool.
     auto tool = delegate.lookupTool(name);
     if (!tool) {
-      error(forNode, "invalid tool type in 'tools' map");
+      error(forNode, "invalid tool (" + name.str() +") type in 'tools' map");
       return nullptr;
     }
     auto result = tool.get();


### PR DESCRIPTION
We have started to see errors in one of our third party tools that is raising this specific error (`error: error: invalid tool type in 'tools' map`). However, there is no information to go on regarding what tool was unfound and since the issue is not consistent we are having a tough time tracking down what the issue might be. This change simply includes the tool name that could not be found which will hopefully help us narrow down the issue.
