### PR TITLE
Add reporting of the reason why a rule's result is invalid to clients

### DIFF
--- a/include/llbuild/BuildSystem/BuildSystem.h
+++ b/include/llbuild/BuildSystem/BuildSystem.h
@@ -235,7 +235,9 @@ public:
   ///  \param reason - Describes why the rule needs to run. For example, because it has never run or because an input was rebuilt.
   ///
   ///  \param inputRule - If `reason` is `InputRebuilt`, the rule for the rebuilt input, else  `nullptr`.
-  virtual void determinedRuleNeedsToRun(core::Rule* ruleNeedingToRun, core::Rule::RunReason reason, core::Rule* inputRule) = 0;
+  ///
+  ///  \param details - Unstructured additional detail explaining why the rule needs to run.
+  virtual void determinedRuleNeedsToRun(core::Rule* ruleNeedingToRun, core::Rule::RunReason reason, core::Rule* inputRule, StringRef details) = 0;
 };
 
 /// The BuildSystem class is used to perform builds using the native build

--- a/include/llbuild/BuildSystem/BuildSystemFrontend.h
+++ b/include/llbuild/BuildSystem/BuildSystemFrontend.h
@@ -295,7 +295,9 @@ public:
   ///  \param reason - Describes why the rule needs to run. For example, because it has never run or because an input was rebuilt.
   ///
   ///  \param inputRule - If `reason` is `InputRebuilt`, the rule for the rebuilt input, else  `nullptr`.
-  virtual void determinedRuleNeedsToRun(core::Rule* ruleNeedingToRun, core::Rule::RunReason reason, core::Rule* inputRule) override;
+  ///
+  ///  \param details - Unstructured additional detail explaining why the rule needs to run.
+  virtual void determinedRuleNeedsToRun(core::Rule* ruleNeedingToRun, core::Rule::RunReason reason, core::Rule* inputRule, StringRef details) override;
 
   /// Called when a cycle is detected by the build engine and it cannot make
   /// forward progress.

