### PR TITLE
[tests] Fix buildsystem-capi test on FreeBSD/OpenBSD by linking execinfo

### DIFF
--- a/tests/Examples/buildsystem-capi.llbuild
+++ b/tests/Examples/buildsystem-capi.llbuild
@@ -1,6 +1,6 @@
 # Check that the BuildSystem C API example builds and runs correctly.
 #
-# RUN: %clangxx -o %t.exe -x c++ %{srcroot}/examples/c-api/buildsystem/main.c -I %{srcroot}/products/libllbuild/include -lllbuild -lllbuildBuildSystem -lllbuildCore -lllbuildBasic -lllvmSupport -lllvmDemangle -L %{llbuild-lib-dir} -Werror -Xlinker %{sqlite} %{curses} %{threads} %{dl}
+# RUN: %clangxx -o %t.exe -x c++ %{srcroot}/examples/c-api/buildsystem/main.c -I %{srcroot}/products/libllbuild/include -lllbuild -lllbuildBuildSystem -lllbuildCore -lllbuildBasic -lllvmSupport -lllvmDemangle -L %{llbuild-lib-dir} -Werror -Xlinker %{sqlite} %{curses} %{threads} %{dl} %{execinfo}
 # RUN: env DYLD_LIBRARY_PATH=%{llbuild-lib-dir} LD_LIBRARY_PATH=%{llbuild-lib-dir} %t.exe %s > %t.out
 # RUN: %{FileCheck} %s --input-file %t.out
 #

--- a/tests/lit.cfg
+++ b/tests/lit.cfg
@@ -129,6 +129,10 @@ config.substitutions.append( ('%{sqlite}', config.sqlite_library) )
 config.substitutions.append( ('%{curses}', config.curses_library) )
 config.substitutions.append( ('%{threads}', config.threads_library) )
 config.substitutions.append( ('%{dl}', config.dl_library) )
+if platform.system() in ['FreeBSD', 'OpenBSD']:
+    config.substitutions.append( ('%{execinfo}', '-lexecinfo') )
+else:
+    config.substitutions.append( ('%{execinfo}', '') )
 
 if config.osx_sysroot:
     config.substitutions.append( ('%{swiftc-platform-flags}', "-sdk " + config.osx_sysroot) )


### PR DESCRIPTION
Closes: #1024 #1006 following what @etcwilde said: https://github.com/swiftlang/swift-llbuild/issues/1006#issuecomment-3202416477

```
-- Testing: 1 tests, 1 workers --
PASS: llbuild :: Examples/buildsystem-capi.llbuild (1 of 1)

Testing Time: 0.24s

Total Discovered Tests: 1
  Passed: 1 (100.00%)
```

References:
- [backtrace FreeBSD](https://man.freebsd.org/cgi/man.cgi?query=backtrace&sektion=3&manpath=OpenBSD+7.0)
- [backtrace OpenBSD](https://man.openbsd.org/backtrace)
