### PR TITLE
[6.0] Import new Bionic module from Android overlay

### DIFF
--- a/products/llbuildSwift/BuildDBBindings.swift
+++ b/products/llbuildSwift/BuildDBBindings.swift
@@ -17,8 +17,8 @@ import WinSDK
 import Glibc
 #elseif canImport(Musl)
 import Musl
-#elseif canImport(Android)
-import Android
+#elseif canImport(Bionic)
+import Bionic
 #else
 #error("Missing libc or equivalent")
 #endif

--- a/products/llbuildSwift/BuildDBBindings.swift
+++ b/products/llbuildSwift/BuildDBBindings.swift
@@ -17,6 +17,8 @@ import WinSDK
 import Glibc
 #elseif canImport(Musl)
 import Musl
+#elseif canImport(Android)
+import Android
 #else
 #error("Missing libc or equivalent")
 #endif

--- a/products/llbuildSwift/BuildKey.swift
+++ b/products/llbuildSwift/BuildKey.swift
@@ -17,8 +17,8 @@ import WinSDK
 import Glibc
 #elseif canImport(Musl)
 import Musl
-#elseif canImport(Android)
-import Android
+#elseif canImport(Bionic)
+import Bionic
 #else
 #error("Missing libc or equivalent")
 #endif

--- a/products/llbuildSwift/BuildKey.swift
+++ b/products/llbuildSwift/BuildKey.swift
@@ -17,6 +17,8 @@ import WinSDK
 import Glibc
 #elseif canImport(Musl)
 import Musl
+#elseif canImport(Android)
+import Android
 #else
 #error("Missing libc or equivalent")
 #endif

--- a/products/llbuildSwift/BuildSystemBindings.swift
+++ b/products/llbuildSwift/BuildSystemBindings.swift
@@ -17,6 +17,8 @@ import WinSDK
 import Glibc
 #elseif canImport(Musl)
 import Musl
+#elseif canImport(Android)
+import Android
 #else
 #error("Missing libc or equivalent")
 #endif
@@ -1235,7 +1237,7 @@ public final class BuildSystem {
         #elseif os(Windows)
         info.pointee.mod_time.seconds = UInt64(s.st_mtime)
         info.pointee.mod_time.nanoseconds = 0
-        #elseif canImport(Glibc) || canImport(Musl)
+        #elseif canImport(Glibc) || canImport(Musl) || canImport(Android)
         info.pointee.mod_time.seconds = UInt64(s.st_mtim.tv_sec)
         info.pointee.mod_time.nanoseconds = UInt64(s.st_mtim.tv_nsec)
         #else

--- a/products/llbuildSwift/BuildSystemBindings.swift
+++ b/products/llbuildSwift/BuildSystemBindings.swift
@@ -17,8 +17,8 @@ import WinSDK
 import Glibc
 #elseif canImport(Musl)
 import Musl
-#elseif canImport(Android)
-import Android
+#elseif canImport(Bionic)
+import Bionic
 #else
 #error("Missing libc or equivalent")
 #endif
@@ -1237,7 +1237,7 @@ public final class BuildSystem {
         #elseif os(Windows)
         info.pointee.mod_time.seconds = UInt64(s.st_mtime)
         info.pointee.mod_time.nanoseconds = 0
-        #elseif canImport(Glibc) || canImport(Musl) || canImport(Android)
+        #elseif canImport(Glibc) || canImport(Musl) || canImport(Bionic)
         info.pointee.mod_time.seconds = UInt64(s.st_mtim.tv_sec)
         info.pointee.mod_time.nanoseconds = UInt64(s.st_mtim.tv_nsec)
         #else

--- a/products/llbuildSwift/BuildValue.swift
+++ b/products/llbuildSwift/BuildValue.swift
@@ -17,8 +17,8 @@ import WinSDK
 import Glibc
 #elseif canImport(Musl)
 import Musl
-#elseif canImport(Android)
-import Android
+#elseif canImport(Bionic)
+import Bionic
 #else
 #error("Missing libc or equivalent")
 #endif

--- a/products/llbuildSwift/BuildValue.swift
+++ b/products/llbuildSwift/BuildValue.swift
@@ -17,6 +17,8 @@ import WinSDK
 import Glibc
 #elseif canImport(Musl)
 import Musl
+#elseif canImport(Android)
+import Android
 #else
 #error("Missing libc or equivalent")
 #endif

--- a/products/llbuildSwift/Internals.swift
+++ b/products/llbuildSwift/Internals.swift
@@ -17,8 +17,8 @@ import WinSDK
 import Glibc
 #elseif canImport(Musl)
 import Musl
-#elseif canImport(Android)
-import Android
+#elseif canImport(Bionic)
+import Bionic
 #else
 #error("Missing libc or equivalent")
 #endif

--- a/products/llbuildSwift/Internals.swift
+++ b/products/llbuildSwift/Internals.swift
@@ -17,6 +17,8 @@ import WinSDK
 import Glibc
 #elseif canImport(Musl)
 import Musl
+#elseif canImport(Android)
+import Android
 #else
 #error("Missing libc or equivalent")
 #endif


### PR DESCRIPTION
__Explanation:__ Now that this new module and overlay were merged into the 6.0 compiler too in swiftlang/swift#74758, this adds the overlay to the five files that currently `import Glibc`.

__Scope:__ Add imports on Android only

__Issue:__ None

__Original PR:__ #919 and #921

__Risk:__ None

__Testing:__ Passed all CI on trunk, plus on my daily Android CI, finagolfin/swift-android-sdk#151

__Reviewer:__ @owenv

@ddunbar, let me know what you think.