### PR TITLE
Support configuring output nodes of dynamic tasks

### DIFF
--- a/include/llbuild/BuildSystem/BuildFile.h
+++ b/include/llbuild/BuildSystem/BuildFile.h
@@ -138,7 +138,7 @@ public:
   ///
   /// \param isImplicit Whether the node is an implicit one (created as a side
   /// effect of being declared by a command).
-  virtual std::unique_ptr<Node> lookupNode(StringRef name,
+  virtual std::unique_ptr<Node> createNode(StringRef name,
                                            bool isImplicit=false) = 0;
 };
 

--- a/include/llbuild/BuildSystem/BuildSystem.h
+++ b/include/llbuild/BuildSystem/BuildSystem.h
@@ -36,6 +36,7 @@ namespace buildsystem {
 
 class BuildDescription;
 class BuildKey;
+class BuildNode;
 class BuildValue;
 class Command;
 class Node;
@@ -312,6 +313,8 @@ public:
   /// @}
 
   ShellCommandHandler* resolveShellCommandHandler(ShellCommand* command);
+  
+  BuildNode *lookupNode(StringRef name);
 };
 
 }

--- a/lib/BuildSystem/BuildFile.cpp
+++ b/lib/BuildSystem/BuildFile.cpp
@@ -368,7 +368,7 @@ class BuildFileImpl {
       return it->second.get();
     
     // Otherwise, ask the delegate to create the node.
-    auto node = delegate.lookupNode(name, isImplicit);
+    auto node = delegate.createNode(name, isImplicit);
     assert(node);
     auto result = node.get();
     nodes[name] = std::move(node);

--- a/lib/Commands/BuildSystemCommand.cpp
+++ b/lib/Commands/BuildSystemCommand.cpp
@@ -92,7 +92,7 @@ public:
 
   virtual void loadedDefaultTarget(StringRef target) override;
 
-  virtual std::unique_ptr<Node> lookupNode(StringRef name,
+  virtual std::unique_ptr<Node> createNode(StringRef name,
                                            bool isImplicit) override;
 
   virtual void loadedCommand(StringRef name,
@@ -368,7 +368,7 @@ void ParseBuildFileDelegate::loadedDefaultTarget(StringRef target) {
 }
 
 std::unique_ptr<Node>
-ParseBuildFileDelegate::lookupNode(StringRef name,
+ParseBuildFileDelegate::createNode(StringRef name,
                                    bool isImplicit) {
   if (!isImplicit) {
     if (showOutput) {

--- a/products/libllbuild/include/llbuild/llbuild-defines.h
+++ b/products/libllbuild/include/llbuild/llbuild-defines.h
@@ -84,6 +84,7 @@
 /// compile for multiple versions of the API.
 ///
 /// Version History:
+/// 18: Added support for configuring outputs of dynamic tasks via the C API.
 ///
 /// 17: Added `llb_buildsystem_dependency_data_format_makefile_ignoring_subsequent_outputs`
 ///
@@ -120,6 +121,6 @@
 /// 1: Added `environment` parameter to llb_buildsystem_invocation_t.
 ///
 /// 0: Pre-history
-#define LLBUILD_C_API_VERSION 17
+#define LLBUILD_C_API_VERSION 18
 
 #endif


### PR DESCRIPTION
This ensures the build system can correctly track when dynamic task outputs are deleted, and rebuild them