### PR TITLE
[Buildsystem] Replace pipes with shlex for command quoting

### DIFF
--- a/tests/SwiftBuildTool/Inputs/pseudo-swiftc
+++ b/tests/SwiftBuildTool/Inputs/pseudo-swiftc
@@ -4,7 +4,7 @@
 import argparse
 import json
 import os
-import pipes
+import shlex
 import sys
 
 def main():
@@ -47,7 +47,7 @@ def main():
     
     # If run in show commands mode, print some dummy output.
     if args.show_commands:
-        print(' '.join(map(pipes.quote, [
+        print(' '.join(map(shlex.quote, [
             sys.argv[0], "-frontend", "...blablabla..."])))
         return
         


### PR DESCRIPTION
The pipes modules was removed in [python 3.13](https://docs.python.org/3/library/pipes.html)  causing the fedora build to fail. 

replace with `shlex` 

https://ci.swift.org/view/all/job/oss-swift-6.2-package-fedora-41