### PR TITLE
fix lit.cfg

### DIFF
--- a/tests/lit.cfg
+++ b/tests/lit.cfg
@@ -103,8 +103,7 @@ def inferSwiftBinary(binaryName):
     execPath = lit.util.which(binaryName, PATH)
 
     if execPath:
-        if not lit_config.quiet:
-            lit_config.note('using {}: {}'.format(binaryName, execPath))
+        lit_config.note('using {}: {}'.format(binaryName, execPath))
     else:
         msg = "couldn't find '{}' program, try setting {} in your environment"
         lit_config.warning(msg.format(binaryName, envVarName))


### PR DESCRIPTION
This removes the lit_config.quiet check, because it no longer exists. The lit_config.note function now automatically checks whether to emit the diagnostic.