### PR TITLE
Use STATUS_CONTROL_C_EXIT on Windows for SIGINT cancellation

### DIFF
--- a/lib/Basic/Subprocess.cpp
+++ b/lib/Basic/Subprocess.cpp
@@ -458,7 +458,7 @@ void ProcessGroup::signalAll(int signal) {
     // We are killing the whole process group here, this depends on us
     // spawning each process in its own group earlier.
 #if defined(_WIN32)
-    TerminateProcess(it.first, signal);
+    TerminateProcess(it.first, signal == SIGINT ? STATUS_CONTROL_C_EXIT : signal);
 #else
     ::kill(-it.first, signal);
 #endif
@@ -776,8 +776,9 @@ static void cleanUpExecutedProcess(ProcessDelegate& delegate,
   // subprocess (probably as a new point sample).
 
   // Notify of the process completion.
+  bool cancelled = (exitCode == STATUS_CONTROL_C_EXIT);
   ProcessStatus processStatus =
-      (exitCode == 0) ? ProcessStatus::Succeeded : ProcessStatus::Failed;
+      cancelled ? ProcessStatus::Cancelled : (exitCode == 0) ? ProcessStatus::Succeeded : ProcessStatus::Failed;
   ProcessResult processResult(processStatus, exitCode, pid, utime, stime,
                               counters.PeakWorkingSetSize);
 #else  // !defined(_WIN32)


### PR DESCRIPTION
On Windows, signalAll() now passes STATUS_CONTROL_C_EXIT (0xC000013A) to TerminateProcess when signal == SIGINT, placing the exit code in the NTSTATUS 0xC0000000 error range instead of the raw POSIX value 2.

The Windows completion handler in cleanUpExecutedProcess() now checks for STATUS_CONTROL_C_EXIT to emit ProcessStatus::Cancelled, mirroring the POSIX path which checks WIFSIGNALED + SIGINT/SIGKILL.