--- a/include/llbuild/BuildSystem/Command.h
+++ b/include/llbuild/BuildSystem/Command.h
@@ -20,6 +20,7 @@ namespace llbuild {
 namespace core {
 
 class TaskInterface;
+class Rule;
 
 }
 
@@ -141,8 +142,8 @@ public:
   ///
   /// @{
 
-  virtual bool isResultValid(BuildSystem& system, const BuildValue& value) = 0;
-  
+  virtual core::Rule::ValidationResult isResultValid(BuildSystem& system, const BuildValue& value) = 0;
+
   virtual void start(BuildSystem& system, core::TaskInterface ti) = 0;
 
   virtual void providePriorValue(BuildSystem& system, core::TaskInterface ti,

--- a/include/llbuild/BuildSystem/ExternalCommand.h
+++ b/include/llbuild/BuildSystem/ExternalCommand.h
@@ -129,8 +129,8 @@ public:
 
   virtual BuildValue getResultForOutput(Node* node,
                                         const BuildValue& value) override;
-  
-  virtual bool isResultValid(BuildSystem&, const BuildValue& value) override;
+
+  virtual core::Rule::ValidationResult isResultValid(BuildSystem&, const BuildValue& value) override;
 
   virtual void start(BuildSystem& system, core::TaskInterface ti) override;
 

--- a/include/llbuild/Core/BuildEngine.h
+++ b/include/llbuild/Core/BuildEngine.h
@@ -332,6 +332,17 @@ public:
     Forced = 4
   };
 
+  struct ValidationResult {
+    /// Whether the rule's value is valid.
+    bool isValid;
+
+    /// Optional unstructured description of why the value is invalid.
+    std::string details;
+
+    ValidationResult(bool valid, const std::string& details = "")
+      : isValid(valid), details(details) {}
+  };
+
 public:
   /// The key computed by the rule.
   const KeyType key;
@@ -358,7 +369,7 @@ public:
   /// state managed externally to the build engine. For example, a rule which
   /// computes something on the file system may use this to verify that the
   /// computed output has not changed since it was built.
-  virtual bool isResultValid(BuildEngine&, const ValueType&) = 0;
+  virtual ValidationResult isResultValid(BuildEngine& engine, const ValueType& value) = 0;
 
   /// Called to indicate a change in the rule status.
   virtual void updateStatus(BuildEngine&, StatusKind);
@@ -388,7 +399,10 @@ public:
   ///  \param reason - Describes why the rule needs to run. For example, because it has never run or because an input was rebuilt.
   ///
   ///  \param inputRule - If `reason` is `InputRebuilt`, the rule for the rebuilt input, else  `nullptr`.
-  virtual void determinedRuleNeedsToRun(Rule* ruleNeedingToRun, Rule::RunReason reason, Rule* inputRule);
+  ///
+  ///  \param details - Optional unstructured additional detail about why the rule needs to run.
+  virtual void determinedRuleNeedsToRun(Rule* ruleNeedingToRun, Rule::RunReason reason, Rule* inputRule,
+                                        StringRef details);
 
   /// Called when a cycle is detected by the build engine to check if it should
   /// attempt to resolve the cycle and continue

--- a/lib/BuildSystem/BuildSystemFrontend.cpp
+++ b/lib/BuildSystem/BuildSystemFrontend.cpp
@@ -741,7 +741,7 @@ void BuildSystemFrontendDelegate::commandProcessStarted(Command*,
                                                         ProcessHandle) {
 }
 
-void BuildSystemFrontendDelegate::determinedRuleNeedsToRun(core::Rule* ruleNeedingToRun, core::Rule::RunReason reason, core::Rule* inputRule) {}
+void BuildSystemFrontendDelegate::determinedRuleNeedsToRun(core::Rule* ruleNeedingToRun, core::Rule::RunReason reason, core::Rule* inputRule, StringRef details) {}
 
 bool BuildSystemFrontendDelegate::
 shouldResolveCycle(const std::vector<core::Rule*>& items,

--- a/lib/Commands/BuildEngineCommand.cpp
+++ b/lib/Commands/BuildEngineCommand.cpp
@@ -205,8 +205,8 @@ static int runAckermannBuild(int m, int n, int recomputeCount,
         auto k = AckermannKey(key);
         return new AckermannTask(engine, k.m, k.n);
       }
-      bool isResultValid(core::BuildEngine&, const core::ValueType&) override {
-        return true;
+      ValidationResult isResultValid(core::BuildEngine&, const core::ValueType&) override {
+        return ValidationResult(true);
       }
     };
 

--- a/lib/Commands/BuildSystemCommand.cpp
+++ b/lib/Commands/BuildSystemCommand.cpp
@@ -227,8 +227,8 @@ public:
                                         const BuildValue& value) override {
     return BuildValue::makeMissingInput();
   }
-  virtual bool isResultValid(BuildSystem&, const BuildValue&) override {
-    return false;
+  virtual core::Rule::ValidationResult isResultValid(BuildSystem&, const BuildValue&) override {
+    return core::Rule::ValidationResult(false);
   }
   virtual void start(BuildSystem&, TaskInterface) override {}
   virtual void providePriorValue(BuildSystem&, TaskInterface, const BuildValue&) override {}

--- a/lib/Commands/NinjaBuildCommand.cpp
+++ b/lib/Commands/NinjaBuildCommand.cpp
@@ -1713,7 +1713,7 @@ std::unique_ptr<core::Rule> NinjaBuildEngineDelegate::lookupRule(const core::Key
       return buildInput(*context, node);
     }
 
-    bool isResultValid(core::BuildEngine&, const core::ValueType& value) override {
+    ValidationResult isResultValid(core::BuildEngine&, const core::ValueType& value) override {
       // If simulating, assume cached results are valid.
       if (context->simulate) return true;
 
@@ -2123,7 +2123,7 @@ int commands::executeNinjaBuildCommand(std::vector<std::string> args) {
         return buildCommand(context, command);
       }
 
-      bool isResultValid(core::BuildEngine&, const core::ValueType& value) override {
+      ValidationResult isResultValid(core::BuildEngine&, const core::ValueType& value) override {
         // If simulating, assume cached results are valid.
         if (context.simulate)
           return true;
@@ -2152,7 +2152,7 @@ int commands::executeNinjaBuildCommand(std::vector<std::string> args) {
         return selectCompositeBuildResult(context, command, index, compositeRuleName);
       }
 
-      bool isResultValid(core::BuildEngine&, const core::ValueType& value) override {
+      ValidationResult isResultValid(core::BuildEngine&, const core::ValueType& value) override {
         // If simulating, assume cached results are valid.
         if (context.simulate)
           return true;
@@ -2173,7 +2173,7 @@ int commands::executeNinjaBuildCommand(std::vector<std::string> args) {
         return buildTargets(context, targets);
       }
 
-      bool isResultValid(core::BuildEngine&, const core::ValueType& value) override {
+      ValidationResult isResultValid(core::BuildEngine&, const core::ValueType& value) override {
         return false;
       }
     };

--- a/perftests/Xcode/PerfTests/CorePerfTests.mm
+++ b/perftests/Xcode/PerfTests/CorePerfTests.mm
@@ -106,7 +106,7 @@ public:
 
     Task* createTask(BuildEngine&) override { return new SimpleTask(inputs, compute); }
 
-    bool isResultValid(BuildEngine&, const ValueType& value) override {
+    ValidationResult isResultValid(BuildEngine&, const ValueType& value) override {
         if (!valid) return true;
         return valid(value);
     }

--- a/products/libllbuild/Core-C-API.cpp
+++ b/products/libllbuild/Core-C-API.cpp
@@ -43,12 +43,12 @@ class CAPIBuildEngineDelegate : public BuildEngineDelegate, public basic::Execut
       return (Task*) rule.create_task(rule.context, engineContext);
     }
 
-    bool isResultValid(BuildEngine&, const ValueType& value) override {
-      if (!rule.is_result_valid) return true;
+    ValidationResult isResultValid(BuildEngine&, const ValueType& value) override {
+      if (!rule.is_result_valid) return ValidationResult(true);
 
       llb_data_t value_data{ value.size(), value.data() };
-      return rule.is_result_valid(rule.context, engineContext, &rule,
-                                  &value_data);
+      bool valid = rule.is_result_valid(rule.context, engineContext, &rule, &value_data);
+      return ValidationResult(valid);
     }
 
     void updateStatus(BuildEngine&, Rule::StatusKind status) override {

--- a/products/libllbuild/include/llbuild/buildsystem.h
+++ b/products/libllbuild/include/llbuild/buildsystem.h
@@ -508,7 +508,10 @@ typedef struct llb_buildsystem_delegate_t_ {
   ///  Xparam reason Describes why the rule needs to run. For example, because it has never run or because an input was rebuilt.
   ///
   ///  Xparam input_rule If `reason` is `InputRebuilt`, the rule for the rebuilt input, else  `nullptr`.
+  ///
+  ///  Xparam details Optional additional unstructured description of why the rule needs to run.
   void (*determined_rule_needs_to_run)(void* context, llb_build_key_t* rule_needing_to_run, llb_rule_run_reason_t reason, llb_build_key_t* input_rule);
+  void (*determined_rule_needs_to_run_v2)(void* context, llb_build_key_t* rule_needing_to_run, llb_rule_run_reason_t reason, llb_build_key_t* input_rule, const char* details);
 
   /// Called when a cycle is detected by the build engine and it cannot make
   /// forward progress.

--- a/unittests/BuildSystem/BuildSystemFrontendTest.cpp
+++ b/unittests/BuildSystem/BuildSystemFrontendTest.cpp
@@ -742,7 +742,7 @@ TEST(BuildSystemInvocationTest, formatCycle) {
   public:
     NullRule(const KeyType& key) : Rule(key) { }
     Task* createTask(core::BuildEngine&) override { return nullptr; }
-    bool isResultValid(core::BuildEngine&, const core::ValueType&) override {
+    ValidationResult isResultValid(core::BuildEngine&, const core::ValueType&) override {
       return true;
     }
   };

--- a/unittests/BuildSystem/MockBuildSystemDelegate.h
+++ b/unittests/BuildSystem/MockBuildSystemDelegate.h
@@ -204,7 +204,7 @@ public:
     }
   }
   
-  virtual void determinedRuleNeedsToRun(core::Rule* ruleNeedingToRun, core::Rule::RunReason reason, core::Rule* inputRule) { }
+  virtual void determinedRuleNeedsToRun(core::Rule* ruleNeedingToRun, core::Rule::RunReason reason, core::Rule* inputRule, StringRef details) { }
 };
 
 }

--- a/unittests/Core/BuildEngineCancellationTest.cpp
+++ b/unittests/Core/BuildEngineCancellationTest.cpp
@@ -139,7 +139,7 @@ public:
     return new SimpleTask([this]{ return inputs; }, compute);
   }
 
-  bool isResultValid(BuildEngine&, const ValueType&) override { return true; }
+  ValidationResult isResultValid(BuildEngine&, const ValueType&) override { return true; }
 };
 
 

--- a/unittests/Core/BuildEngineTest.cpp
+++ b/unittests/Core/BuildEngineTest.cpp
@@ -159,7 +159,7 @@ public:
 
   Task* createTask(BuildEngine&) override { return new SimpleTask([this]{ return inputs; }, compute); }
 
-  bool isResultValid(BuildEngine&, const ValueType& value) override {
+  ValidationResult isResultValid(BuildEngine&, const ValueType& value) override {
     if (!valid) return true;
     return valid(value);
   }
@@ -653,7 +653,7 @@ TEST(BuildEngineTest, discoveredDependencies) {
       builtKeys.push_back(key.str());
       return new TaskWithDiscoveredDependency(dep);
     }
-    bool isResultValid(BuildEngine&, const ValueType&) override { return true; }
+    ValidationResult isResultValid(BuildEngine&, const ValueType&) override { return true; }
   };
   engine.addRule(std::unique_ptr<core::Rule>(new RuleWithDiscoveredDependency("output", builtKeys, valueB)));
 
@@ -794,7 +794,7 @@ TEST(BuildEngineTest, CycleDuringScanningFromTop) {
     Task* createTask(BuildEngine&) override {
       return new SimpleTask(input, compute);
     }
-    bool isResultValid(BuildEngine&, const ValueType&) override {
+    ValidationResult isResultValid(BuildEngine&, const ValueType&) override {
       return valid;
     }
   };

--- a/unittests/Core/DepsBuildEngineTest.cpp
+++ b/unittests/Core/DepsBuildEngineTest.cpp
@@ -133,7 +133,7 @@ public:
 
     Task* createTask(BuildEngine&) override { return new SimpleTask(inputs, compute); }
 
-    bool isResultValid(BuildEngine&, const ValueType& value) override {
+    ValidationResult isResultValid(BuildEngine&, const ValueType& value) override {
         if (!valid) return true;
         return valid(value);
     }
@@ -237,7 +237,7 @@ TEST(DepsBuildEngineTest, BogusConcurrentDepScan) {
       builtKeys.push_back(key);
       return new DynamicTask();
     }
-    bool isResultValid(BuildEngine&, const ValueType&) override { return true; }
+    ValidationResult isResultValid(BuildEngine&, const ValueType&) override { return true; }
   };
   engine.addRule(std::unique_ptr<core::Rule>(new DynamicRule("output", builtKeys)));
 


### PR DESCRIPTION
To include that information in build backtrace tracing