### PR TITLE
Remove android-spawn linkage

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -102,10 +102,7 @@ let package = Package(
         .target(
             name: "llbuildBasic",
             dependencies: ["llvmSupport"],
-            path: "lib/Basic",
-            linkerSettings: [
-                .linkedLibrary("android-spawn", .when(platforms: [.android]))
-            ]
+            path: "lib/Basic"
         ),
         .target(
             name: "llbuildCore",


### PR DESCRIPTION
This does not exist in the Android NDK and doesn't build with the current official nightly release. I believe it was from an earlier iteration of the Swift Android support.