### PR TITLE
Use non-deprecated SQLite3::SQLite3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,7 +61,7 @@ if(NOT SQLite3_FOUND)
 
   FetchContent_MakeAvailable(SQLite)
 
-  add_library(SQLite::SQLite3 ALIAS SQLite3)
+  add_library(SQLite3::SQLite3 ALIAS SQLite3)
   set_property(GLOBAL APPEND PROPERTY LLBuild_EXPORTS SQLite3)
 endif()
 

--- a/lib/Core/CMakeLists.txt
+++ b/lib/Core/CMakeLists.txt
@@ -10,6 +10,6 @@ add_llbuild_library(llbuildCore STATIC
 target_link_libraries(llbuildCore PRIVATE
   llbuildBasic
   llvmSupport
-  SQLite::SQLite3)
+  SQLite3::SQLite3)
 
 set_property(GLOBAL APPEND PROPERTY LLBuild_EXPORTS llbuildCore)

--- a/perftests/Xcode/PerfTests/CMakeLists.txt
+++ b/perftests/Xcode/PerfTests/CMakeLists.txt
@@ -34,7 +34,7 @@ target_link_libraries(XcodePerfTests PRIVATE
   llbuildBuildSystem
   llbuildCommands
   curses
-  SQLite::SQLite3
+  SQLite3::SQLite3
   "${MACOSX_SDK_PATH}/System/Library/Frameworks/Foundation.framework"
   "${MACOSX_PLATFORM_PATH}/Developer/Library/Frameworks/XCTest.framework"
   )

--- a/products/libllbuild/CMakeLists.txt
+++ b/products/libllbuild/CMakeLists.txt
@@ -19,7 +19,7 @@ target_link_libraries(llbuild PRIVATE
   llbuildBasic
   llbuildNinja
   llvmSupport
-  SQLite::SQLite3)
+  SQLite3::SQLite3)
 
 if(NOT CMAKE_SYSTEM_NAME STREQUAL Windows)
   target_link_libraries(llbuild PRIVATE
@@ -74,7 +74,7 @@ if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
     llbuildBasic
     llbuildNinja
     llvmSupport
-    SQLite::SQLite3
+    SQLite3::SQLite3
     curses)
 
   # Manually set up the remaining framework structure.

--- a/products/llbuild/CMakeLists.txt
+++ b/products/llbuild/CMakeLists.txt
@@ -8,7 +8,7 @@ target_link_libraries(llbuild-tool PRIVATE
   llbuildCore
   llbuildBasic
   llvmSupport
-  SQLite::SQLite3)
+  SQLite3::SQLite3)
 
 set_target_properties(llbuild-tool PROPERTIES
   OUTPUT_NAME llbuild)

--- a/products/llbuildSwift/CMakeLists.txt
+++ b/products/llbuildSwift/CMakeLists.txt
@@ -42,7 +42,7 @@ if(CMAKE_SYSTEM_NAME STREQUAL Darwin)
   endif()
 else()
   target_link_libraries(llbuildSwift PRIVATE
-    SQLite::SQLite3)
+    SQLite3::SQLite3)
   if(dispatch_FOUND)
     target_link_libraries(llbuildSwift PRIVATE
       swiftDispatch)

--- a/products/swift-build-tool/CMakeLists.txt
+++ b/products/swift-build-tool/CMakeLists.txt
@@ -6,7 +6,7 @@ target_link_libraries(swift-build-tool PRIVATE
   llbuildCore
   llbuildBasic
   llvmSupport
-  SQLite::SQLite3)
+  SQLite3::SQLite3)
 
 if(NOT ${CMAKE_SYSTEM_NAME} STREQUAL "Windows")
   target_link_libraries(swift-build-tool PRIVATE

--- a/unittests/BuildSystem/CMakeLists.txt
+++ b/unittests/BuildSystem/CMakeLists.txt
@@ -12,7 +12,7 @@ target_link_libraries(BuildSystemTests PRIVATE
   llbuildCore
   llbuildBasic
   llvmSupport
-  SQLite::SQLite3)
+  SQLite3::SQLite3)
 
 if(NOT ${CMAKE_SYSTEM_NAME} STREQUAL "Windows")
   target_link_libraries(BuildSystemTests PRIVATE

--- a/unittests/CAPI/CMakeLists.txt
+++ b/unittests/CAPI/CMakeLists.txt
@@ -11,7 +11,7 @@ target_link_libraries(CAPITests PRIVATE
   llvmSupport
   llbuildBasic
   llbuild
-  SQLite::SQLite3)
+  SQLite3::SQLite3)
 
 if(NOT ${CMAKE_SYSTEM_NAME} STREQUAL "Windows")
   target_link_libraries(CAPITests PRIVATE

--- a/unittests/Core/CMakeLists.txt
+++ b/unittests/Core/CMakeLists.txt
@@ -11,7 +11,7 @@ target_link_libraries(CoreTests PRIVATE
   llbuildCore
   llbuildBasic
   llvmSupport
-  SQLite::SQLite3)
+  SQLite3::SQLite3)
 
 if(NOT ${CMAKE_SYSTEM_NAME} STREQUAL "Windows")
   target_link_libraries(CoreTests PRIVATE


### PR DESCRIPTION
Building the Swift compiler routinely issues warnings from the llbuild project:

>   The target name SQLite::SQLite3 is deprecated.  Please use SQLite3::SQLite3  instead.

This updates the CMakeLists.txt files in llbuild to correct this warning.