### PR TITLE
[Utils] Use utimesat on non-Windows POSIX platforms

### DIFF
--- a/utils/adjust-times/adjust-times.cpp
+++ b/utils/adjust-times/adjust-times.cpp
@@ -50,7 +50,8 @@ static int file_time_set_fixed(const char* filename, struct timespec time_to_set
     struct timeval times[2] = { tv, tv };
     return utimes(filename, times);
   }
-#elif defined __linux__
+#elif !defined(_WIN32)
+  // POSIX.1-2008 platforms (Linux, FreeBSD, OpenBSD, etc.) provide utimensat.
   struct timespec times[2] = { time_to_set, time_to_set };
   return utimensat(AT_FDCWD, filename, times, 0);
 #else


### PR DESCRIPTION
Partially address: #1024

This hopefully fixes `Ninja/Build/order-only-skip.ninja` test failing on FreeBSD. No clue if there are bigger issue with the `#else` branch and how that will affect Windows. I guess with `utime()` it discards nanosecond precision?

Source: https://github.com/swiftlang/swift-llbuild/blob/7d973f3746285d890b84e8127c1e6037e25d15b5/utils/adjust-times/adjust-times.cpp#L56C1-L64C7 

Setup:
```sh
➜  swift-project rm -rf /tmp/test.build
➜  swift-project mkdir /tmp/test.build
➜  swift-project cp ~/swift-project/llbuild/tests/Ninja/Build/order-only-skip.ninja /tmp/test.build/build.ninja
➜  swift-project touch /tmp/test.build/test.in /tmp/test.build/include-source
```

Before:
```sh
➜  ~ $LLBUILD ninja build --jobs 1 --chdir /tmp/test.build

$ADJTIME -now-plus-ulp /tmp/test.build/include-source -v

$LLBUILD ninja build --jobs 1 --chdir /tmp/test.build
llbuild: Entering directory `/tmp/test.build'
[2/2] cat test.in > test.out                
/tmp/test.build/include-source: set to now + epsilon
  from 2026-02-26 14:52:44.765945000
  to   2026-02-26 14:52:50.000000000
llbuild: Entering directory `/tmp/test.build'
llbuild: note: no work to do.
```

```
➜  llbuild ~/swift-project/build/Ninja-ReleaseAssert+swift-DebugAssert/llvm-freebsd-x86_64/bin/llvm-lit -v tests/Ninja/Build/order-only-skip.ninja
FAIL: llbuild :: Ninja/Build/order-only-skip.ninja (1 of 1)
******************** TEST 'llbuild :: Ninja/Build/order-only-skip.ninja' FAILED ********************
Exit Code: 1

# | Input was:
# | <<<<<<
# |             1: llbuild: Entering directory `/home/ramon/swift-project/build/Ninja-ReleaseAssert+swift-DebugAssert/earlyswiftdriver-freebsd-x86_64/release/dependencies/llbuild/tests/Ninja/Build/Output/order-only-skip.ninja.tmp.build' 
# | check:15'0     X~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ error: no match found
# | check:15'1                               ?                                                                                                                                                                                                possible intended match
# |             2: llbuild: note: no work to do. 
# | check:15'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
# | >>>>>>

```


After:

```sh
➜  ~ $LLBUILD ninja build --jobs 1 --chdir /tmp/test.build

$ADJTIME -now-plus-ulp /tmp/test.build/include-source -v

$LLBUILD ninja build --jobs 1 --chdir /tmp/test.build
llbuild: Entering directory `/tmp/test.build'
[2/2] cat test.in > test.out                
/tmp/test.build/include-source: set to now + epsilon
  from 2026-02-26 14:50:08.656323000
  to   2026-02-26 14:50:14.971754001
llbuild: Entering directory `/tmp/test.build'
[1/2] cat include-source > generated-include
```

Things are passing now:

```
➜  llbuild ~/swift-project/build/Ninja-ReleaseAssert+swift-DebugAssert/llvm-freebsd-x86_64/bin/llvm-lit -v tests/Ninja/Build/order-only-skip.ninja
-- Testing: 1 tests, 1 workers --
PASS: llbuild :: Ninja/Build/order-only-skip.ninja (1 of 1)

Testing Time: 0.12s

Total Discovered Tests: 1
  Passed: 1 (100.00%)
```