### PR TITLE
add <stdint.h> import to gtest-death-test.cc

### DIFF
--- a/utils/unittest/googletest/src/gtest-death-test.cc
+++ b/utils/unittest/googletest/src/gtest-death-test.cc
@@ -52,6 +52,7 @@
 # endif  // GTEST_OS_LINUX
 
 # include <stdarg.h>
+# include <stdint.h>
 
 # if GTEST_OS_WINDOWS
 #  include <windows.h>


### PR DESCRIPTION
Add import to test file so it can compile with gcc 15 +, with gcc 15 some of the headers were updated to remove implicit dependencies, see: https://gcc.gnu.org/gcc-15/porting_to.html#header-dep-changes

This was caught trying to build on ubuntu 26.04 with gcc 15 installed. Error seen
```
11:58:37  /home/build-user/llbuild/utils/unittest/googletest/src/gtest-death-test.cc:1301:26: warning: variable 'dummy' is uninitialized when passed as a const pointer argument here [-Wuninitialized-const-pointer]
11:58:37   1301 |   StackLowerThanAddress(&dummy, &result);
11:58:37        |                          ^~~~~
11:58:37  /home/build-user/llbuild/utils/unittest/googletest/src/gtest-death-test.cc:1385:26: error: unknown type name 'uintptr_t'; did you mean 'intptr_t'?
11:58:37   1385 |         reinterpret_cast<uintptr_t>(stack_top) % kMaxStackAlignment == 0);
11:58:37        |                          ^~~~~~~~~
11:58:37        |                          intptr_t
11:58:37  /home/build-user/llbuild/utils/unittest/googletest/src/gtest-death-test.cc:308:38: note: expanded from macro 'GTEST_DEATH_TEST_CHECK_'
11:58:37    308 |     if (!::testing::internal::IsTrue(expression)) { \
11:58:37        |                                      ^
11:58:37  /usr/include/unistd.h:267:20: note: 'intptr_t' declared here
11:58:37    267 | typedef __intptr_t intptr_t;
11:58:37        |                    ^
11:58:37  1 warning and 1 error generated.
```